### PR TITLE
Fixed type annotations for primitives.

### DIFF
--- a/src/declaration/path.js
+++ b/src/declaration/path.js
@@ -25,10 +25,10 @@
   *     <a href="{{resolvePath(path)}}">Resolved</a>
   * 
   * @method resolvePath
-  * @param {String} url Url path to resolve.
-  * @param {String} base Optional base url against which to resolve, defaults
+  * @param {string} url Url path to resolve.
+  * @param {string} base Optional base url against which to resolve, defaults
   * to the element's ownerDocument url.
-  * returns {String} resolved url.
+  * returns {string} resolved url.
   */
 
 var path = {

--- a/src/instance/base.js
+++ b/src/instance/base.js
@@ -39,9 +39,9 @@
      *     }
      *
      * @method job
-     * @param String {String} job A string identifier for the job to debounce.
+     * @param string {string} job A string identifier for the job to debounce.
      * @param Function {Function} callback A function that is called (with `this` context) when the wait time elapses.
-     * @param Number {Number} wait Time in milliseconds (ms) after the last signal that must elapse before invoking `callback`
+     * @param number {number} wait Time in milliseconds (ms) after the last signal that must elapse before invoking `callback`
      * @type Handle
      */
     job: function(job, callback, wait) {
@@ -388,7 +388,7 @@
    * 
    * @method isBase
    * @param Object {Object} object Object to test.
-   * @type Boolean
+   * @type boolean
    */
   function isBase(object) {
     return object.hasOwnProperty('PolymerBase')

--- a/src/instance/events.js
+++ b/src/instance/events.js
@@ -65,9 +65,9 @@
    * 
    * @method addEventListener
    * @param {Node} node node on which to listen
-   * @param {String} eventType name of the event
+   * @param {string} eventType name of the event
    * @param {Function} handlerFn event handler function
-   * @param {Boolean} capture set to true to invoke event capturing
+   * @param {boolean} capture set to true to invoke event capturing
    * @type Function
    */
   // alias PolymerGestures event listener logic
@@ -82,9 +82,9 @@
    * 
    * @method removeEventListener
    * @param {Node} node node on which to listen
-   * @param {String} eventType name of the event
+   * @param {string} eventType name of the event
    * @param {Function} handlerFn event handler function
-   * @param {Boolean} capture set to true to invoke event capturing
+   * @param {boolean} capture set to true to invoke event capturing
    * @type Function
    */
   scope.removeEventListener = function(node, eventType, handlerFn, capture) {

--- a/src/instance/utils.js
+++ b/src/instance/utils.js
@@ -66,8 +66,8 @@
       * @param {string} type An event name.
       * @param {any} detail
       * @param {Node} onNode Target node.
-      * @param {Boolean} bubbles Set false to prevent bubbling, defaults to true
-      * @param {Boolean} cancelable Set false to prevent cancellation, defaults to true
+      * @param {boolean} bubbles Set false to prevent bubbling, defaults to true
+      * @param {boolean} cancelable Set false to prevent cancellation, defaults to true
       */
     fire: function(type, detail, onNode, bubbles, cancelable) {
       var node = onNode || this;


### PR DESCRIPTION
JavaScript primitive types are not actually instances of their own constructor and so technically these type declarations were incorrect. e.g. if you actually provided a `Boolean` instance, it does not act like the primitive `true|false` as one might think.

```javascript
var value = new Boolean(false);
!!value;
// true, because it is an Object, which is always true...
```

Obviously...this is nitpicking since no one really does this..but it's a simple fix so...why not. :beers: 