### PR TITLE
webcomponentsjs should be a dependency, not just a dev dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,11 +15,11 @@
     "core-component-page": "Polymer/core-component-page#master",
     "polymer-expressions": "Polymer/polymer-expressions#master",
     "polymer-gestures": "Polymer/polymer-gestures#master",
-    "URL": "Polymer/URL#master"
+    "URL": "Polymer/URL#master",
+    "webcomponentsjs": "Polymer/webcomponentsjs#master"
   },
   "devDependencies": {
     "tools": "Polymer/tools#master",
-    "web-component-tester": "Polymer/web-component-tester#^1.4.2",
-    "webcomponentsjs": "Polymer/webcomponentsjs#master"
+    "web-component-tester": "Polymer/web-component-tester#^1.4.2"
   }
 }


### PR DESCRIPTION
Ran into this when I tried to seed gh-pages and open the page on Safari - 404'd when loading webcomponents.js
