### PR TITLE
[0.8] Basic AMD implementation as a replacement to modulate

### DIFF
--- a/PRIMER.md
+++ b/PRIMER.md
@@ -291,6 +291,8 @@ This user is a manager.
 <a name="module-registry"></a>
 ## Module registry
 
+TODO(nevir): Document `define` and friends.
+
 Polymer provides and internally uses a JavaScript "module registry" to organize library code defined outside the context of a custom element prototype, and may be used to organize user code when convenient as well.  The registry is responsible for storing and retrieving JS modules by name.  As this facility does not provide dependency loading, it is the responsibility of the user to HTMLImport files containing any dependent modules before use.
 
 Modules are registered using the `modulate` global function, passing a name to register and a factory function that returns the module:

--- a/polymer-micro.html
+++ b/polymer-micro.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/polymer-mini.html
+++ b/polymer-mini.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
   

--- a/polymer.html
+++ b/polymer.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/expr/polymer-expr.html
+++ b/src/expr/polymer-expr.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/expr/resolveUrl.html
+++ b/src/expr/resolveUrl.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-using(['Base'], function(Base) {
+define(['Base'], function(Base) {
 
   var domModule = document.createElement('dom-module');
 

--- a/src/expr/x-styling-defaults.html
+++ b/src/expr/x-styling-defaults.html
@@ -10,8 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../lib/style-util.html">
 <script>
 
-  modulate('StyleDefaults', ['Base', 'StyleUtil'], function(Base, styleUtil) {
-    
+  define('StyleDefaults', ['Base', 'StyleUtil'], function(Base, styleUtil) {
+
     Base.addFeature({
 
       // TODO(sorvell): decide if this fits; an element can supply

--- a/src/expr/x-styling.html
+++ b/src/expr/x-styling.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../lib/shadow-settings.html">
 <link rel="import" href="x-styling-defaults.html">
 <script>
-  using(['Base', 'StyleTransformer', 'StyleUtil', 'ShadowSettings', 'StyleDefaults'],
+  define(['Base', 'StyleTransformer', 'StyleUtil', 'ShadowSettings', 'StyleDefaults'],
     function(Base, transformer, styleUtil, settings, defaults) {
     
     var beforeReady = Base._beforeReady;

--- a/src/features/micro/attributes.html
+++ b/src/features/micro/attributes.html
@@ -50,8 +50,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @class base feature: attributes
    */
-  
-  using('Base', function(Base) {
+
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/features/micro/constructor.html
+++ b/src/features/micro/constructor.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class base feature: constructor
    */
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/features/micro/extends.html
+++ b/src/features/micro/extends.html
@@ -26,8 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *   @class base feature: extends
    */
 
-  using('Base', function(Base) {
-    
+  define(['Base'], function(Base) {
+
     Base.addFeature({
 
       _prepExtends: function() {

--- a/src/features/micro/mixins.html
+++ b/src/features/micro/mixins.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     /**
      * Automatically extend using objects referenced in `mixins`
@@ -39,7 +39,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var host = this;
           this.mixins.forEach(function(m) {
             if (typeof m === 'string') {
-              using(m, function(m) {
+              // TODO(nevir): Switch this to local (or global?) `require` once
+              // we have that.
+              define([m], function(m) {
                 Base.extend(host, m);
               });
             } else {

--- a/src/features/micro/published.html
+++ b/src/features/micro/published.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
 
     /**

--- a/src/features/mini/content.html
+++ b/src/features/mini/content.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../lib/array-splice.html">
 <script>
 
-  using(['Base', 'ArraySplice'], function(Base, ArraySplice) {
+  define(['Base', 'ArraySplice'], function(Base, ArraySplice) {
 
     /**
 

--- a/src/features/mini/ready.html
+++ b/src/features/mini/ready.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class standard feature: ready
    */
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     hostStack = [];
 

--- a/src/features/mini/shadow.html
+++ b/src/features/mini/shadow.html
@@ -9,8 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="../../lib/shadow-settings.html">
 <script>
-  
-using(['Base', 'ShadowSettings'], function(Base, settings) {
+
+define(['Base', 'ShadowSettings'], function(Base, settings) {
 
   /**
     Implements `shadyRoot` compatible dom scoping using native ShadowDOM.

--- a/src/features/mini/template.html
+++ b/src/features/mini/template.html
@@ -21,8 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *  
    * @class standard feature: template
    */
-  
-  using('Base', function(Base) {
+
+  define(['Base'], function(Base) {
 
     var domModule = document.createElement('dom-module');
 

--- a/src/features/standard/annotations.html
+++ b/src/features/standard/annotations.html
@@ -113,7 +113,7 @@ TODO(sjmiles): this module should produce either syntactic metadata
 
 */
 
-  using(['Base', 'Annotations'], function(Base, Annotations) {
+  define(['Base', 'Annotations'], function(Base, Annotations) {
 
     Base.addFeature({
 

--- a/src/features/standard/configure.html
+++ b/src/features/standard/configure.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   directly (on-foo-changed).
   */
 
-  using(['Base'], function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/features/standard/effects.html
+++ b/src/features/standard/effects.html
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class data feature: bind
    */
 
-  using(['Base', 'bind', 'bind-annotations'], 
+  define(['Base', 'bind', 'bind-annotations'],
    function(Base, Bind, BindAnnotations) {
 
     Base.addFeature({

--- a/src/features/standard/events.html
+++ b/src/features/standard/events.html
@@ -9,13 +9,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
+  // TODO(nevir): We should expose these constants directly on `Polymer`, or
+  // maybe implement AMD's global `require()`.
   /**
    * Supports `listeners` and `keyPresses` objects.
    * 
    * Example:
-   * 
-   *     using('Base', function(Base) {
-   * 
+   *
+   *     define(['Base'], function(Base) {
+   *
    *       Polymer({
    * 
    *         listeners: {
@@ -38,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * 
    */
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Base.addFeature({
 

--- a/src/features/standard/notify-path.html
+++ b/src/features/standard/notify-path.html
@@ -58,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class data feature: path notification
    */
 
-using(['Base', 'Annotations'], function(Base, Annotations) {
+define(['Base', 'Annotations'], function(Base, Annotations) {
 
   Base.addFeature({
     /**

--- a/src/features/standard/styling.html
+++ b/src/features/standard/styling.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../lib/shadow-settings.html">
 <script>
 
-  using(['Base', 'StyleTransformer', 'StyleUtil', 'ShadowSettings', 'Annotations'], 
+  define(['Base', 'StyleTransformer', 'StyleUtil', 'ShadowSettings', 'Annotations'],
     function(Base, transformer, styleUtil, settings, Annotations) {
     
     var prepTemplate = Base._prepTemplate;

--- a/src/features/standard/utils.html
+++ b/src/features/standard/utils.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-using(['Base', 'Async', 'Debounce'], function(Base, Async, Debounce) {
+define(['Base', 'Async', 'Debounce'], function(Base, Async, Debounce) {
 
   Base.addFeature({
 

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -62,7 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  * @class Template feature
  */
 
-  modulate('Annotations', function() {
+  define('Annotations', function() {
 
     // null-array (shared empty array to avoid null-checks)
     var nar = [];

--- a/src/lib/annotations/demo/app-chrome.html
+++ b/src/lib/annotations/demo/app-chrome.html
@@ -36,7 +36,7 @@
 
   <script>
 
-    using('Annotations', function(Annotations) {
+    define('Annotations', function(Annotations) {
 
       var template = document.querySelector('template');
       var list = Annotations.parseAnnotations(template);

--- a/src/lib/array-observe.html
+++ b/src/lib/array-observe.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-modulate('ArrayObserve', 'Debounce', function(Debounce) {
+define('ArrayObserve', ['Debounce'], function(Debounce) {
 
   var callbacks = new WeakMap();
   

--- a/src/lib/array-splice.html
+++ b/src/lib/array-splice.html
@@ -8,8 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-modulate('ArraySplice', function() {
-  
+define('ArraySplice', function() {
+
   function newSplice(index, removed, addedCount) {
     return {
       index: index,

--- a/src/lib/async.html
+++ b/src/lib/async.html
@@ -9,8 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-modulate('Async', function() {
-  
+define('Async', function() {
+
   var currVal = 0;
   var lastVal = 0;
   var callbacks = [];

--- a/src/lib/base.html
+++ b/src/lib/base.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  modulate('Base', function() {
+  define('Base', function() {
 
     var Base = {
 

--- a/src/lib/bind/bind-annotations.html
+++ b/src/lib/bind/bind-annotations.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  modulate('bind-annotations', ['bind'], function(Bind) {
+  define('bind-annotations', ['bind'], function(Bind) {
 
     /*
      * Parses the annotations list created by `annotations` features to perform

--- a/src/lib/bind/bind-effects.html
+++ b/src/lib/bind/bind-effects.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  using(['Annotations', 'bind'], function(Annotations, Bind) {
+  define(['Annotations', 'bind'], function(Annotations, Bind) {
 
     Bind.addComputedPropertyEffect = function(model, name, expression) {
       var index = expression.indexOf('(');

--- a/src/lib/bind/bind.html
+++ b/src/lib/bind/bind.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  modulate('bind', function() {
+  define('bind', function() {
 
     var Bind = {
 

--- a/src/lib/bind/demo/src/annotations-bind-demo.html
+++ b/src/lib/bind/demo/src/annotations-bind-demo.html
@@ -18,7 +18,7 @@
 
   // TODO(sjmiles): should 'bind-annotations' blend the other two modules
   // somehow so we don't need to include all three here?
-  using(['Annotations', 'bind', 'bind-annotations'], 
+  define(['Annotations', 'bind', 'bind-annotations'],
 
    function(Annotations, Bind, BindAnnotations) {
 

--- a/src/lib/bind/demo/src/bind-demo.html
+++ b/src/lib/bind/demo/src/bind-demo.html
@@ -4,7 +4,7 @@
   
 <script>
 
-  using(['bind'], function(Bind) {
+  define(['bind'], function(Bind) {
 
     var out = document.querySelector('#bd');
     out.innerHTML += '<hr><h3>bind demo</h3><hr>';

--- a/src/lib/collection.html
+++ b/src/lib/collection.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, ArrayObserve, Debounce) {
+define('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, ArrayObserve, Debounce) {
 
   var collections = new WeakMap();
 

--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -4,7 +4,7 @@
   Extremely simple css parser. Intended to be not more than what we need
   and definitely not necessarly correct =).
 */
-modulate('CssParse', function() {
+define('CssParse', function() {
 
   // given a string of css, return a simple rule tree
   function parse(text) {

--- a/src/lib/debounce.html
+++ b/src/lib/debounce.html
@@ -9,8 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-modulate('Debounce', 'Async', function(Async) {
-  
+define('Debounce', ['Async'], function(Async) {
+
   // usage
   
   // invoke cb.call(this) in 100ms, unless the job is re-registered,

--- a/src/lib/module.html
+++ b/src/lib/module.html
@@ -101,10 +101,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   // TODO(nevir): Get rid of these; they're purely transitionary.
   scope.modulate = function(id, dependencies, factory) {
+    console.warn('modulate() is deprecated. Please call define() instead.');
     dependencies = typeof dependencies === 'string' ? [dependencies] : dependencies;
     define(id, dependencies, factory);
   };
   scope.using = function(dependencies, factory) {
+    console.warn('using() is deprecated. Please call define() instead.');
     dependencies = typeof dependencies === 'string' ? [dependencies] : dependencies;
     define(dependencies, factory);
   };

--- a/src/lib/module.html
+++ b/src/lib/module.html
@@ -9,48 +9,106 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 (function(scope) {
+  'use strict';
 
-  function withDependencies(task, depends) {
-    depends = depends || [];
-    if (!depends.map) {
-      depends = [depends];
+  /** @type {Object<key, *>} A mapping of ids to modules. */
+  var _modules = Object.create(null);
+
+  // `define`
+
+  /**
+   * An AMD-compliant implementation of `define` that does not perform loading.
+   *
+   * @see https://github.com/amdjs/amdjs-api/wiki/AMD
+   *
+   * Dependencies must be loaded prior to calling `define`, or you will receive
+   * an error.
+   *
+   * @param {string=} id The id of the module being defined. If not provided,
+   *     one will be given to the module based on the document it was called in.
+   * @param {Array<string>=} dependencies A list of module ids that should be
+   *     exposed as dependencies of the module being defined.
+   * @param {function(...*)|*} factory A function that is given the exported
+   *     values for `dependencies`, in the same order. Alternatively, you can
+   *     pass the exported value directly.
+   */
+  function define(id, dependencies, factory) {
+    factory = factory || dependencies || id;
+    // TODO(nevir): Assign directly as exports if not a function.
+    if (typeof factory !== 'function') {
+      throw new TypeError('The last argument to define() must be a function');
     }
-    return task.apply(this, depends.map(marshal));
+
+    if (!Array.isArray(dependencies)) {
+      // TODO(nevir): Default dependencies should be require, exports, module.
+      dependencies = Array.isArray(id) ? id : [];
+    }
+
+    if (typeof id !== 'string') {
+      id = _inferModuleId();
+    }
+
+    if (id in _modules) {
+      throw new Error('The module "' + id + '" has already been defined');
+    }
+
+    _modules[id] = _withDependencies(dependencies, factory);
+    return _modules[id];
+  }
+  // Semi-private. We expose this for tests & introspection.
+  define._modules = _modules;
+
+  /**
+   * Let other implementations know that this is an AMD implementation.
+   * @see https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property-
+   */
+  define.amd = {};
+
+  // Utility
+
+  // TODO(nevir): Temporary for anonymous module ids until we determine them via
+  // current script URL.
+  var _anonymousModuleCount = 0;
+
+  /** @return {string} A module id inferred from the current document/import. */
+  function _inferModuleId() {
+    return '__anonymous_' + _anonymousModuleCount++ + '__';
   }
 
-  function module(name, dependsOrFactory, moduleFactory) {
-    var module = null;
-    switch (arguments.length) {
-      case 0:
-        return;
-      case 2:
-        // dependsOrFactory is `factory` in this case
-        module = dependsOrFactory.apply(this);
-        break;
-      default:
-        // dependsOrFactory is `depends` in this case
-        module = withDependencies(moduleFactory, dependsOrFactory);
-        break;
-    }
-    modules[name] = module;
-  };
-
-  function marshal(name) {
-    return modules[name];
+  /**
+   * Calls `factory` with the exported values of `dependencies`.
+   *
+   * @param {Array<string>} dependencies
+   * @param {function(...*)} factory
+   */
+  function _withDependencies(dependencies, factory) {
+    var modules = dependencies.map(function(id) {
+      if (!(id in _modules)) {
+        throw new ReferenceError('The module "' + id + '" has not been loaded');
+      }
+      return _modules[id];
+    });
+    return factory.apply(null, modules);
   }
 
-  var modules = {};
+  // Exports
 
-  var using = function(depends, task) {
-    withDependencies(task, depends);
+  scope.define = define;
+
+  // TODO(nevir): Do we want to also implement AMD's (optional) global `require`
+  // function? It doesn't support relative lookups, so that may be a no-go:
+  // https://github.com/amdjs/amdjs-api/blob/master/require.md
+
+  // TODO(nevir): Get rid of these; they're purely transitionary.
+  scope.modulate = function(id, dependencies, factory) {
+    dependencies = typeof dependencies === 'string' ? [dependencies] : dependencies;
+    define(id, dependencies, factory);
+  };
+  scope.using = function(dependencies, factory) {
+    dependencies = typeof dependencies === 'string' ? [dependencies] : dependencies;
+    define(dependencies, factory);
   };
 
-  // exports
-
-  scope.marshal = marshal;
-  // `module` confuses commonjs detectors
-  scope.modulate = module;
-  scope.using = using;
 
 })(this);
 </script>

--- a/src/lib/shadow-settings.html
+++ b/src/lib/shadow-settings.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-  modulate('ShadowSettings', function() {
+  define('ShadowSettings', function() {
     // NOTE: Users must currently opt into using ShadowDOM. They do so by doing:
     // PolymerSettings = {shadow: true};
     // TODO(sorvell): Decide if this should be auto-use when available.

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="style-util.html">
 <script>
 
-  modulate('StyleTransformer', ['StyleUtil'], function(styleUtil) {
+  define('StyleTransformer', ['StyleUtil'], function(styleUtil) {
 
     /* Transforms ShadowDOM styling into ShadyDOM styling
 

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="css-parse.html">
 <script>
 
-  modulate('StyleUtil', ['CssParse'], function(parser) {
+  define('StyleUtil', ['CssParse'], function(parser) {
 
     function toCssText(rules, callback) {
       if (typeof rules === 'string') {

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-modulate('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
+define('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
 
   Templatizer = {
 

--- a/src/lib/template/x-autobind.html
+++ b/src/lib/template/x-autobind.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  define(['Base'], function(Base) {
 
     Polymer({
 

--- a/src/lib/template/x-repeat.html
+++ b/src/lib/template/x-repeat.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using(['ArrayObserve', 'Collection', 'Debounce'], function(ArrayObserve, Collection, Debounce) {
+  define(['ArrayObserve', 'Collection', 'Debounce'], function(ArrayObserve, Collection, Debounce) {
     /**
      * Creates a pseudo-custom-element that maps property values to bindings
      * in DOM.

--- a/src/polymer.html
+++ b/src/polymer.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  modulate('Polymer', ['Base'], function(Base) {
+  define('Polymer', ['Base'], function(Base) {
 
     Base.__proto__ = HTMLElement.prototype;
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -16,17 +16,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     WCT.loadSuites([
-      'unit/base.html',
       'unit/async.html',
-      'unit/micro.html',
-      'unit/template.html',
-      'unit/ready.html',
+      'unit/base.html',
+      'unit/bind.html',
       'unit/configure.html',
       'unit/content.html',
-      'unit/projection.html',
-      'unit/projection-shadow.html',
-      'unit/bind.html',
+      'unit/micro.html',
+      'unit/module.html',
       'unit/notify-path.html',
+      'unit/projection-shadow.html',
+      'unit/projection.html',
+      'unit/ready.html',
+      'unit/template.html',
       'unit/utils.html'
     ]);
   </script>

--- a/test/unit/async.html
+++ b/test/unit/async.html
@@ -19,16 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
 <script>
-  
-  beforeEach(function() {
-    using('Async', function(Async) {
-      window.Async = Async;
-    });
-  });
 
-  afterEach(function() {
-    delete window.Async;
-  });
+define(['Async'], function(Async) {
 
   suite('no-wait async', function() {
 
@@ -259,6 +251,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
   });
+
+});
 
 </script>
 </body>

--- a/test/unit/base.html
+++ b/test/unit/base.html
@@ -18,121 +18,123 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../src/lib/base.html">
 </head>
 <body>
+
 <script>
 
-var Child;
-var instance;
+define(['Base'], function(Base) {
 
-beforeEach(function() {
-  using('Base', function(Base) {
+  var Child;
+  var instance;
+
+  beforeEach(function() {
     // Ensure a clean environment for each test.
-    window.Base = Base;
-    window.Child = Object.create(Base);
+    Child = Object.create(Base);
     Child.registerFeatures = function() {};
     Child.initFeatures = function() {};
     Child.setAttributeToProperty = function() {};
-    window.instance = Object.create(Child);
-  });
-});
-
-suite('addFeature', function() {
-
-  test('mixes the feature into Base', function() {
-    assert.notOk(Base.someProperty);
-    Base.addFeature({someProperty: 123});
-    assert.equal(Base.someProperty, 123);
+    instance = Object.create(Child);
   });
 
-});
+  suite('addFeature', function() {
 
-suite('registerCallback', function() {
+    test('mixes the feature into Base', function() {
+      assert.notOk(Base.someProperty);
+      Base.addFeature({someProperty: 123});
+      assert.equal(Base.someProperty, 123);
+    });
 
-  test('calls registered() after registerFeatures()', function() {
-    var called = [];
-    Child.registerFeatures = function() {
-      called.push('1');
-    };
-    Child.registered = function() {
-      called.push('2');
-    };
-    assert.deepEqual(called, []);
-    Child.registerCallback();
-    assert.includeMembers(called, ['1', '2']);
   });
 
-});
+  suite('registerCallback', function() {
 
-suite('createdCallback', function() {
+    test('calls registered() after registerFeatures()', function() {
+      var called = [];
+      Child.registerFeatures = function() {
+        called.push('1');
+      };
+      Child.registered = function() {
+        called.push('2');
+      };
+      assert.deepEqual(called, []);
+      Child.registerCallback();
+      assert.includeMembers(called, ['1', '2']);
+    });
 
-  // TODO(nevir): sinonify.
-  test('calls lifecycle events in the proper order', function() {
-    var called = [];
-    Child.beforeCreated = function() {
-      called.push('beforeCreated');
-    };
-    Child.created = function() {
-      called.push('created');
-    };
-    Child.afterCreated = function() {
-      called.push('afterCreated');
-    };
-    assert.deepEqual(called, []);
-    instance.createdCallback();
-    assert.deepEqual(called, ['beforeCreated', 'created', 'afterCreated']);
   });
 
-  test('calls initFeatures()', function() {
-    var called = false;
-    Child.initFeatures = function() {
-      called = true;
-    };
-    instance.createdCallback();
-    assert.isTrue(called);
+  suite('createdCallback', function() {
+
+    // TODO(nevir): sinonify.
+    test('calls lifecycle events in the proper order', function() {
+      var called = [];
+      Child.beforeCreated = function() {
+        called.push('beforeCreated');
+      };
+      Child.created = function() {
+        called.push('created');
+      };
+      Child.afterCreated = function() {
+        called.push('afterCreated');
+      };
+      assert.deepEqual(called, []);
+      instance.createdCallback();
+      assert.deepEqual(called, ['beforeCreated', 'created', 'afterCreated']);
+    });
+
+    test('calls initFeatures()', function() {
+      var called = false;
+      Child.initFeatures = function() {
+        called = true;
+      };
+      instance.createdCallback();
+      assert.isTrue(called);
+    });
+
+    test('calls initFeatures() with the correct `this`', function() {
+      Child.initFeatures = function() {
+        assert.equal(this, instance);
+      };
+      instance.createdCallback();
+    });
+
   });
 
-  test('calls initFeatures() with the correct `this`', function() {
-    Child.initFeatures = function() {
-      assert.equal(this, instance);
-    };
-    instance.createdCallback();
+  suite('attachedCallback', function() {
+
+    test('calls attached()', function() {
+      var called = false;
+      Child.attached = function() {called = true};
+      instance.attachedCallback();
+      assert.isTrue(called);
+    });
+
   });
 
-});
+  suite('detachedCallback', function() {
 
-suite('attachedCallback', function() {
+    test('calls detached()', function() {
+      var called = false;
+      Child.detached = function() {called = true};
+      instance.detachedCallback();
+      assert.isTrue(called);
+    });
 
-  test('calls attached()', function() {
-    var called = false;
-    Child.attached = function() {called = true};
-    instance.attachedCallback();
-    assert.isTrue(called);
   });
 
-});
+  suite('attributeChangedCallback', function() {
 
-suite('detachedCallback', function() {
+    test('calls attributeChanged()', function() {
+      var args = null;
+      Child.attributeChanged = function() {args = arguments};
+      instance.attributeChangedCallback('attr', null, 1, 'stuff');
 
-  test('calls detached()', function() {
-    var called = false;
-    Child.detached = function() {called = true};
-    instance.detachedCallback();
-    assert.isTrue(called);
-  });
+      assert.equal(args.length, 4);
+      assert.equal(args[0], 'attr');
+      assert.equal(args[1], null);
+      assert.equal(args[2], 1);
+      assert.equal(args[3], 'stuff');
+    });
 
-});
-
-suite('attributeChangedCallback', function() {
-
-  test('calls attributeChanged()', function() {
-    var args = null;
-    Child.attributeChanged = function() {args = arguments};
-    instance.attributeChangedCallback('attr', null, 1, 'stuff');
-
-    assert.equal(args.length, 4);
-    assert.equal(args[0], 'attr');
-    assert.equal(args[1], null);
-    assert.equal(args[2], 1);
-    assert.equal(args[3], 'stuff');
   });
 
 });

--- a/test/unit/module.html
+++ b/test/unit/module.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../src/lib/module.html">
+</head>
+<body>
+
+<script>
+
+  suite('define()', function() {
+
+    beforeEach(function() {
+      for (var key in define._modules) { delete define._modules[key]; };
+      define('a', function() { return 'module A'; });
+      define('b', function() { return 'module B'; });
+    });
+
+    test('supports anonymous modules', function(done) {
+      define(['a'], function(a) {
+        assert.equal(a, 'module A');
+        done();
+      });
+    });
+
+    test('supports modules with dependencies', function(done) {
+      define('c', ['a'], function(a) {
+        assert.equal(a, 'module A');
+        return 'module C';
+      });
+
+      define(['c'], function(c) {
+        assert.equal(c, 'module C');
+        done();
+      });
+    });
+
+    test('passes dependencies in order', function(done) {
+      define('c', ['b', 'a'], function(b, a) {
+        assert.equal(b, 'module B');
+        assert.equal(a, 'module A');
+        return 'module C';
+      });
+
+      define(['c'], function(c) {
+        assert.equal(c, 'module C');
+        done();
+      });
+    });
+
+    test('allows modules that export nothing', function(done) {
+      define('c', function() {});
+
+      define(['c'], function(c) {
+        assert.equal(c, undefined);
+        done();
+      });
+    });
+
+    test('throws if the last argument is not a function', function() {
+      assert.throw(function() {
+        define('a', ['b']);
+      }, TypeError, /function/i);
+    });
+
+    test('throws if a dependency is missing', function() {
+      assert.throw(function() {
+        define('c', ['zzz'], function(z) {});
+      }, ReferenceError, /"zzz".*loaded/i);
+    });
+
+    test('throws if a module has been redefined', function() {
+      assert.throw(function() {
+        define('a', function() {});
+      }, Error, /"a".*defined/i);
+    });
+
+  });
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
**The background and rationale on this change will be forthcoming; please don't flip out yet :)**

I was hoping to also sneak in the relative module resolution, but that's turning out to be a little more complex, so leaving that out for a separate PR.

This PR:

* Switches `modulate` over to `define`. The only incompatible change is that `define` does not accept strings for the dependency list (it's ambiguous) - you must pass an array.
* Switches all `modulate` and `using` calls over to define.

Also: previously reviewed on my fork: https://github.com/nevir/polymer/pull/1