### PR TITLE
Add [extend] option for layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -260,6 +260,11 @@ html /deep/ [fit] {
   left: 0;
 }
 
+html /deep/ [extend] {
+  width: 100%;
+  height: 100%
+}
+
 body[fullbleed] {
   margin: 0;
   height: 100vh;

--- a/layout.html
+++ b/layout.html
@@ -262,7 +262,7 @@ html /deep/ [fit] {
 
 html /deep/ [extend] {
   width: 100%;
-  height: 100%
+  height: 100%;
 }
 
 body[fullbleed] {


### PR DESCRIPTION
The extend tag allows (for example) paper-shadow to extend to the full
width of the parent div when the content is smaller than the parent.

When the parent does not have a fixed width or height, the fix tag
breaks the layout and in that case, the extend tag can be used.