### PR TITLE
[0.8] more-feature supporting WebAnimations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
   },
   "devDependencies": {
     "web-component-tester": "*",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#master"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#master",
+    "web-animations-js": "web-animations/web-animations-js"
   },
   "private": true
 }

--- a/src/more-features/animation.html
+++ b/src/more-features/animation.html
@@ -1,0 +1,175 @@
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!--
+TODO(nevir): After https://github.com/Polymer/polymer/pull/987
+<link rel="import"../base.html">
+-->
+<link rel="import" href="../../../web-animations-js/web-animations.html">
+
+<script>
+
+(function() {
+
+  /**
+   * A map of globally defined animations by name. Referenced via the
+   * `animation` property on descriptions within an element's `animations`.
+   *
+   * The `effect`s defined on a global animation description will be used
+   * directly. Any properties defined via `timing` are used as defaults, and may
+   * be overridden on a per-element basis.
+   *
+   * @type {String, Object}
+   */
+  Base.Animations = {};
+
+  /**
+   * Animation descriptions support the following options:
+   *
+   * target:
+   *   A selector to the node(s) that the animation should be performed upon.
+   *   Note that this is evaluated immediately after `created`; Any nodes that
+   *   you dynamically add later will not be handled.
+   *
+   * animation:
+   *   The name of the globally defined animation that effects and timing should
+   *   be inherited from. See `Base.Animations`.
+   *
+   * effect:
+   *   The effect of the animation (typically key frames). This is passed
+   *   directly as the second argument to `new Animation()`.
+   *
+   * timing:
+   *   Timing configuration. This is passed directly as the third argument to
+   *   `new Animation()`.
+   *
+   * autoplay:
+   *   Whether the animation should begin playing immediately.
+   *
+   * @typedef {{
+   *   target:    String,
+   *   animation: ?String,
+   *   effect:    Array|Object,
+   *   timing:    Object,
+   *   autoplay:  Boolean,
+   * }}
+   */
+  var AnimationDescription;
+
+  /**
+   * Adds sugaring for named web animations via the `animations` property on
+   * elements.
+   *
+   * Each animation is described by a configuration object keyed by name on the
+   * `animations` property. For example:
+   *
+   *   animations: {
+   *     pulse: {
+   *       autoplay: true,
+   *       target: '#notice',
+   *       effect: [
+   *         {transform: "scale(0.85)"},
+   *         {transform: "scale(1)"},
+   *       ],
+   *       timing: {
+   *         direction: 'alternate',
+   *         duration: 500,
+   *         iterations: Infinity,
+   *       },
+   *     },
+   *   }
+   */
+  Base.addFeature({
+
+    /** @type {String, AnimationDescription} Animations declared per element. */
+    animations: {},
+
+    /** @override */
+    init: function() {
+      // Animation targets are evaluated at creation time for simplicity's sake.
+      //
+      // We have to defer until after the template has been stamped, and "more"
+      // features can't hook into the load order (i.e. `afterCreated`), so async
+      // we go.
+      //
+      // TODO(nevir): This should be an `endOfMicrotask` call.
+      this.async(function() {
+        this.$animations = {};
+
+        Object.keys(this.animations).forEach(function(name) {
+          this.$animations[name] = buildAnimation(this, name, this.animations[name]);
+          if (this.animations[name].autoplay) {
+            this.play(name);
+          }
+        }.bind(this));
+      });
+    },
+
+    /** @param {String} name The animation to play. */
+    play: function(name) {
+      if (!this.$animations) {
+        throw new Error('Calling play() inside created() is not supported. Try calling it after an async()');
+      }
+      if (!this.$animations[name]) {
+        throw new ReferenceError('Animation "' + name + '" has not been registered');
+      }
+
+      if (!this.ownerDocument || !this.ownerDocument.timeline) {
+        throw new Error('Unable to play animation "' + name + '". Element\'s document lacks an animation timeline');
+      }
+
+      this.ownerDocument.timeline.play(this.$animations[name]);
+    },
+
+  });
+
+  function buildAnimation(root, name, description) {
+    mergeGlobalAnimation(description);
+
+    if (!description.target) {
+      throw new TypeError('target is a required property of an animation description');
+    }
+    if (!description.effect) {
+      throw new TypeError('effect is a required property of an animation description');
+    }
+    if (!description.timing) {
+      throw new TypeError('timing is a required property of an animation description');
+    }
+
+    var animations = [];
+    // TODO(nevir): Support more than one element.
+    var nodes = root.querySelectorAll(description.target);
+    for (var i = 0, node; node = nodes[i]; i++) {
+      animations.push(new Animation(node, description.effect, description.timing));
+    }
+
+    return new AnimationGroup(animations, {iterations: 1});
+  }
+
+  function mergeGlobalAnimation(description, globalName) {
+    if (!description.animation) return;
+
+    var globalDescription = Base.Animations[description.animation];
+    if (!globalDescription) {
+      throw new TypeError('The global animation "' + description.animation + '" is not defined');
+    }
+
+    description.effect = globalDescription.effect;
+    description.timing = description.timing || {};
+    if (globalDescription.timing) {
+      Object.keys(globalDescription.timing).forEach(function(key) {
+        if (key in description.timing) return;
+        description.timing[key] = globalDescription.timing[key];
+      });
+    }
+  }
+
+})();
+
+</script>

