### PR TITLE
Fixed insertion of numbers and booleans in the weakmap in 0.8-preview

### DIFF
--- a/src/lib/collection.html
+++ b/src/lib/collection.html
@@ -43,9 +43,12 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
       var s = this.store;
       for (var i=0; i<s.length; i++) {
         var v = s[i];
-        if (typeof v == 'string') {
-          v = s[i] = new String(v);
-        }
+        var t = typeof v;
+        var w = v;
+        if (t == 'string') w = new String(v);
+        else if (t == 'number') w = new Number(v);
+        else if (t =='boolean') w = new Boolean(v);
+        v = s[i] = w;
         map.set(v, i);
       }
     },
@@ -93,7 +96,7 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
         this.added = [];
         this.removed = [];
       }
-      this.callbacks.forEach(function(cb) { 
+      this.callbacks.forEach(function(cb) {
         cb(splices);
       }, this);
     },
@@ -168,7 +171,7 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
   return {
     get: getCollection
   };
-  
+
 });
 
 </script>


### PR DESCRIPTION
I stumbled on this bug while trying to render numbers or booleans in 0.8-preview.

It works perfectly when the property is an array of objects or strings.

The error is : "Uncaught TypeError: Invalid value used as weak map key" and can be tracked down to lib/collection.html a line 49.

To reproduce : 

```javascript
<dom-module id="x-component">
  <template>
    <template is="x-repeat" items="{{values}}">
      <span>{{item}}</span>
    </template>
  </template>
</dom-module>
<script>
Polymer({
  is: 'x-component',
  ready: function() {
    this.values = [ 1, 2, 3 ];
  }
});
</script>
```
