### PR TITLE
Support Bower's main-files feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,11 @@
   "dependencies": {
     "platform": "Polymer/platform#master",
     "core-component-page": "Polymer/core-component-page#master"
-  }
+  },
+  "main": [
+    "layout.html",
+    "polymer.html",
+    "polymer.js",
+    "polymer.js.map"
+  ]
 }


### PR DESCRIPTION
Bower packages can provide a list of files that are important to
projects using this package. Some build tools use this list to copy,
concatenate, or munge the contents of the files in some way without
touching the files in `bower_components`.

This commit adds the Polymer files to the list of files that should be
delivered to a build tool.