--- a/test/more-features/animation/globals.html
+++ b/test/more-features/animation/globals.html
@@ -1,0 +1,21 @@
+<!-- TODO(nevir): Remove after https://github.com/Polymer/polymer/pull/987 -->
+<link rel="import" href="../../../src/lang.html">
+<link rel="import" href="../../../src/base.html">
+<!-- Actual imports -->
+<link rel="import" href="../../../src/more-features/animation.html">
+
+<script>
+
+Base.Animations.pulse = {
+  effect: [
+    {transform: "scale(0.85)"},
+    {transform: "scale(1)"},
+  ],
+  timing: {
+    direction: 'alternate',
+    duration: 1500,
+    iterations: Infinity,
+  },
+};
+
+</script>

--- a/test/more-features/animation/index.html
+++ b/test/more-features/animation/index.html
@@ -11,15 +11,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="globals.html">
+  <link rel="import" href="x-animations.html">
+
+  <style>
+    body {
+      padding: 5em;
+    }
+  </style>
 </head>
 <body>
-  <script>
-    WCT.loadSuites([
-      'unit/base.html',
-      'unit/ready.html',
-      'unit/more-features/animation.html',
-    ]);
-  </script>
+  <x-animations></x-animations>
 </body>
 </html>

--- a/test/more-features/animation/x-animations.html
+++ b/test/more-features/animation/x-animations.html
@@ -1,0 +1,64 @@
+<link rel="import" href="../../../polymer.html">
+<link rel="import" href="../../../src/more-features/animation.html">
+<link rel="import" href="globals.html">
+
+<style>
+  x-animations {
+    display: inline-block;
+    padding: 1em;
+    cursor: pointer;
+  }
+
+  x-animations .word {
+    display: inline-block;
+  }
+</style>
+<template>
+  <div id="notice">
+    <span class="word">Hello</span> from <span class="word">x-animations</span>
+  </div>
+</template>
+<script>
+
+  Polymer({
+    name: 'x-animations',
+
+    animations: {
+
+      pulse: {
+        autoplay: true,
+        target: '#notice',
+        animation: 'pulse',
+        timing: {duration: 500},
+      },
+
+      pulse2: {
+        target: '#notice',
+        animation: 'pulse',
+        effect: [
+          {please: "ignore me"},
+        ],
+      },
+
+      spin: {
+        target: '#notice .word',
+        effect: [
+          {transform: "rotateZ(0deg)"},
+          {transform: "rotateZ(180deg)"},
+        ],
+        timing: {duration: 500},
+      },
+
+    },
+
+    listeners: {
+      click: 'onClick',
+    },
+
+    onClick: function() {
+      this.play('spin');
+    },
+
+  });
+
+</script>

--- a/test/unit/more-features/animation.html
+++ b/test/unit/more-features/animation.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+
+  <!-- TODO(nevir): Remove after https://github.com/Polymer/polymer/pull/987 -->
+  <link rel="import" href="../../../src/lang.html">
+  <link rel="import" href="../../../src/base.html">
+  <!-- Actual feature. -->
+  <link rel="import" href="../../../src/more-features/animation.html">
+
+  <!-- Use the demo as our main fixture. -->
+  <link rel="import" href="../../more-features/animation/x-animations.html">
+</head>
+<body>
+
+<x-animations id="common"></x-animations>
+
+<script>
+
+var common = document.getElementById('common');
+
+var sandbox;
+before(function() {
+  sandbox = sinon.sandbox.create();
+  sandbox.stub(document.timeline, 'play');
+});
+
+after(function() {
+  sandbox.restore();
+});
+
+specify('autoplays when set', function(done) {
+  var el = document.createElement('x-animations');
+  flush(function() {
+    expect(document.timeline.play).to.have.been.calledWith(el.$animations.pulse);
+    done();
+  });
+});
+
+specify('expands to multiple targets', function() {
+  var animGroup = common.$animations.spin;
+  expect(animGroup.children.length).to.eq(2);
+  expect(animGroup.children[0].target.getAttribute('class')).to.eq('word');
+  expect(animGroup.children[1].target.getAttribute('class')).to.eq('word');
+});
+
+describe('global animations', function() {
+
+  specify('should override any immediate effects', function() {
+    var anim = common.$animations.pulse2.children[0];
+    expect(anim.target).to.eq(common.$.notice);
+    // Polyfill only :(
+    if (!anim.effect._frames) return;
+    expect(anim.effect._frames.length).to.eq(2);
+  });
+
+  specify('allows for timing overrides', function() {
+    var anim = common.$animations.pulse.children[0];
+    expect(anim.timing.duration).to.eq(500);
+  });
+
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Hopefully makes web animations a little easier to declare within polymer elements.

Note that this gives us all the same shorthand behavior as `element.animate` (i.e. groups). For the next iteration, I want to tackle shorthands for groups and sequences (which potentially have different target selectors)