### PR TITLE
Grunt "retire" task added

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -86,6 +86,16 @@ module.exports = function(grunt) {
         }
       }
     },
+    retire : {
+      js      : ['gruntfile.js', 'src/*.js', 'src/**/*.js', 'test/**/*.js', 'workbench/smoke/*.js'],
+      node    : ['./'],
+      options : {
+        verbose        : true,
+        packageOnly    : true,
+        jsRepository   : 'https://raw.github.com/bekk/retire.js/master/repository/jsrepository.json',
+        nodeRepository : 'https://raw.github.com/bekk/retire.js/master/repository/npmrepository.json'
+      }
+    },    
     pkg: grunt.file.readJSON('package.json')
   });
 
@@ -115,4 +125,5 @@ module.exports = function(grunt) {
     delete config.dependencies.URL;
     grunt.file.write('./dist/bower.json', JSON.stringify(config, null, 2));
   });
+  grunt.loadNpmTasks('grunt-retire');
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-string-replace": "^1.0.0",
-    "web-component-tester": "^1.1.0"
+    "web-component-tester": "^1.1.0",
+    "grunt-retire": "^0.3.7"
   }
 }


### PR DESCRIPTION
All dependencies are fine now but I think it could be a good idea to automate the check process.

![polymerretire](https://cloud.githubusercontent.com/assets/2753855/5693069/a4bda5fc-990d-11e4-89b6-803412edfc83.png)
