### PR TITLE
g-overlay: refactor/simplify

### DIFF
--- a/src/css/g-overlay.css
+++ b/src/css/g-overlay.css
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012 The Toolkitchen Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+ 
+@host {
+  position: fixed;
+  z-index: 10;
+  outline: none;
+}
+    
+/*
+  TODO(sorvell): include a reasonable set of default overlay opening 
+  animations. What's here right now is ad hoc.
+*/
+@host.g-overlay-fade {
+  opacity: 0;
+  -webkit-transition: all 0.218s;
+}
+
+@host.g-overlay-fade[opened] {
+  opacity: 1;
+}
+
+@host.g-overlay-scale-slideup {
+  opacity: 0.0;
+  -webkit-transform: scale(1.05);
+  -webkit-transition: all 0.218s;
+}
+
+@host.g-overlay-scale-slideup[opened] {
+  opacity: 1.0;
+  -webkit-transform: scale(1.0);
+}
+
+@host.g-overlay-scale-slideup:not([opened])[animating] {
+  opacity: 0;
+  -webkit-transform: translateY(-100%);
+  -webkit-transition: all 1s;
+}
+
+@-webkit-keyframes g-overlay-shakeFadeIn {
+  0% {
+    display: block;
+    opacity: 0;
+    -webkit-transform: translateX(0);
+  }
+  10% {
+    display: block;
+    -webkit-transform: translateX(-50px);
+  }
+  30% {
+    display: block;
+    -webkit-transform: translateX(50px);
+  }
+  50% {
+    display: block;
+    -webkit-transform: translateX(-25px);
+  }
+  70% {
+    display: block;
+    -webkit-transform: translateX(25px);
+  }
+  90% {
+    display: block;
+    -webkit-transform: translateX(-13px);
+  }
+  100% {
+    display: block;
+    -webkit-transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes g-overlay-shakeFadeOut {
+  0% {
+    opacity: 1;
+    -webkit-transform: translateX(0);
+  }
+  10% {
+    -webkit-transform: translateX(-50px);
+  }
+  30% {
+    -webkit-transform: translateX(50px);
+  }
+  100% {
+    -webkit-transform: translateX(-100%);
+    opacity: 0;
+  }
+}
+
+@host.g-overlay-shake[opened] {
+  -webkit-animation-duration: 0.5s;
+  -webkit-animation-fill-mode: both;
+  -webkit-animation-name: g-overlay-shakeFadeIn;
+}
+
+@host.g-overlay-shake:not([opened])[animating] {
+  -webkit-animation-duration: 0.3s;
+  -webkit-animation-fill-mode: both;
+  -webkit-animation-name: g-overlay-shakeFadeOut;
+}

--- a/src/g-overlay.html
+++ b/src/g-overlay.html
@@ -5,70 +5,90 @@
  * license that can be found in the LICENSE file.
  */
 -->
-<element name="g-overlay" attributes="showing, timeout">
+<element name="g-overlay" attributes="opened, timeout" 
+         handlers="click: clickHandler, keydown: keydownHandler,
+         webkitAniamtionEnd: finishAnimate, webkitTransitionEnd: finishAnimate">
 <link rel="components" href="g-component.html">
+<link rel="stylesheet" href="css/g-overlay.css">
 <template>
-	<style scoped>
-		@host {
-			position: absolute;
-			z-index: 10;
-		}
-	</style>
 	<content></content>
 </template>
 <script>
+  // TODO(sorvell): promote this if it becomes a pattern
+  var setBooleanAttribute = function(inNode, inName, inValue) {
+    inNode[inValue ? 'setAttribute' : 'removeAttribute'](inName, '');
+  };
+  
+  // TODO(sorvell): is there a more new-fangled way to do this?
+  var makeFocusable = function(inNode) {
+    if (!inNode.hasAttribute('tabIndex')) {
+      inNode.setAttribute('tabIndex', -1);
+    }
+  }
+  
+  /**
+   * The overlay component is hidden by default and can be opened to display
+   * its content. It's common to animate an overlay opened and closed. This 
+   * can be achieved by styling the overlay node via the `opened` and
+   * `animating` attributes.
+  */
   this.component({
     shadowRootCreated: function() {
       this.hidden = true;
     },
+    created: function() {
+      makeFocusable(this);
+    },
     prototype: {
+      //* Timeout (ms) for animation. After timeout, any opening animation will 
+      //* be aborted and overlay will be set to opened or not and not animating.
       timeout: 1000,
-      showingChanged: function() {
-        this.animateShowing();
-        webkitRequestAnimationFrame(this.fireShowingChange.bind(this));
+      openedChanged: function() {
+        this.startAnimation();
+        // TODO(sorvell): need a controllable api for this, including 
+        // maybe focusElement.
+        if (this.opened) {
+          this.focus();
+        }
+        this.fireEvent('openedChanged', {opened: this.opened});
       },
-      dispatch: function(inName, inDetail) {
-        this.dispatchEvent(new CustomEvent(inName, {
-          bubbles: true,
-          detail: inDetail
-        }));
-      },
-      fireShowingChange: function() {
-        this.dispatch("showingChange", {
-          showing: this.showing,
-          rect: this.getBoundingClientRect()
-        });
-      },
-      animateShowing: function() {
+      startAnimation: function() {
+        this.cancelAnimation();
         this.hidden = false;
         webkitRequestAnimationFrame(function() {
-          var setBooleanAttribute = function(inNode, inName, inValue) {
-            inNode[inValue ? "setAttribute" : "removeAttribute"](inName, "");
-          };
-          setBooleanAttribute(this, "opening", this.showing);
-          setBooleanAttribute(this, "closing", !this.showing);
-          this.unlisten();
-          this.listen();
+          setBooleanAttribute(this, 'opened', this.opened);
+          setBooleanAttribute(this, 'animating', true);
+          this._animating = setTimeout(this.finishAnimate.bind(this), this.timeout);
         }.bind(this));
       },
-      listen: function() {
-        this.animationListener = this.finishAnimate.bind(this);
-        this.addEventListener("webkitAnimationEnd", this.animationListener);
-        this.addEventListener("webkitTransitionEnd", this.animationListener);
-        // always finish animation within timeout
-        this.jobId = this.utils.job(this.jobId, this.animationListener, this.timeout);
-      },
       finishAnimate: function() {
-        if (!this.showing) {
-          this.hidden = true;
-          this.classList.remove(this.hideClass);
+        if (this._animating) {
+          this.cancelAnimation();
+          setBooleanAttribute(this, 'animating', false);
+          if (!this.opened) {
+            this.hidden = true;
+          }
         }
-        this.unlisten();
       },
-      unlisten: function() {
-        this.removeEventListener("webkitAnimationEnd", this.animationListener);
-        this.removeEventListener("webkitTransitionEnd", this.animationListener);
-        this.utils.job.stop(this.jobId);
+      cancelAnimation: function() {
+        if (this._animating) {
+          clearTimeout(this._animating);
+          this._animating = null;
+        }
+      },
+      //* Toggle the opened state of the overlay.
+      toggle: function() {
+        this.opened = !this.opened;
+      },
+      clickHandler: function(e) {
+        if (e.target && e.target.hasAttribute('overlay-toggle')) {
+          this.toggle();
+        }
+      },
+      keydownHandler: function(e) {
+        if (e.keyCode == 27) {
+          this.opened = false;
+        }
       }
     }
   });

--- a/workbench/overlay.html
+++ b/workbench/overlay.html
@@ -4,6 +4,7 @@
 	<title>Overlay</title>
   <script src="../../polyfills/Components/components-polyfill.js" shadow="shim"></script>
   <link rel="components" href="../../toolkit/src/g-overlay.html">
+  <link rel="stylesheet" href="../../toolkit/src/css/g-overlay.css">
 	<style>
 		body {
 			font-family: Arial, Helvetica, sans-serif;
@@ -12,8 +13,8 @@
 			font-size: 13px;
 		}
 		
-		.dialog {
-			box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+    #dialog, #dialog2 {
+      box-shadow: 0 4px 16px rgba(0,0,0,0.2);
 			background: white;
 			left: 50%;
 			outline: 1px solid rgba(0,0,0,0.2);
@@ -26,91 +27,12 @@
 			z-index: 100;
 			top: 72px;
 			margin-left: -256px;
-			
-			/*display: none;*/
-			opacity: 0.0;
-			-webkit-transform: scale(1.05);
-			-webkit-transition: all 0.218s;
-		}
-		
-    #dialog[opening] {
-			opacity: 1.0;
-			-webkit-transform: scale(1.0);
-		}
-
-    #dialog[closing] {
-			opacity: 0;
-			-webkit-transform: translateY(-100%);
-			-webkit-transition: all 1s;
-		}
-
-		@-webkit-keyframes shakeFadeIn {
-			0% {
-				display: block;
-				opacity: 0;
-				-webkit-transform: translateX(0);
-			}
-			10% {
-				display: block;
-				-webkit-transform: translateX(-50px);
-			}
-			30% {
-				display: block;
-				-webkit-transform: translateX(50px);
-			}
-			50% {
-				display: block;
-				-webkit-transform: translateX(-25px);
-			}
-			70% {
-				display: block;
-				-webkit-transform: translateX(25px);
-			}
-			90% {
-				display: block;
-				-webkit-transform: translateX(-13px);
-			}
-			100% {
-				display: block;
-				-webkit-transform: translateX(0);
-				opacity: 1;
-			}
-		}
-
-		@-webkit-keyframes shakeFadeOut {
-			0% {
-				opacity: 1;
-				-webkit-transform: translateX(0);
-			}
-			10% {
-				-webkit-transform: translateX(-50px);
-			}
-			30% {
-				-webkit-transform: translateX(50px);
-			}
-			100% {
-				-webkit-transform: translateX(-100%);
-				opacity: 0;
-			}
-		}
-
-		#dialog2[opening] {
-			-webkit-animation-duration: 0.5s;
-			-webkit-animation-fill-mode: both;
-			-webkit-animation-name: shakeFadeIn;
-		}
-
-		#dialog2[closing] {
-			-webkit-animation-duration: 0.3s;
-			-webkit-animation-fill-mode: both;
-			-webkit-animation-name: shakeFadeOut;
-		}
-
+    }
 	</style>
 </head>
 <body>
 	<button onclick="toggleDialog('#dialog')">Toggle Dialog</button>
-	<g-overlay id="dialog" class="dialog">
+	<g-overlay id="dialog" class="g-overlay-scale-slideup">
 		<h2>Dialog</h2>
 		<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla sapien sed enim sollicitudin laoreet. Suspendisse suscipit, metus ac volutpat sodales, libero magna semper lacus, molestie fringilla massa orci ut arcu. Nullam sodales urna sit amet odio vehicula mattis.</div><br><br>
 		<div>Ut aliquam vulputate congue. Vestibulum pretium pretium nulla quis sollicitudin. Praesent lacinia congue erat nec mattis. Fusce commodo lacus est. Duis turpis eros, ultrices sed aliquet non, blandit egestas velit. Integer a augue nec lorem tristique hendrerit. Curabitur imperdiet risus id enim bibendum vestibulum. Integer id magna at arcu faucibus fermentum vel a augue. Sed fringilla venenatis dolor, in blandit magna molestie luctus. Vestibulum dignissim posuere ultrices. Aenean urna nisl, tincidunt vitae iaculis ut, pharetra nec eros.</div><br><br>
@@ -118,20 +40,20 @@
 			<g-checkbox></g-checkbox>
 			I agree with this wholeheartedly.
 		</div><br><br>
-		<button onclick="toggleDialog('#dialog')">OK</button>
+		<button overlay-toggle>OK</button>
 	</g-overlay>
 	<br><br>
 	<button onclick="toggleDialog('#dialog2')">Toggle Dialog 2</button>
-	<g-overlay id="dialog2" class="dialog" showing="true">
+	<g-overlay id="dialog2" class="g-overlay-shake">
 		<h2>Dialog 2</h2>
 			I'm dizzy.
 		</div><br><br>
-		<button onclick="toggleDialog('#dialog2')">OK</button>
+		<button overlay-toggle>OK</button>
 	</g-overlay>
 	<script>
 		toggleDialog = function(inSlctr) {
       var d = document.querySelector(inSlctr);
-      d.showing = !d.showing;
+      d.toggle();
 		}
 	</script>
 </body>


### PR DESCRIPTION
- rename 'showing' property to 'opened'
- simplify event listeners
- style animations based on 'opened' and 'animating' attributes
- add beginnings of library of open/close animations
