### PR TITLE
Introduce jshint

### DIFF
--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -9,6 +9,7 @@
  */
 
 module.exports = function(karma) {
+  'use strict';
   var common = require('../../tools/test/karma-common.conf.js');
   karma.set(common.mixin_common_opts(karma, {
     // base path, that will be used to resolve files and exclude

--- a/conf/mocha.conf.js
+++ b/conf/mocha.conf.js
@@ -8,6 +8,7 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+/*global mocha: true */
 mocha.setup({
   ui:'tdd',
   slow: 1000,

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('default', ['minify']);
-  grunt.registerTask('minify', ['jshint', 'concat_sourcemap', 'version', 'string-replace', 'uglify']);
+  grunt.registerTask('minify', ['jshint:server', 'concat_sourcemap', 'version', 'string-replace', 'uglify']);
   grunt.registerTask('test', ['wct-test:local']);
   grunt.registerTask('test-remote', ['wct-test:remote']);
   grunt.registerTask('test-build', ['minify', 'stash', 'test', 'restore']);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -9,7 +9,7 @@
 module.exports = function(grunt) {
   'use strict';
   var readManifest = require('../tools/loader/readManifest.js');
-  var Polymer = readManifest('build.json');
+  // var Polymer = readManifest('build.json');
   var banner = grunt.file.read('banner.txt') + '// @version <%= buildversion %>\n';
 
   grunt.initConfig({

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -7,10 +7,12 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 module.exports = function(grunt) {
+  'use strict';
   var readManifest = require('../tools/loader/readManifest.js');
-  var Polymer = readManifest('build.json');
+  // var Polymer = readManifest('build.json');
 
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
     'wct-test': {
       local: {
         options: {remote: false},
@@ -85,7 +87,39 @@ module.exports = function(grunt) {
         }
       }
     },
-    pkg: grunt.file.readJSON('package.json')
+    jshint: {
+      options: {
+        eqeqeq: true,
+        noarg: true,
+        quotmark: 'single',
+        undef: true,
+        unused: 'vars',
+        strict: true,
+        reporter: require('jshint-stylish')
+      },
+      server: {
+        options: {
+          node: true
+        },
+        src: ['*.js', 'conf/**/*.js']
+      },
+      client: {
+        options: {
+          browser: true,
+          extract: 'auto',
+          globals: {
+            Polymer: true,
+            WebComponents: true,
+            PolymerGestures: true,
+            PolymerExpressions: true,
+            CustomElements: true,
+            DOMTokenList: true
+          }
+        },
+        src: ['*.html',
+              'src/**/*.js']
+      }
+    }
   });
 
   grunt.loadTasks('../tools/tasks');
@@ -95,6 +129,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-concat-sourcemap');
   grunt.loadNpmTasks('grunt-audit');
   grunt.loadNpmTasks('grunt-string-replace');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('web-component-tester');
 
   grunt.registerTask('stash', 'prepare for testing build', function() {
@@ -109,7 +144,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('default', ['minify']);
-  grunt.registerTask('minify', ['concat_sourcemap', 'version', 'string-replace', 'uglify']);
+  grunt.registerTask('minify', ['jshint', 'concat_sourcemap', 'version', 'string-replace', 'uglify']);
   grunt.registerTask('test', ['wct-test:local']);
   grunt.registerTask('test-remote', ['wct-test:remote']);
   grunt.registerTask('test-build', ['minify', 'stash', 'test', 'restore']);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
     "grunt-audit": "^0.0.3",
     "grunt-concat-sourcemap": "^0.4.1",
     "grunt-contrib-concat": "^0.4.0",
+    "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.5.0",
     "grunt-string-replace": "^0.2.7",
+    "jshint-stylish": "^1.0.0",
+    "lodash": "^2.4.1",
     "web-component-tester": "^1.1.0"
   }
 }

--- a/polymer.html
+++ b/polymer.html
@@ -14,6 +14,7 @@
 <scripts>
 	<script>
 	(function() {
+		'use strict';
 		// evacipate all scripts in parent!
 		if (window.WebComponents) {
 			var scripts = document._currentScript.parentNode;

--- a/src/api.js
+++ b/src/api.js
@@ -7,7 +7,8 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 (function(scope) {
-
+  'use strict';
+  
   // imports
 
   var extend = scope.extend;

--- a/src/declaration/attributes.js
+++ b/src/declaration/attributes.js
@@ -7,6 +7,7 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 (function(scope) {
+  'use strict';
 
   // magic words
 

--- a/src/declaration/events.js
+++ b/src/declaration/events.js
@@ -8,10 +8,11 @@
  */
 
 (function(scope) {
+  'use strict';
 
   // imports
 
-  var log = window.WebComponents ? WebComponents.flags.log : {};
+  // var log = window.WebComponents ? WebComponents.flags.log : {};
   var api = scope.api.instance.events;
   var EVENT_PREFIX = api.EVENT_PREFIX;
 
@@ -37,7 +38,7 @@
     },
     addAttributeDelegates: function(delegates) {
       // for each attribute
-      for (var i=0, a; a=this.attributes[i]; i++) {
+      for (var i=0, a; (a=this.attributes[i]); i++) {
         // does it have magic marker identifying it as an event delegate?
         if (this.hasEventPrefix(a.name)) {
           // if so, add the info to delegates

--- a/src/declaration/mdv.js
+++ b/src/declaration/mdv.js
@@ -8,7 +8,8 @@
  */
 
 (function(scope) {
-
+  'use strict';
+  
   // imports
   var events = scope.api.declaration.events;
 

--- a/src/declaration/path.js
+++ b/src/declaration/path.js
@@ -8,7 +8,8 @@
  */
 
 (function(scope) {
-
+  'use strict';
+  
 /**
  * @class polymer-base
  */

--- a/src/declaration/polymer-element.js
+++ b/src/declaration/polymer-element.js
@@ -8,7 +8,8 @@
  */
 
 (function(scope) {
-
+  'use strict';
+  
   // imports
 
   var extend = scope.extend;
@@ -44,10 +45,10 @@
     // are registered. We are currently blocked from doing this based on 
     // crbug.com/395686.
     registerWhenReady: function() {
-     if (this.registered
-       || this.waitingForPrototype(this.name)
-       || this.waitingForQueue()
-       || this.waitingForResources()) {
+     if (this.registered ||
+        this.waitingForPrototype(this.name) ||
+        this.waitingForQueue() ||
+        this.waitingForResources()) {
           return;
       }
       queue.go(this);

--- a/src/declaration/polymer.js
+++ b/src/declaration/polymer.js
@@ -64,7 +64,7 @@
   var prototypesByName = {};
 
   function registerPrototype(name, prototype) {
-    return prototypesByName[name] = prototype || {};
+    return (prototypesByName[name] = prototype || {});
   }
 
   function getRegisteredPrototype(name) {
@@ -110,7 +110,7 @@
   // we do here.
 
   if (WebComponents.consumeDeclarations) {
-    WebComponents.consumeDeclarations(function(declarations) {;
+    WebComponents.consumeDeclarations(function(declarations) {
       if (declarations) {
         for (var i=0, l=declarations.length, d; (i<l) && (d=declarations[i]); i++) {
           element.apply(null, d);


### PR DESCRIPTION
It is more than recommended to use a linter when developing JavaScript code. This contribution introduces jshint to Polymer as a grunt task executed before minification. Also one may run it by hand with `grunt jshint`, which lints both server side (node) and client side. You can try `grunt jshint:server` to lint the server side only. Or you can try `grunt jshint:client` to lint the client side. Both `.html` and `.js` files are linted.