### PR TITLE
Removes unneccessary px declarations in coordinate attributes.

### DIFF
--- a/workbench/images/star_full.svg
+++ b/workbench/images/star_full.svg
@@ -5,12 +5,12 @@
 ]>
 <svg version="1.1"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
-	 x="0px" y="0px" width="21px" height="21px" viewBox="0 0 21 21" overflow="visible" enable-background="new 0 0 21 21"
+	 x="0" y="0" width="21px" height="21px" viewBox="0 0 21 21" overflow="visible" enable-background="new 0 0 21 21"
 	 xml:space="preserve">
 <defs>
 </defs>
 <g>
-	<polygon fill="#dd4b39" points="10.5,5 11.711,9.201 16,9.201 12.5,11.764 13.898,16 10.5,13.291 7.101,16 8.5,11.764 5,9.201 
+	<polygon fill="#dd4b39" points="10.5,5 11.711,9.201 16,9.201 12.5,11.764 13.898,16 10.5,13.291 7.101,16 8.5,11.764 5,9.201
 		9.289,9.201 	"/>
 </g>
 <path fill="#ab1400" d="M10.498,5.902l0.975,3.369c0.029,0.105,0.129,0.18,0.24,0.18c0.002,0,0.002,0,0.002,0h3.492l-2.857,2.109


### PR DESCRIPTION
SVG elements don't need px units on coordinate values.
