### PR TITLE
small fix to bubbles parameter of utils.fire

### DIFF
--- a/src/instance/utils.js
+++ b/src/instance/utils.js
@@ -39,7 +39,7 @@
       //log.events && console.log('[%s]: sending [%s]', node.localName, inType);
       node.dispatchEvent(
         new CustomEvent(type, {
-          bubbles: (bubbles !== undefined ? false : true), 
+          bubbles: (bubbles !== undefined ? bubbles : true), 
           detail: detail
         }));
       return detail;


### PR DESCRIPTION
I think the logic was wrong; if you supplied "true" it was interpreted as false.
