### PR TITLE
Fix wrong HTML Imports loaded callback in 'using'

### DIFF
--- a/src/system/module.js
+++ b/src/system/module.js
@@ -44,7 +44,7 @@
   var modules = {};
 
   function using(depends, task) {
-    HTMLImports.whenImportsReady(function() {
+    HTMLImports.whenReady(function() {
       withDependencies(task, depends);
     });
   };


### PR DESCRIPTION
HTMLImports.whenImportsReady was renamed to whenReady.