### PR TITLE
0.8 demodulate

### DIFF
--- a/polymer-micro.html
+++ b/polymer-micro.html
@@ -17,21 +17,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    registerFeatures: function() {
+      this._prepMixins();
+      this._prepExtends();
+      this._prepConstructor();
+    },
 
-      registerFeatures: function() {
-        this._prepMixins();
-        this._prepExtends();
-        this._prepConstructor();
-      },
-
-      initFeatures: function() {
-        this._marshalAttributes();
-      }
-
-    });
+    initFeatures: function() {
+      this._marshalAttributes();
+    }
 
   });
 

--- a/polymer-mini.html
+++ b/polymer-mini.html
@@ -7,6 +7,7 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
 <link rel="import" href="polymer-micro.html">
 
 <link rel="import" href="src/lib/dom-module.html">
@@ -17,29 +18,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
-  
-      registerFeatures: function() {
-        this._prepMixins();
-        this._prepExtends();
-        this._prepConstructor();
-        this._prepTemplate();
-        this._prepContent();
-      },
-  
-      initFeatures: function() {
-        this._poolContent();
-        this._pushHost();
-        this._stampTemplate();
-        this._popHost();
-        this._marshalAttributes();
-        this._readyContent();
-      }
-  
-    });
-      
+    registerFeatures: function() {
+      this._prepMixins();
+      this._prepExtends();
+      this._prepConstructor();
+      this._prepTemplate();
+      this._prepContent();
+    },
+
+    initFeatures: function() {
+      this._poolContent();
+      this._pushHost();
+      this._stampTemplate();
+      this._popHost();
+      this._marshalAttributes();
+      this._readyContent();
+    }
+
   });
 
 </script>

--- a/polymer.html
+++ b/polymer.html
@@ -21,34 +21,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    registerFeatures: function() {
+      this._prepMixins();
+      this._prepExtends();
+      this._prepConstructor();
+      this._prepTemplate();
+      this._prepAnnotations();
+      this._prepEffects();
+      this._prepContent();
+    },
 
-      registerFeatures: function() {
-        this._prepMixins();
-        this._prepExtends();
-        this._prepConstructor();
-        this._prepTemplate();
-        this._prepAnnotations();
-        this._prepEffects();
-        this._prepContent();
-      },
-
-      initFeatures: function() {
-        this._poolContent();
-        this._pushHost();
-        this._setupConfigure();
-        this._stampTemplate();
-        this._marshalAnnotationReferences();
-        this._popHost();
-        this._marshalInstanceEffects();
-        this._marshalAttributes();
-        this._marshalListeners();
-        this._readyContent();
-      }
-
-    });
+    initFeatures: function() {
+      this._poolContent();
+      this._pushHost();
+      this._setupConfigure();
+      this._stampTemplate();
+      this._marshalAnnotationReferences();
+      this._popHost();
+      this._marshalInstanceEffects();
+      this._marshalAttributes();
+      this._marshalListeners();
+      this._readyContent();
+    }
 
   });
 

--- a/src/features/micro/attributes.html
+++ b/src/features/micro/attributes.html
@@ -55,134 +55,121 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class base feature: attributes
    */
   
-  using(['Base', 'Annotations'], function(Base, Annotations) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    _marshalAttributes: function() {
+      this._takeAttributes();
+      this._installHostAttributes(this.hostAttributes);
+    },
 
-      _marshalAttributes: function() {
-        this._takeAttributes();
-        this._installHostAttributes(this.hostAttributes);
-      },
-
-      _installHostAttributes: function(attributes) {
-        if (attributes) {
-          this.cloneAttributes(this, attributes);
-        }
-      },
-
-      cloneAttributes: function(node, attr$) {
-        attr$.split(' ').forEach(function(a) {
-          node.setAttribute(a, '');
-        });
-      },
-
-      _takeAttributes: function() {
-        this._takeAttributesToModel(this);
-      },
-
-      _takeAttributesToModel: function(model) {
-        for (var propName in this.properties) {
-          var type = this.getPropertyType(propName);
-          var attrName = Annotations.camelToDashCase(propName);
-          if (type && this.hasAttribute(attrName)) {
-            var val = this.getAttribute(attrName);
-            model[propName] = this.deserialize(val, type);
-          }
-        }
-      },
-
-      setAttributeToProperty: function(model, attrName) {
-        // Don't deserialize back to property if currently reflecting
-        if (!this._serializing) {
-          var propName = Annotations.dashToCamelCase(attrName);
-          var type = this.getPropertyType(propName);
-          if (type) {
-            var val = this.getAttribute(attrName);
-            model[propName] = this.deserialize(val, type);
-          }
-        }
-      },
-
-      deserialize: function(value, type) {
-        switch (type) {
-
-          case Number:
-            value = Number(value);
-            break;
-
-          case Boolean:
-            value = (value !== null);
-            break;
-
-          case Object:
-          case Array:
-            try {
-              value = JSON.parse(value);
-            } catch(x) {
-              value = '[invalid JSON]';
-            }
-            break;
-
-          case Date:
-            value = new Date(value);
-            break;
-
-          case String:
-          default:
-            break;
-
-        }
-        return value;
-
-      },
-
-      serialize: function(value) {
-        switch (typeof value) {
-
-          case 'boolean':
-            return value ? '' : undefined;
-
-          case 'object':
-            if (value instanceof Date) {
-              return value;
-            } else if (value) {
-              try {
-                return JSON.stringify(value);
-              } catch(x) {
-                return '';
-              }
-            }
-
-          default:
-            return value != null ? value : undefined;
-
-        }
-      },
-
-      _serializing: false,
-      reflectPropertyToAttribute: function(name) {
-        this._serializing = true;
-        this.serializeValueToAttribute(this[name], name);
-        this._serializing = false;
-      },
-
-      serializeValueToAttribute: function(value, attribute, node) {
-        value = this.serialize(value);
-        (node || this)[value === undefined ? 'removeAttribute' : 'setAttribute'](
-          this.camelToDashCase(attribute), value
-        );
-      },
-
-      // TODO(sjmiles): duplicate of function in Annotations library
-      camelToDashCase: function(camel) {
-        return camel.replace(/([a-z][A-Z])/g, 
-          function (g) { 
-            return g[0] + '-' + g[1].toLowerCase() 
-          }
-        );
+    _installHostAttributes: function(attributes) {
+      if (attributes) {
+        this.cloneAttributes(this, attributes);
       }
+    },
 
-    });
+    cloneAttributes: function(node, attr$) {
+      attr$.split(' ').forEach(function(a) {
+        node.setAttribute(a, '');
+      });
+    },
+
+    _takeAttributes: function() {
+      this._takeAttributesToModel(this);
+    },
+
+    _takeAttributesToModel: function(model) {
+      for (var propName in this.properties) {
+        var type = this.getPropertyType(propName);
+        var attrName = Polymer.Annotations.camelToDashCase(propName);
+        if (type && this.hasAttribute(attrName)) {
+          var val = this.getAttribute(attrName);
+          model[propName] = this.deserialize(val, type);
+        }
+      }
+    },
+
+    setAttributeToProperty: function(model, attrName) {
+      // Don't deserialize back to property if currently reflecting
+      if (!this._serializing) {
+        var propName = Polymer.Annotations.dashToCamelCase(attrName);
+        var type = this.getPropertyType(propName);
+        if (type) {
+          var val = this.getAttribute(attrName);
+          model[propName] = this.deserialize(val, type);
+        }
+      }
+    },
+
+    _serializing: false,
+    reflectPropertyToAttribute: function(name) {
+      this._serializing = true;
+      this.serializeValueToAttribute(this[name], name);
+      this._serializing = false;
+    },
+
+    serializeValueToAttribute: function(value, attribute, node) {
+      var str = this.serialize(value);
+      (node || this)
+        [str === undefined ? 'removeAttribute' : 'setAttribute']
+          (Polymer.Annotations.camelToDashCase(attribute), str);
+    },
+
+    deserialize: function(value, type) {
+      switch (type) {
+
+        case Number:
+          value = Number(value);
+          break;
+
+        case Boolean:
+          value = (value !== null);
+          break;
+
+        case Object:
+        case Array:
+          try {
+            value = JSON.parse(value);
+          } catch(x) {
+            value = '[invalid JSON]';
+          }
+          break;
+
+        case Date:
+          value = new Date(value);
+          break;
+
+        case String:
+        default:
+          break;
+
+      }
+      return value;
+
+    },
+
+    serialize: function(value) {
+      switch (typeof value) {
+
+        case 'boolean':
+          return value ? '' : undefined;
+
+        case 'object':
+          if (value instanceof Date) {
+            return value;
+          } else if (value) {
+            try {
+              return JSON.stringify(value);
+            } catch(x) {
+              return '';
+            }
+          }
+
+        default:
+          return value != null ? value : undefined;
+
+      }
+    }
 
   });
 

--- a/src/features/micro/constructor.html
+++ b/src/features/micro/constructor.html
@@ -12,23 +12,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Generates a boilerplate constructor.
    * 
-   * Unless the user has specified a constructor on the prototype, 
-   * this module generates one.
-   *
    *     XFoo = Polymer({
    *       is: 'x-foo'
    *     });
    *     ASSERT(new XFoo() instanceof XFoo);
    *  
-   * Remember that `document.registerElement` does not produce a functional
-   * constructor, so any custom constructor must create it's own `this`, e.g.:
+   * You can supply a custom constructor on the prototype. But remember that 
+   * this constructor will only run if invoked **manually**. Elements created
+   * via `document.createElement` or from HTML _will not invoke this method_.
+   * 
+   * Instead, we reuse the concept of `constructor` for a factory method which 
+   * can take arguments. 
    * 
    *     MyFoo = Polymer({
    *       is: 'my-foo',
    *       constructor: function(foo) {
-   *         var elt = document.createElement('my-foo');
-   *         elt.foo = foo;
-   *         return elt; 
+   *         this.foo = foo;
    *       }
    *       ...
    *     });
@@ -36,39 +35,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class base feature: constructor
    */
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    // registration-time
 
-      // registration-time
-
-      _prepConstructor: function() {
-        if (!this.hasOwnProperty('constructor')) {
-          var ctor;
-          if (this.extends) {
-            ctor = function() {
-              return document.createElement(this.extends, this.is);
-            };
-          } else {
-            ctor = function() {
-              return document.createElement(this.is);
-            };
-          }
-          // ensure constructor is set. The `constructor` property is
-          // not writable on Safari; note: Chrome requires the property
-          // to be configurable.
-          Object.defineProperty(this, 'constructor', {value: ctor, 
-            writable: true, configurable: true});
-          ctor.prototype = this;
-        } else {
-          ctor = this.constructor;
-        }
-        if (this.hasOwnProperty('extends')) {
-          ctor.extends = this.extends; 
-        }
+    _prepConstructor: function() {
+      // capture user-supplied `constructor`
+      if (this.hasOwnProperty('constructor')) {
+        this._userConstructor = this.constructor;
       }
+      // support both possible `createElement` signatures
+      this._factoryArgs = this.extends ? [this.extends, this.is] : [this.is];
+      // thunk the constructor to delegate allocation to `createElement`
+      var ctor = function() { 
+        return this._factory(); 
+      };
+      if (this.hasOwnProperty('extends')) {
+        ctor.extends = this.extends; 
+      }
+      // ensure constructor is set. The `constructor` property is
+      // not writable on Safari; note: Chrome requires the property
+      // to be configurable.
+      Object.defineProperty(this, 'constructor', {value: ctor, 
+        writable: true, configurable: true});
+      ctor.prototype = this;
+    },
 
-    });
+    _factory: function() {
+      var elt = document.createElement.apply(document, this._factoryArgs);
+      if (this._userConstructor) {
+        this._userConstructor.apply(elt, arguments);
+      }
+      return elt;
+    }
 
   });
+
 </script>

--- a/src/features/micro/extends.html
+++ b/src/features/micro/extends.html
@@ -12,52 +12,67 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Support `extends` property (for type-extension only).
    *
-   *  If the mixin is String-valued, the corresponding Polymer module
-   *  is mixed in.
+   * If the mixin is String-valued, the corresponding Polymer module
+   * is mixed in.
    *
    *     Polymer({
-   *       mixins: [
-   *         someObject,
-   *         'PolymerMixinModuleName'
-   *       ],
+   *       is: 'pro-input',
+   *       extends: 'input',
    *       ...
    *     });
+   * 
+   * Type-extension objects are created using `is` notation in HTML, or via
+   * the secondary argument to `document.createElement` (the type-extension
+   * rules are part of the Custom Elements specification, not something 
+   * created by Polymer). 
+   * 
+   * Example:
+   * 
+   *     <!-- right: creates a pro-input element -->
+   *     <input is="pro-input">
+   *   
+   *     <!-- wrong: creates an unknown element -->
+   *     <pro-input>  
+   * 
+   *     <script>
+   *        // right: creates a pro-input element
+   *        var elt = document.createElement('input', 'pro-input');
+   * 
+   *        // wrong: creates an unknown element
+   *        var elt = document.createElement('pro-input');
+   *     <\script>
    *
    *   @class base feature: extends
    */
 
-  using('Base', function(Base) {
-    
-    Base.addFeature({
+  Polymer.Base.addFeature({
 
-      _prepExtends: function() {
-        if (this.extends) {
-          this.__proto__ = this.getExtendedPrototype(this.extends);
-        }
-      },
-
-      getExtendedPrototype: function(tag) {
-        return this.getExtendedNativePrototype(tag);
-      },
-
-      nativePrototypes: {}, // static
-
-      getExtendedNativePrototype: function(tag) {
-        var p = this.nativePrototypes[tag];
-        if (!p) {
-          var np = this.getNativePrototype(tag);
-          p = this.extend(Object.create(np), Base);
-          this.nativePrototypes[tag] = p;
-        }
-        return p;
-      },
-
-      getNativePrototype: function(tag) {
-        // TODO(sjmiles): sad necessity
-        return Object.getPrototypeOf(document.createElement(tag));
+    _prepExtends: function() {
+      if (this.extends) {
+        this.__proto__ = this.getExtendedPrototype(this.extends);
       }
+    },
 
-    });
+    getExtendedPrototype: function(tag) {
+      return this.getExtendedNativePrototype(tag);
+    },
+
+    nativePrototypes: {}, // static
+
+    getExtendedNativePrototype: function(tag) {
+      var p = this.nativePrototypes[tag];
+      if (!p) {
+        var np = this.getNativePrototype(tag);
+        p = this.extend(Object.create(np), Polymer.Base);
+        this.nativePrototypes[tag] = p;
+      }
+      return p;
+    },
+
+    getNativePrototype: function(tag) {
+      // TODO(sjmiles): sad necessity
+      return Object.getPrototypeOf(document.createElement(tag));
+    }
 
   });
 

--- a/src/features/micro/mixins.html
+++ b/src/features/micro/mixins.html
@@ -9,47 +9,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  using('Base', function(Base) {
+  /**
+   * Automatically extend using objects referenced in `mixins` array. 
+   * 
+   *     Polymer({
+   *     
+   *       mixins: [
+   *         someMixinObject
+   *       ]
+   *     
+   *       ...
+   *     
+   *     });
+   * 
+   * @class base feature: mixins
+   */
 
-    /**
-     * Automatically extend using objects referenced in `mixins`
-     * array of the protoype. 
-     * 
-     * If the mixin is String-valued, the corresponding Polymer module
-     * is mixed in.
-     *
-     *     Polymer({
-     *     
-     *       mixins: [
-     *         someObject,
-     *         'PolymerMixinModuleName'
-     *       ]
-     *     
-     *       ...
-     *     
-     *     });
-     * 
-     * @class base feature: mixins
-     */
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
-
-      _prepMixins: function() {
-        if (this.mixins) {
-          var host = this;
-          this.mixins.forEach(function(m) {
-            if (typeof m === 'string') {
-              using(m, function(m) {
-                Base.extend(host, m);
-              });
-            } else {
-              Base.extend(host, m);
-            }
-          });
-        }
+    _prepMixins: function() {
+      if (this.mixins) {
+        this.mixins.forEach(function(m) {
+          Polymer.Base.extend(this, m);
+        }, this);
       }
-
-    });
+    }
 
   });
 

--- a/src/features/micro/properties.html
+++ b/src/features/micro/properties.html
@@ -9,92 +9,87 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
+  /**
+   * Define property metadata.
+   *
+   *     properties: {
+   *       <property>: <Type || Object>,
+   *       ...
+   *     }
+   * 
+   * Example:
+   * 
+   *     properties: {
+   *       // `foo` property can be assigned via attribute, will be deserialized to
+   *       // the specified data-type. All `properties` properties have this behavior.
+   *       foo: String,
+   *
+   *       // `bar` property has additional behavior specifiers.
+   *       //   type: as above, type for (de-)serialization
+   *       //   notify: true to send a signal when a value is set to this property
+   *       //   reflect: true to serialize the property to an attribute
+   *       //   readOnly: if true, the property has no setter
+   *       bar: {
+   *         type: Boolean,
+   *         notify: true
+   *       }
+   *     }
+   *
+   * By itself the properties feature doesn't do anything but provide property
+   * information. Other features use this information to control behavior.
+   *
+   * The `type` information is used by the `attributes` feature to convert
+   * String values in attributes to typed properties. The `bind` feature uses 
+   * property information to control property access.
+   *
+   * Marking a property as `notify` causes a change in the property to
+   * fire a non-bubbling event called `<property>-changed`. Elements that
+   * have enabled two-way binding to the property use this event to
+   * observe changes.
+   *
+   * `readOnly` properties have a getter, but no setter. To set a read-only
+   * property, use the private setter method `_set_<property>(value)`.
+   *
+   * @class base feature: properties
+   */
 
-  using('Base', function(Base) {
+  // null object
+  Polymer.nob = Object.create(null);
+  
+  Polymer.Base.addFeature({
 
+    properties: {
+    },
 
-    /**
-     * Define property metadata.
-     *
-     *     properties: {
-     *       <property>: <Type || Object>,
-     *       ...
-     *     }
-     * 
-     * Example:
-     * 
-     *     properties: {
-     *       // `foo` property can be assigned via attribute, will be deserialized to
-     *       // the specified data-type. All `properties` properties have this behavior.
-     *       foo: String,
-     *
-     *       // `bar` property has additional behavior specifiers.
-     *       //   type: as above, type for (de-)serialization
-     *       //   notify: true to send a signal when a value is set to this property
-     *       //   reflect: true to serialize the property to an attribute
-     *       //   readOnly: if true, the property has no setter
-     *       bar: {
-     *         type: Boolean,
-     *         notify: true
-     *       }
-     *     }
-     *
-     * By itself the properties feature doesn't do anything but provide property
-     * information. Other features use this information to control behavior.
-     *
-     * The `type` information is used by the `attributes` feature to convert
-     * String values in attributes to typed properties. The `bind` feature uses 
-     * property information to control property access.
-     *
-     * Marking a property as `notify` causes a change in the property to
-     * fire a non-bubbling event called `<property>-changed`. Elements that
-     * have enabled two-way binding to the property use this event to
-     * observe changes.
-     *
-     * `readOnly` properties have a getter, but no setter. To set a read-only
-     * property, use the private setter method `_set_<property>(value)`.
-     *
-     * @class base feature: properties
-     */
+    getPropertyInfo: function(property) {
+      return this._getPropertyInfo(property, this.properties);
+    },
 
-    Base.addFeature({
-
-      properties: {
-      },
-
-      nob: Object.create(null),
-
-      getPropertyInfo: function(property) {
-        return this._getPropertyInfo(property, this.properties);
-      },
-
-      _getPropertyInfo: function(property, properties) {
-        var p = properties[property];
-        if (typeof(p) === 'function') {
-          p = properties[property] = {
-            type: p
-          };
-        }
-        return p || Base.nob;
-      },
-
-      getPropertyType: function(property) {
-        return this.getPropertyInfo(property).type;
-      },
-
-      isReadOnlyProperty: function(property) {
-        return this.getPropertyInfo(property).readOnly;
-      },
-
-      isNotifyProperty: function(property) {
-        return this.getPropertyInfo(property).notify;
-      },
-
-      isReflectedProperty: function(property) {
-        return this.getPropertyInfo(property).reflect;
+    _getPropertyInfo: function(property, properties) {
+      var p = properties[property];
+      if (typeof(p) === 'function') {
+        p = properties[property] = {
+          type: p
+        };
       }
+      return p || Polymer.nob;
+    },
 
-    });
+    getPropertyType: function(property) {
+      return this.getPropertyInfo(property).type;
+    },
+
+    isReadOnlyProperty: function(property) {
+      return this.getPropertyInfo(property).readOnly;
+    },
+
+    isNotifyProperty: function(property) {
+      return this.getPropertyInfo(property).notify;
+    },
+
+    isReflectedProperty: function(property) {
+      return this.getPropertyInfo(property).reflect;
+    }
 
   });
 

--- a/src/features/mini/ready.html
+++ b/src/features/mini/ready.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 
   /**
-   *
    * Provides `ready` lifecycle callback which is called parent to child.
    *
    * This can be useful in a number of cases. Here are some examples:
@@ -30,95 +29,91 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class standard feature: ready
    */
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    hostStack = [];
+    hostStack: [],
 
-    Base.addFeature({
+    // for overriding
+    configure: function() {
+    },
 
-      // for overriding
-      configure: function() {
-      },
+    // for overriding
+    ready: function() {
+    },
 
-      // for overriding
-      ready: function() {
-      },
+    queryHost: function() {
+      return this.host;
+    },
 
-      queryHost: function() {
-        return this.host;
-      },
+    // 1. set this element's `host` and push this element onto the `host`'s
+    // list of `client` elements
+    // 2. establish this element as the current hosting element (allows 
+    // any elements we stamp to easily set host to us).
+    _pushHost: function() {
+      this.host = Polymer.Base.hostStack[Polymer.Base.hostStack.length-1];
+      if (this.host) {
+        this.host._clients.push(this);
+      }
+      if (!this._clients) {
+        this._clients = [];
+      }
+      this._beginHost();
+    },
 
-      // 1. set this element's `host` and push this element onto the `host`'s
-      // list of `client` elements
-      // 2. establish this element as the current hosting element (allows 
-      // any elements we stamp to easily set host to us).
-      _pushHost: function() {
-        this.host = hostStack[hostStack.length-1];
-        if (this.host) {
-          this.host._clients.push(this);
-        }
-        if (!this._clients) {
-          this._clients = [];
-        }
-        this._beginHost();
-      },
+    _beginHost: function() {
+      Polymer.Base.hostStack.push(this);
+    },
 
-      _beginHost: function() {
-        hostStack.push(this);
-      },
+    _popHost: function() {
+      // this element is no longer the current hosting element
+      Polymer.Base.hostStack.pop();
+    },
 
-      _popHost: function() {
-        // this element is no longer the current hosting element
-        hostStack.pop();
-      },
+    _readyContent: function() {
+      if (this._canReady()) {
+        this._initializeContent();
+      }
+    },
 
-      _readyContent: function() {
-        if (this._canReady()) {
-          this._initializeContent();
-        }
-      },
+    _canReady: function() {
+      return !this._readied && (!this.host || this.host._readied);
+    },
 
-      _canReady: function() {
-        return !this._readied && (!this.host || this.host._readied);
-      },
+    // TODO(sorvell): can this be collapsed with _distributeContent?
+    _initializeContent: function() {
+      // prepare root
+      this._setupRoot();
+      // logically distribute self
+      this._prepareContent();
+      // send data configuration signal
+      this._configure();
+      // now fully prepare localChildren
+      var c$ = this._getDistributionClients();
+      for (var i=0, l= c$.length, c; (i<l) && (c=c$[i]); i++) {
+        c._initializeContent();
+      }
+      // perform actual dom composition
+      this._composeContent();
+      // send ready signal
+      this._ready();
+    },
 
-      // TODO(sorvell): can this be collapsed with _distributeContent?
-      _initializeContent: function() {
-        // prepare root
-        this._setupRoot();
-        // logically distribute self
-        this._prepareContent();
-        // send data configuration signal
-        this._configure();
-        // now fully prepare localChildren
-        var c$ = this._getDistributionClients();
-        for (var i=0, l= c$.length, c; (i<l) && (c=c$[i]); i++) {
-          c._initializeContent();
-        }
-        // perform actual dom composition
-        this._composeContent();
-        // send ready signal
-        this._ready();
-      },
+    // calls `configure`
+    // note: called host -> localChild
+    _configure: function() {
+      this.configure();
+    },
 
-      // calls `configure`
-      // note: called host -> localChild
-      _configure: function() {
-        this.configure();
-      },
+    // mark readied and call `ready`
+    // note: called localChildren -> host
+    _ready: function() {
+      this._readied = true;
+      this._beforeReady();
+      this.ready();
+    },
 
-      // mark readied and call `ready`
-      // note: called localChildren -> host
-      _ready: function() {
-        this._readied = true;
-        this._beforeReady();
-        this.ready();
-      },
-
-      // for system overriding
-      _beforeReady: function() {},
-
-    });
+    // for system overriding
+    _beforeReady: function() {}
 
   });
 

--- a/src/features/mini/shadow.html
+++ b/src/features/mini/shadow.html
@@ -10,30 +10,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../lib/settings.html">
 <script>
   
-using(['Base', 'Settings'], function(Base, settings) {
-
   /**
     Implements `shadyRoot` compatible dom scoping using native ShadowDOM.
   */
 
   // Transform styles if not using ShadowDOM or if flag is set.
-  
 
-  if (settings.useShadow) {
+  if (Polymer.Settings.useShadow) {
 
-    Base.addFeature({
+    Polymer.Base.addFeature({
 
       // no-op's when ShadowDOM is in use
       _poolContent: function() {},
-
       _prepareContent: function() {},
-
       _composeTree: function() {},
-
       distributeContent: function() {},
 
-      // create a shadowRoot!
+      // create a shadowRoot
       _createLocalRoot: function() {
+        // native ShadowDOM method
         this.createShadowRoot();
         this.shadowRoot.appendChild(this.root);
         this.root = this.shadowRoot;
@@ -42,7 +37,5 @@ using(['Base', 'Settings'], function(Base, settings) {
     });
 
   }
-
-});
 
 </script>

--- a/src/features/mini/shady.html
+++ b/src/features/mini/shady.html
@@ -11,14 +11,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../lib/dom-api.html">
 <script>
 
-  using(['Base', 'ArraySplice', 'DomApi'], function(Base, ArraySplice, DomApi) {
+  (function() {
     /**
 
       Implements a pared down version of ShadowDOM's scoping, which is easy to
       polyfill across browsers.
 
     */
-    Base.addFeature({
+    Polymer.Base.addFeature({
 
       _prepContent: function() {
         // Use this system iff localDom is needed.
@@ -223,7 +223,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Ensures that the rendered node list inside `node` is `children`.
       _updateChildNodes: function(node, children) {
-        var splices = ArraySplice.calculateSplices(children, node.childNodes);
+        var splices = 
+          Polymer.ArraySplice.calculateSplices(children, node.childNodes);
         for (var i=0; i<splices.length; i++) {
           var s = splices[i];
           // remove
@@ -282,9 +283,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
-    var saveLightChildrenIfNeeded = DomApi.saveLightChildrenIfNeeded;
-    var getLightChildren = DomApi.getLightChildren;
-    var matchesSelector = DomApi.matchesSelector;
+    var saveLightChildrenIfNeeded = Polymer.DomApi.saveLightChildrenIfNeeded;
+    var getLightChildren = Polymer.DomApi.getLightChildren;
+    var matchesSelector = Polymer.DomApi.matchesSelector;
 
     function distributeNodeInto(child, insertionPoint) {
       insertionPoint._distributedNodes.push(child);
@@ -330,6 +331,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
-  });
+  })();
 
 </script>

--- a/src/features/mini/template.html
+++ b/src/features/mini/template.html
@@ -15,50 +15,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * The `template` feature locates and instances a `<template>` element
    * corresponding to the current Polymer prototype.
    * 
-   * As of this writing, the `<template>` element must be immediately
-   * preceeding the script that invokes `Polymer()`. This is not the final
-   * API.
+   * The `<template>` element may be immediately preceeding the script that 
+   * invokes `Polymer()`.
    *  
    * @class standard feature: template
    */
   
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    var domModule = document.createElement('dom-module');
-
-    Base.addFeature({
-
-      _prepTemplate: function() {
-        // locate template using dom-module
-        this._template = this._template || domModule.import(this.is, 'template');
-        // fallback to look at the node previous to the currentScript.
-        if (!this._template) {
-          var script = document._currentScript || document.currentScript;
-          var prev = script && script.previousElementSibling;
-          if (prev && prev.localName === 'template') {
-            this._template = prev;
-          }
+    _prepTemplate: function() {
+      // locate template using dom-module
+      this._template = 
+        this._template || Polymer.DomModule.import(this.is, 'template');
+      // fallback to look at the node previous to the currentScript.
+      if (!this._template) {
+        var script = document._currentScript || document.currentScript;
+        var prev = script && script.previousElementSibling;
+        if (prev && prev.localName === 'template') {
+          this._template = prev;
         }
-      },
-
-      _stampTemplate: function() {
-        if (this._template) {
-          // note: root is now a fragment which can be manipulated
-          // while not attached to the element.
-          this.root = this.instanceTemplate(this._template);
-        }
-      },
-
-      instanceTemplate: function(template) {
-        var dom = document.importNode(template._content || template.content, true);
-        // TODO(sjmiles): hello prollyfill
-        if (window.CustomElements && CustomElements.upgradeSubtree) {
-          CustomElements.upgradeSubtree(dom);
-        }
-        return dom;
       }
+    },
 
-    });
+    _stampTemplate: function() {
+      if (this._template) {
+        // note: root is now a fragment which can be manipulated
+        // while not attached to the element.
+        this.root = this.instanceTemplate(this._template);
+      }
+    },
+
+    instanceTemplate: function(template) {
+      var dom = 
+        document.importNode(template._content || template.content, true);
+      // TODO(sjmiles): hello prollyfill
+      if (window.CustomElements && CustomElements.upgradeSubtree) {
+        CustomElements.upgradeSubtree(dom);
+      }
+      return dom;
+    }
 
   });
 

--- a/src/features/standard/annotations.html
+++ b/src/features/standard/annotations.html
@@ -113,83 +113,81 @@ TODO(sjmiles): this module should produce either syntactic metadata
 
 */
 
-  using(['Base', 'Annotations', 'ResolveUrl'], 
-    function(Base, Annotations, resolver) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    // registration-time
 
-      // registration-time
+    _prepAnnotations: function() {
+      if (!this._template) {
+        this._annotes = [];
+      } else {
+        // TODO(sorvell): ad hoc method of plugging behavior into Annotations
+        Polymer.Annotations.prepElement = this._prepElement.bind(this);
+        this._annotes = Polymer.Annotations.parseAnnotations(this._template);
+        Polymer.Annotations.prepElement = null;
+      }
+    },
 
-      _prepAnnotations: function() {
-        // TODO(sorvell): ad hoc method of plugging behavior into Annotations.
-        Annotations.prepElement = this._prepElement.bind(this);
-        this._annotes = !this._template ? [] 
-          : Annotations.parseAnnotations(this._template);
-        Annotations.prepElement = null;
-      },
+    _prepElement: function(element) {
+      Polymer.ResolveUrl.resolveAttrs(element, this._template.ownerDocument);
+    },
 
-      _prepElement: function(element) {
-        resolver.resolveAttrs(element, this._template.ownerDocument);
-      },
+    // instance-time
 
-      // instance-time
+    findAnnotatedNode: Polymer.Annotations.findAnnotatedNode,
 
-      findAnnotatedNode: Annotations.findAnnotatedNode,
+    // marshal all teh things
+    _marshalAnnotationReferences: function() {
+      if (this._template) {
+        this._marshalTemplateContent();
+        this._marshalIdNodes();
+        this._marshalAnnotatedNodes();
+        this._marshalAnnotatedListeners();
+      }
+    }, 
 
-      // marshal all teh things
-      _marshalAnnotationReferences: function() {
-        if (this._template) {
-          this._marshalTemplateContent();
-          this._marshalIdNodes();
-          this._marshalAnnotatedNodes();
-          this._marshalAnnotatedListeners();
+    // nested template contents have been stored prototypically to avoid 
+    // unnecessary duplication, here we put references to the 
+    // indirected contents onto the nested template instances
+    _marshalTemplateContent: function() {
+      this._annotes.forEach(function(note) {
+        if (note.templateContent) {
+          var template = this.findAnnotatedNode(this.root, note);
+          template._content = note.templateContent;
         }
-      }, 
+      }, this);
+    },
 
-      // nested template contents have been stored prototypically to avoid 
-      // unnecessary duplication, here we put references to the 
-      // indirected contents onto the nested template instances
-      _marshalTemplateContent: function() {
-        this._annotes.forEach(function(note) {
-          if (note.templateContent) {
-            var template = this.findAnnotatedNode(this.root, note);
-            template._content = note.templateContent;
-          }
-        }, this);
-      },
-
-      // construct `$` map (from id annotations)
-      _marshalIdNodes: function() {
-        this.$ = {};
-        this._annotes.forEach(function(a) {
-          if (a.id) {
-            this.$[a.id] = Annotations.findAnnotatedNode(this.root, a);
-          }
-        }, this);
-      },
-
-      // concretize `_nodes` map (from anonymous annotations)
-      _marshalAnnotatedNodes: function() {
-        if (this._nodes) {
-          this._nodes = this._nodes.map(function(a) {
-            return Annotations.findAnnotatedNode(this.root, a);
-          }, this);
+    // construct `$` map (from id annotations)
+    _marshalIdNodes: function() {
+      this.$ = {};
+      this._annotes.forEach(function(a) {
+        if (a.id) {
+          this.$[a.id] = this.findAnnotatedNode(this.root, a);
         }
-      },
+      }, this);
+    },
 
-      // install event listeners (from event annotations)
-      _marshalAnnotatedListeners: function() {
-        this._annotes.forEach(function(a) {
-          if (a.events && a.events.length) {
-            var node = Annotations.findAnnotatedNode(this.root, a);
-            a.events.forEach(function(e) {
-              this.listen(node, e.name, e.value);
-            }, this);
-          }
+    // concretize `_nodes` map (from anonymous annotations)
+    _marshalAnnotatedNodes: function() {
+      if (this._nodes) {
+        this._nodes = this._nodes.map(function(a) {
+          return this.findAnnotatedNode(this.root, a);
         }, this);
       }
+    },
 
-    });
+    // install event listeners (from event annotations)
+    _marshalAnnotatedListeners: function() {
+      this._annotes.forEach(function(a) {
+        if (a.events && a.events.length) {
+          var node = this.findAnnotatedNode(this.root, a);
+          a.events.forEach(function(e) {
+            this.listen(node, e.name, e.value);
+          }, this);
+        }
+      }, this);
+    }
 
   });
 

--- a/src/features/standard/configure.html
+++ b/src/features/standard/configure.html
@@ -41,123 +41,119 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   directly (on-foo-changed).
   */
 
-  using(['Base'], function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    // storage for configuration
+    _setupConfigure: function(initialConfig) {
+      this._config = initialConfig || {};
+      this._handlers = [];
+    },
 
-      // storage for configuration
-      _setupConfigure: function(initialConfig) {
-        this._config = initialConfig || {};
-        this._handlers = [];
-      },
+    // static attributes are deserialized into _config
+    _takeAttributes: function() {
+      this._takeAttributesToModel(this._config);
+    },
 
-      // static attributes are deserialized into _config
-      _takeAttributes: function() {
-        this._takeAttributesToModel(this._config);
-      },
+    // at configure time values are stored in _config
+    _configValue: function(name, value) {
+      this._config[name] = value;
+    },
 
-      // at configure time values are stored in _config
-      _configValue: function(name, value) {
-        this._config[name] = value;
-      },
-
-      // configure: returns user supplied default property values
-      // combines with _config to create final property values
-      _configure: function() {
-        this._beforeConfigure();
-        var i;
-        // get individual default values from property config
-        var config = {};
-        for (i in this.properties) {
-          var c = this.properties[i];
-          if (c.value !== undefined) {
-            if (typeof c.value == 'function') {
-              config[i] = c.value.call(this, this._config);
-            } else {
-              config[i] = c.value;
-            }
+    // configure: returns user supplied default property values
+    // combines with _config to create final property values
+    _configure: function() {
+      this._beforeConfigure();
+      var i;
+      // get individual default values from property config
+      var config = {};
+      for (i in this.properties) {
+        var c = this.properties[i];
+        if (c.value !== undefined) {
+          if (typeof c.value == 'function') {
+            config[i] = c.value.call(this, this._config);
+          } else {
+            config[i] = c.value;
           }
         }
-        // get add'l default values from central configure 
-        mixin(config, this.configure(this._config));
-        // combine defaults returned from configure with inputs in _config
-        mixin(config, this._config);
-        // this is the new _config, which are the final values to be applied
-        this._config = config;
-        // pass configuration data to bindings
-        this._distributeConfig(this._config);
-      },
+      }
+      // get add'l default values from central configure 
+      this.simpleMixin(config, this.configure(this._config));
+      // combine defaults returned from configure with inputs in _config
+      this.simpleMixin(config, this._config);
+      // this is the new _config, which are the final values to be applied
+      this._config = config;
+      // pass configuration data to bindings
+      this._distributeConfig(this._config);
+    },
 
-      // system override point
-      _beforeConfigure: function() {},
+    // TODO(sorvell): simple version of mixin; should go elsewhere
+    simpleMixin: function(a, b) {
+      for (var i in b) {
+        a[i] = b[i];
+      }
+    },
 
-      // distribute config values to bound nodes.
-      _distributeConfig: function(config) {
-        var fx$ = this._propertyEffects;
-        if (fx$) {
-          for (var p in config) {
-            var fx = fx$[p];
-            if (fx) {
-              for (var i=0, l=fx.length, x; (i<l) && (x=fx[i]); i++) {
-                if (x.kind === 'annotation') {
-                  var node = this._nodes[x.effect.index];
-                  // seeding configuration only
-                  if (node._configValue) {
-                    node._configValue(x.effect.name, config[p]);
-                  }
+    // system override point
+    _beforeConfigure: function() {},
+
+    // distribute config values to bound nodes.
+    _distributeConfig: function(config) {
+      var fx$ = this._propertyEffects;
+      if (fx$) {
+        for (var p in config) {
+          var fx = fx$[p];
+          if (fx) {
+            for (var i=0, l=fx.length, x; (i<l) && (x=fx[i]); i++) {
+              if (x.kind === 'annotation') {
+                var node = this._nodes[x.effect.index];
+                // seeding configuration only
+                if (node._configValue) {
+                  node._configValue(x.effect.name, config[p]);
                 }
               }
             }
           }
         }
-      },
+      }
+    },
 
-      _beforeReady: function() {
-        this._applyConfig(this._config);
-        this._flushHandlers();
-      },
+    _beforeReady: function() {
+      this._applyConfig(this._config);
+      this._flushHandlers();
+    },
 
-      // NOTE: values are already propagated to children via 
-      // _distributeConfig so propagation triggered by effects here is 
-      // redundant, but safe due to dirty checking
-      _applyConfig: function(config) {
-        for (var n in config) {
-          // Don't stomp on values that may have been set by other side effects
-          if (this[n] === undefined) {
-            this[n] = config[n];
-          }
-        }
-      },
-
-      // NOTE: Notifications can be processed before ready since
-      // they are sent at *child* ready time. Since notifications cause side
-      // effects and side effects must not be processed before ready time,
-      // handling is queue/defered until then.
-      _notifyListener: function(fn, e) {
-        if (!this._readied) {
-          this._queueHandler(arguments);
-        } else {
-          return fn.call(this, e);
-        }
-      },
-
-      _queueHandler: function(args) {
-        this._handlers.push(args);
-      },
-
-      _flushHandlers: function() {
-        var h$ = this._handlers;
-        for (var i=0, l=h$.length, h; (i<l) && (h=h$[i]); i++) {
-          h[0].call(this, h[1]);
+    // NOTE: values are already propagated to children via 
+    // _distributeConfig so propagation triggered by effects here is 
+    // redundant, but safe due to dirty checking
+    _applyConfig: function(config) {
+      for (var n in config) {
+        // Don't stomp on values that may have been set by other side effects
+        if (this[n] === undefined) {
+          this[n] = config[n];
         }
       }
+    },
 
-    });
+    // NOTE: Notifications can be processed before ready since
+    // they are sent at *child* ready time. Since notifications cause side
+    // effects and side effects must not be processed before ready time,
+    // handling is queue/defered until then.
+    _notifyListener: function(fn, e) {
+      if (!this._readied) {
+        this._queueHandler(arguments);
+      } else {
+        return fn.call(this, e);
+      }
+    },
 
-    // TODO(sorvell): simple version of mixin; should go elsewhere
-    function mixin(a, b) {
-      for (var i in b) {
-        a[i] = b[i];
+    _queueHandler: function(args) {
+      this._handlers.push(args);
+    },
+
+    _flushHandlers: function() {
+      var h$ = this._handlers;
+      for (var i=0, l=h$.length, h; (i<l) && (h=h$[i]); i++) {
+        h[0].call(this, h[1]);
       }
     }
 

--- a/src/features/standard/effects.html
+++ b/src/features/standard/effects.html
@@ -53,101 +53,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class data feature: bind
    */
 
-  using(['Base', 'bind', 'bind-annotations'], 
-   function(Base, Bind, BindAnnotations) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    addPropertyEffect: function(property, kind, effect) {
+     var model = property.split('.').shift();
+     Polymer.Bind.addPropertyEffect(this, model, kind, effect);
+    },
 
-      addPropertyEffect: function(property, kind, effect) {
-       var model = property.split('.').shift();
-       Bind.addPropertyEffect(this, model, kind, effect);
-      },
+    // prototyping
 
-      // prototyping
+    _notifyListener: Polymer.Bind._notifyListener,
 
-      _notifyListener: Bind._notifyListener,
+    _prepEffects: function() {
+      Polymer.Bind.prepareModel(this);
+      this._addDynamicEffects(this.properties);
+      this._addObserverEffects(this.observers);
+      this._addAnnotationEffects(this._annotes);
+      Polymer.Bind.createBindings(this);
+    },
 
-      _prepEffects: function() {
-        Bind.prepareModel(this);
-        this._addDynamicEffects(this.properties);
-        this._addObserverEffects(this.observers);
-        this._addAnnotationEffects(this._annotes);
-        Bind.createBindings(this);
-      },
-
-      _addDynamicEffects: function(dynamic) {
-        if (dynamic) {
-          for (var n in dynamic) {
-            var effect = dynamic[n];
-            if (effect.observer) {
-              this._addObserverEffect(n, effect.observer);
-            }
-            if (effect.computed) {
-              Bind.addComputedPropertyEffect(this, n, effect.computed);
-            }
-            if (this.isNotifyProperty(n)) {
-              this.addPropertyEffect(n, 'notify');
-            }
-            if (this.isReflectedProperty(n)) {
-              this.addPropertyEffect(n, 'reflect');
-            }
+    _addDynamicEffects: function(dynamic) {
+      if (dynamic) {
+        for (var n in dynamic) {
+          var effect = dynamic[n];
+          if (effect.observer) {
+            this._addObserverEffect(n, effect.observer);
+          }
+          if (effect.computed) {
+            Polymer.Bind.addComputedPropertyEffect(this, n, effect.computed);
+          }
+          if (this.isNotifyProperty(n)) {
+            this.addPropertyEffect(n, 'notify');
+          }
+          if (this.isReflectedProperty(n)) {
+            this.addPropertyEffect(n, 'reflect');
           }
         }
-      },
-
-      _addObserverEffects: function(observers) {
-        for (var n in observers) {
-          this._addObserverEffect(n, observers[n]);
-        }
-      },
-
-      _addObserverEffect: function(property, observer) {
-        var props = property.split(' ');
-        var methodString;
-        if (props.length == 1) {
-          // Single property synchronous observer (supports paths)
-          var model = property.split('.').shift();
-          if (model != property) {
-             // TODO(kschaaf): path observers won't get the right `new` argument...care?
-             this.addPathObserver(property, observer);
-          }
-          methodString = 'this.' + observer + '(this._data.' + model + ', old);';
-          this.addPropertyEffect(model, 'observer', {
-            method: observer,
-            property: model,
-            methodString: methodString
-          });
-        } else {
-          // Multiple-property debounced observer
-          var methodArgs = 'this._data.' + props.join(', this._data.');
-          methodString = 'this.debounce(\'_' + observer + '\', function() {\n' +
-            '\t\tthis.' + observer + '(' + methodArgs + ');\n' +
-            '\t});';
-          var effect = {
-            method: observer,
-            properties: props,
-            methodString: methodString
-          };
-          for (var i=0; i<props.length; i++) {
-            this.addPropertyEffect(props[i], 'observer', effect);
-          }
-        }
-      },
-
-      _addAnnotationEffects: function(notes) {
-        if (notes) {
-          BindAnnotations.addEffects(this, notes);
-        }
-      },
-
-      // instancing
-
-      _marshalInstanceEffects: function() {
-        Bind.prepareInstance(this);
-        Bind.setupBindListeners(this);
       }
+    },
 
-    });
+    _addObserverEffects: function(observers) {
+      for (var n in observers) {
+        this._addObserverEffect(n, observers[n]);
+      }
+    },
+
+    _addObserverEffect: function(property, observer) {
+      var props = property.split(' ');
+      var methodString;
+      if (props.length == 1) {
+        // Single property synchronous observer (supports paths)
+        var model = property.split('.').shift();
+        if (model != property) {
+           // TODO(kschaaf): path observers won't get the right `new` argument...care?
+           this.addPathObserver(property, observer);
+        }
+        methodString = 'this.' + observer + '(this._data.' + model + ', old);';
+        this.addPropertyEffect(model, 'observer', {
+          method: observer,
+          property: model,
+          methodString: methodString
+        });
+      } else {
+        // Multiple-property debounced observer
+        var methodArgs = 'this._data.' + props.join(', this._data.');
+        methodString = 'this.debounce(\'_' + observer + '\', function() {\n' +
+          '\t\tthis.' + observer + '(' + methodArgs + ');\n' +
+          '\t});';
+        var effect = {
+          method: observer,
+          properties: props,
+          methodString: methodString
+        };
+        for (var i=0; i<props.length; i++) {
+          this.addPropertyEffect(props[i], 'observer', effect);
+        }
+      }
+    },
+
+    _addAnnotationEffects: function(notes) {
+      if (notes) {
+        Polymer.BindAnnotations.addEffects(this, notes);
+      }
+    },
+
+    // instancing
+
+    _marshalInstanceEffects: function() {
+      Polymer.Bind.prepareInstance(this);
+      Polymer.Bind.setupBindListeners(this);
+    }
 
   });
 

--- a/src/features/standard/events.html
+++ b/src/features/standard/events.html
@@ -38,80 +38,76 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * 
    */
 
-  using('Base', function(Base) {
+  Polymer.Base.addFeature({
 
-    Base.addFeature({
+    listeners: {},
 
-      listeners: {},
+    _marshalListeners: function() {
+      this._listenListeners(this.listeners);
+      this._listenKeyPresses(this.keyPresses);
+    },
 
-      _marshalListeners: function() {
-        this._listenListeners(this.listeners);
-        this._listenKeyPresses(this.keyPresses);
-      },
-
-      _listenListeners: function(listeners) {
-        var node, name, key;
-        for (key in listeners) {
-          if (key.indexOf('.') < 0) {
-            node = this;
-            name = key;
-          } else {
-            name = key.split('.');
-            node = this.$[name[0]];
-            name = name[1];
-          }
-          this.listen(node, name, listeners[key]);
+    _listenListeners: function(listeners) {
+      var node, name, key;
+      for (key in listeners) {
+        if (key.indexOf('.') < 0) {
+          node = this;
+          name = key;
+        } else {
+          name = key.split('.');
+          node = this.$[name[0]];
+          name = name[1];
         }
-      },
-
-      listen: function(node, eventName, methodName) {
-        var host = this;
-        node.addEventListener(eventName, function(e) {
-          if (host[methodName]) {
-            host[methodName](e, e.detail);
-          } else {
-            console.warn('[%s].[%s]: event handler [%s] is null in scope (%o)', 
-              node.localName, eventName, methodName, host);
-          }
-        });
-      },
-
-      keyPresses: {},
-
-      _listenKeyPresses: function(keyPresses) {
-        // for..in here to gate empty keyPresses object (iterates once or never)
-        for (var n in keyPresses) {
-          // only get here if there is something in keyPresses
-          // TODO(sjmiles): _keyPressesFeatureHandler uses `this.keyPresses`
-          // to look up keycodes, it's not agnostic like this method is
-          this.addEventListener('keydown', this._keyPressesFeatureHandler);
-          // map string keys to numeric codes
-          for (n in keyPresses) {
-            if (typeof n === 'string') {
-              keyPresses[this.eventKeyCodes[n]] = keyPresses[n];
-            }
-          }
-          break;
-        }
-      },
-
-      _keyPressesFeatureHandler: function(e) {
-        var method = this.keyPresses[e.keyCode];
-        if (method && this[method]) {
-          return this[method](e.keyCode, e);
-        }
-      },
-
-      eventKeyCodes: {
-        ESC_KEY: 27,
-        ENTER_KEY: 13,
-        LEFT: 37,
-        UP: 38,
-        RIGHT: 39,
-        DOWN: 40
+        this.listen(node, name, listeners[key]);
       }
+    },
 
-    });
+    listen: function(node, eventName, methodName) {
+      var host = this;
+      node.addEventListener(eventName, function(e) {
+        if (host[methodName]) {
+          host[methodName](e, e.detail);
+        } else {
+          console.warn('[%s].[%s]: event handler [%s] is null in scope (%o)', 
+            node.localName, eventName, methodName, host);
+        }
+      });
+    },
+
+    keyPresses: {},
+
+    _listenKeyPresses: function(keyPresses) {
+      // for..in here to gate empty keyPresses object (iterates once or never)
+      for (var n in keyPresses) {
+        // only get here if there is something in keyPresses
+        // TODO(sjmiles): _keyPressesFeatureHandler uses `this.keyPresses`
+        // to look up keycodes, it's not agnostic like this method is
+        this.addEventListener('keydown', this._keyPressesFeatureHandler);
+        // map string keys to numeric codes
+        for (n in keyPresses) {
+          if (typeof n === 'string') {
+            keyPresses[this.eventKeyCodes[n]] = keyPresses[n];
+          }
+        }
+        break;
+      }
+    },
+
+    _keyPressesFeatureHandler: function(e) {
+      var method = this.keyPresses[e.keyCode];
+      if (method && this[method]) {
+        return this[method](e.keyCode, e);
+      }
+    },
+
+    eventKeyCodes: {
+      ESC_KEY: 27,
+      ENTER_KEY: 13,
+      LEFT: 37,
+      UP: 38,
+      RIGHT: 39,
+      DOWN: 40
+    }
 
   });
 

--- a/src/features/standard/notify-path.html
+++ b/src/features/standard/notify-path.html
@@ -58,9 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @class data feature: path notification
    */
 
-using(['Base', 'Annotations'], function(Base, Annotations) {
-
-  Base.addFeature({
+  Polymer.Base.addFeature({
     /**
       Notify that a path has changed. For example:
 
@@ -141,7 +139,7 @@ using(['Base', 'Annotations'], function(Base, Annotations) {
     // a fair amount of runtime lookup
     _pathEffector: function(path, value) {
       // get root property
-      var model = modelForPath(path);
+      var model = this._modelForPath(path);
       // search property effects of the root property for 'annotation' effects
       var fx$ = this._propertyEffects[model];
       if (fx$) {
@@ -248,26 +246,22 @@ using(['Base', 'Annotations'], function(Base, Annotations) {
     },
 
     _notifyPath: function(path, value) {
-      var rootName = modelForPath(path);
-      var dashCaseName = Annotations.camelToDashCase(rootName); 
-      var eventName = dashCaseName + EVENT_PATH_CHANGED;
+      var rootName = this._modelForPath(path);
+      var dashCaseName = Polymer.Annotations.camelToDashCase(rootName); 
+      var eventName = dashCaseName + this._EVENT_PATH_CHANGED;
       this.fire(eventName, { 
         path: path, 
         value: value 
       }, null, false);
-    }
+    },
+
+    _modelForPath: function(path) {
+      return path.split('.').shift();
+    },
+
+    _EVENT_CHANGED: '-changed',
+    _EVENT_PATH_CHANGED: '-path-changed'
 
   });
-
-  // TODO(sjmiles): needs a home
-  function modelForPath(path) {
-    return path.split('.').shift();
-  }
-
-  // TODO(sjmiles): should be imported from elsewhere
-  var EVENT_CHANGED = '-changed';
-  var EVENT_PATH_CHANGED = '-path' + EVENT_CHANGED;
-
-});
 
 </script>

--- a/src/features/standard/resolveUrl.html
+++ b/src/features/standard/resolveUrl.html
@@ -8,15 +8,12 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-using(['Base'], function(Base) {
 
-  var domModule = document.createElement('dom-module');
-
-  Base.addFeature({
+  Polymer.Base.addFeature({
 
     resolveUrl: function(url) {
       // TODO(sorvell): do we want to put the module reference on the prototype?
-      var module = domModule.import(this.is);
+      var module = Polymer.DomModule.import(this.is);
       var root = '';
       if (module) {
         var assetPath = module.getAttribute('assetpath') || '';
@@ -26,5 +23,5 @@ using(['Base'], function(Base) {
     }
 
   });
-});
+
 </script>

--- a/src/features/standard/styling.html
+++ b/src/features/standard/styling.html
@@ -7,41 +7,40 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
 <link rel="import" href="../../lib/style-util.html">
 <link rel="import" href="../../lib/resolve-url.html">
 <link rel="import" href="../../lib/style-transformer.html">
 <link rel="import" href="../../lib/settings.html">
+
 <script>
 
-  using(['Base', 'Annotations', 'StyleTransformer', 'StyleUtil', 'Settings', 
-    'ResolveUrl'], 
-    function(Base, Annotations, transformer, styleUtil, settings, resolver) {
-    
-    var prepTemplate = Base._prepTemplate;
-    var prepElement = Base._prepElement;
-    var stampTemplate = Base._stampTemplate;
+  (function() {
 
-    var domModule = document.createElement('dom-module');
+    var prepTemplate = Polymer.Base._prepTemplate;
+    var prepElement = Polymer.Base._prepElement;
+    var baseStampTemplate = Polymer.Base._stampTemplate;
 
-    Base.addFeature({
+    Polymer.Base.addFeature({
 
       // declaration-y
       _prepTemplate: function() {
         prepTemplate.call(this);
-        var port = domModule.import(this.is);
+        var port = Polymer.DomModule.import(this.is);
         if (this._encapsulateStyle === undefined) {
-          this._encapsulateStyle = Boolean(port && !settings.useNativeShadow);
+          this._encapsulateStyle = 
+            Boolean(port && !Polymer.Settings.useNativeShadow);
         }
         // scope css
         // NOTE: dom scoped via annotations
-        if (settings.useNativeShadow || this._encapsulateStyle) {
+        if (Polymer.Settings.useNativeShadow || this._encapsulateStyle) {
           this._scopeCss();
         }
       },
 
       _prepElement: function(element) {
         if (this._encapsulateStyle) {
-          transformer.element(element, this.is);
+          Polymer.StyleTransformer.element(element, this.is);
         }
         prepElement.call(this, element);
       },
@@ -62,7 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           modules.push(this.is);
         }
         for (var i=0, l=modules.length, n, m; (i<l) && (n=modules[i]); i++) {
-          m = domModule.import(n);
+          m = Polymer.DomModule.import(n);
           if (m) {
             styles = styles.concat(Array.prototype.slice.call(
               m._styles ? m._styles : m.querySelectorAll('style')));
@@ -87,8 +86,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // TODO(sorvell): currently only needed in native since we rely
             // on HTMLImports polyfill otherwise; if we move styles into
             // templates, this will always be required.
-            if (settings.useNativeImports) {
-              s.textContent = resolver.resolveCss(s.textContent, 
+            if (Polymer.Settings.useNativeImports) {
+              s.textContent = Polymer.ResolveUrl.resolveCss(s.textContent, 
                 s.ownerDocument);
             }
             m._styles.push(s);
@@ -103,18 +102,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _scopeStyles: function(styles) {
         for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
           // transform style if necessary and place in correct place
-          if (settings.useNativeShadow) {
+          if (Polymer.Settings.useNativeShadow) {
             this._template.content.appendChild(s);
           } else {
             var rules = this._rulesForStyle(s);
-            styleUtil.applyCss(transformer.css(rules, this.is), this.is);
+            Polymer.StyleUtil.applyCss(
+              Polymer.StyleTransformer.css(rules, this.is), 
+              this.is
+            );
           }
         }
       },
 
       _rulesForStyle: function(style) {
         if (!style.__cssRules) {
-          style.__cssRules = styleUtil.parser.parse(style.textContent);
+          style.__cssRules = Polymer.StyleUtil.parser.parse(style.textContent);
         }
         return style.__cssRules;
       },
@@ -122,26 +124,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // instance-y
       _stampTemplate: function() {
         if (this._encapsulateStyle) {
-          transformer.host(this, this.is);
+          Polymer.StyleTransformer.host(this, this.is);
         }
-        stampTemplate.call(this);
+        baseStampTemplate.call(this);
       },
 
       // add scoping class whenever an element is added to localDOM
       _elementAdd: function(node) {
         if (this._encapsulateStyle && !node.__styleScoped) {
-          transformer.dom(node, this.is);
+          Polymer.StyleTransformer.dom(node, this.is);
         }
       },
 
       // remove scoping class whenever an element is removed from localDOM
       _elementRemove: function(node) {
         if (this._encapsulateStyle) {
-          transformer.dom(node, '');
+          Polymer.StyleTransformer.dom(node, '');
         }
       }
 
     });
 
-  });
+  })();
+
 </script>

--- a/src/features/standard/utils.html
+++ b/src/features/standard/utils.html
@@ -13,9 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-using(['Base', 'Async', 'Debounce'], function(Base, Async, Debounce) {
-
-  Base.addFeature({
+  Polymer.Base.addFeature({
 
     $$: function(slctr) {
       return this.root.querySelector(slctr);
@@ -69,11 +67,11 @@ using(['Base', 'Async', 'Debounce'], function(Base, Async, Debounce) {
     },
 
     async: function(method, waitTime) {
-      return Async.run(method.bind(this), waitTime);
+      return Polymer.Async.run(method.bind(this), waitTime);
     },
 
     cancelAsync: function(handle) {
-      Async.cancel(handle);
+      Polymer.Async.cancel(handle);
     },
 
     queryHost: function(node) {
@@ -133,11 +131,9 @@ using(['Base', 'Async', 'Debounce'], function(Base, Async, Debounce) {
     },
 
     _debounce: function(job, callback, wait) {
-      this[job] = Debounce.call(this, this[job], callback, wait);
+      this[job] = Polymer.Debounce.call(this, this[job], callback, wait);
     }
 
   });
-
-});
 
 </script>

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -62,217 +62,212 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  * @class Template feature
  */
 
-  modulate('Annotations', function() {
+  // null-array (shared empty array to avoid null-checks)
+  Polymer.nar = [];
 
-    // null-array (shared empty array to avoid null-checks)
-    var nar = [];
+  Polymer.Annotations = {
 
-    var Annotations = {
+    // preprocess-time
 
-      // preprocess-time
+    // construct and return a list of annotation records
+    // by scanning `template`'s content
+    //
+    parseAnnotations: function(template) {
+      var list = [];
+      var content = template._content || template.content; 
+      this._parseNodeAnnotations(content, list);
+      return list;
+    },
 
-      // construct and return a list of annotation records
-      // by scanning `template`'s content
-      //
-      parseAnnotations: function(template) {
-        var list = [];
-        var content = template._content || template.content; 
-        this._parseNodeAnnotations(content, list);
-        return list;
-      },
+    // add annotations gleaned from subtree at `node` to `list`
+    _parseNodeAnnotations: function(node, list) {
+      return node.nodeType === Node.TEXT_NODE ?
+        this._parseTextNodeAnnotation(node, list) :
+          // TODO(sjmiles): are there other nodes we may encounter
+          // that are not TEXT_NODE but also not ELEMENT?
+          this._parseElementAnnotations(node, list);
+    },
 
-      // add annotations gleaned from subtree at `node` to `list`
-      _parseNodeAnnotations: function(node, list) {
-        return node.nodeType === Node.TEXT_NODE ?
-          this._parseTextNodeAnnotation(node, list) :
-            // TODO(sjmiles): are there other nodes we may encounter
-            // that are not TEXT_NODE but also not ELEMENT?
-            this._parseElementAnnotations(node, list);
-      },
-
-      // add annotations gleaned from TextNode `node` to `list`
-      _parseTextNodeAnnotation: function(node, list) {
-        var v = node.textContent, escape = v.slice(0, 2);
-        if (escape === '{{' || escape === '[[') {
-          // NOTE: use a space here so the textNode remains; some browsers
-          // (IE) evacipate an empty textNode.
-          node.textContent = ' ';
-          var annote = {
-            bindings: [{
-              kind: 'text',
-              mode: escape[0],
-              value: v.slice(2, -2)
-            }]
-          };
-          list.push(annote);
-          return annote;
-        }
-      },
-
-      // add annotations gleaned from Element `node` to `list`
-      _parseElementAnnotations: function(element, list) {
+    // add annotations gleaned from TextNode `node` to `list`
+    _parseTextNodeAnnotation: function(node, list) {
+      var v = node.textContent, escape = v.slice(0, 2);
+      if (escape === '{{' || escape === '[[') {
+        // NOTE: use a space here so the textNode remains; some browsers
+        // (IE) evacipate an empty textNode.
+        node.textContent = ' ';
         var annote = {
-          bindings: [],
-          events: []
+          bindings: [{
+            kind: 'text',
+            mode: escape[0],
+            value: v.slice(2, -2)
+          }]
         };
-        this._parseChildNodesAnnotations(element, annote, list);
-        // TODO(sjmiles): is this for non-ELEMENT nodes? If so, we should
-        // change the contract of this method, or filter these out above.
-        if (element.attributes) {
-          this._parseNodeAttributeAnnotations(element, annote, list);
-          // TODO(sorvell): ad hoc callback for doing work on elements while
-          // leveraging annotator's tree walk.
-          // Consider adding an node callback registry and moving specific 
-          // processing out of this module.
-          if (this.prepElement) {
-            this.prepElement(element);
-          }
-        }
-        if (annote.bindings.length || annote.events.length || annote.id) {
-          list.push(annote);
-        }
+        list.push(annote);
         return annote;
-      },
+      }
+    },
 
-      // add annotations gleaned from children of `root` to `list`, `root`'s
-      // `annote` is supplied as it is the annote.parent of added annotations 
-      _parseChildNodesAnnotations: function(root, annote, list, callback) {
-        if (root.firstChild) {
-          for (var i=0, node=root.firstChild; node; node=node.nextSibling, i++){
-            if (node.localName === 'template') {
-              // TODO(sjmiles): simply altering the .content reference didn't
-              // work (there was some confusion, might need verification)
-              var content = document.createDocumentFragment();
-              content.appendChild(node.content);
-              // TODO(sjmiles): using `nar` to avoid unnecessary allocation;
-              // in general the handling of these arrays needs some cleanup 
-              // in this module
-              list.push({
-                bindings: nar,
-                events: nar,
-                templateContent: content,
-                parent: annote,
-                index: i
-              });
-            }
-            //
-            var childAnnotation = this._parseNodeAnnotations(node, list, callback);
-            if (childAnnotation) {
-              childAnnotation.parent = annote;
-              childAnnotation.index = i;
-            }
-          }
+    // add annotations gleaned from Element `node` to `list`
+    _parseElementAnnotations: function(element, list) {
+      var annote = {
+        bindings: [],
+        events: []
+      };
+      this._parseChildNodesAnnotations(element, annote, list);
+      // TODO(sjmiles): is this for non-ELEMENT nodes? If so, we should
+      // change the contract of this method, or filter these out above.
+      if (element.attributes) {
+        this._parseNodeAttributeAnnotations(element, annote, list);
+        // TODO(sorvell): ad hoc callback for doing work on elements while
+        // leveraging annotator's tree walk.
+        // Consider adding an node callback registry and moving specific 
+        // processing out of this module.
+        if (this.prepElement) {
+          this.prepElement(element);
         }
-      },
+      }
+      if (annote.bindings.length || annote.events.length || annote.id) {
+        list.push(annote);
+      }
+      return annote;
+    },
 
-      // add annotation data from attributes to the `annotation` for node `node`
-      // TODO(sjmiles): the distinction between an `annotation` and 
-      // `annotation data` is not as clear as it could be
-      _parseNodeAttributeAnnotations: function(node, annotation) {
-        for (var i=0, a; (a=node.attributes[i]); i++) {
-          var n = a.name, v = a.value;
-          // id
-          if (n === 'id') {
-            annotation.id = v;
-          }
-          // events (on-*)
-          else if (n.slice(0, 3) === 'on-') {
-            i--;
-            node.removeAttribute(n);
-            annotation.events.push({
-              name: n.slice(3),
-              value: v
+    // add annotations gleaned from children of `root` to `list`, `root`'s
+    // `annote` is supplied as it is the annote.parent of added annotations 
+    _parseChildNodesAnnotations: function(root, annote, list, callback) {
+      if (root.firstChild) {
+        for (var i=0, node=root.firstChild; node; node=node.nextSibling, i++){
+          if (node.localName === 'template') {
+            // TODO(sjmiles): simply altering the .content reference didn't
+            // work (there was some confusion, might need verification)
+            var content = document.createDocumentFragment();
+            content.appendChild(node.content);
+            // TODO(sjmiles): using `nar` to avoid unnecessary allocation;
+            // in general the handling of these arrays needs some cleanup 
+            // in this module
+            list.push({
+              bindings: Polymer.nar,
+              events: Polymer.nar,
+              templateContent: content,
+              parent: annote,
+              index: i
             });
           }
-          // bindings (other attributes)
-          else {
-            var b = this._parseNodeAttributeAnnotation(node, n, v);
-            if (b) {
-              i--;
-              annotation.bindings.push(b);
-            }
+          //
+          var childAnnotation = this._parseNodeAnnotations(node, list, callback);
+          if (childAnnotation) {
+            childAnnotation.parent = annote;
+            childAnnotation.index = i;
           }
         }
-      },
-
-      // construct annotation data from a generic attribute, or undefined
-      _parseNodeAttributeAnnotation: function(node, n, v) {
-        var mode = '', escape = v.slice(0, 2), name = n;
-        if (escape === '{{' || escape === '[[') {
-          // Mode (one-way or two)
-          mode = escape[0];
-          v = v.slice(2, -2);
-          // Negate
-          var not = false;
-          if (v[0] == '!') {
-            v = v.substring(1);
-            not = true;
-          }
-          // Attribute or property
-          var kind = 'property';
-          if (n[n.length-1] == '$') {
-            name = n.slice(0, -1);
-            kind = 'attribute';
-          }
-          // Remove annotation
-          node.removeAttribute(n);
-          // Case hackery: attributes are lower-case, but bind targets 
-          // (properties) are case sensitive. Gambit is to map dash-case to 
-          // camel-case: `foo-bar` becomes `fooBar`.
-          // Attribute bindings are excepted.
-          if (kind === 'property') {
-            name = Annotations.dashToCamelCase(name);
-          }
-          return {
-            kind: kind,
-            mode: mode,
-            name: name,
-            value: v,
-            negate: not
-          };
-        }
-      },
-
-      dashToCamelCase: function(dash) {
-        // TODO(sjmiles): is rejection test actually helping perf?
-        if (dash.indexOf('-') < 0) {
-          return dash;
-        }
-        return dash.replace(/-([a-z])/g, 
-          function(m) {
-            return m[1].toUpperCase(); 
-          }
-        );
-      },
-
-      camelToDashCase: function(camel) {
-        return camel.replace(/([a-z][A-Z])/g, 
-          function (g) { 
-            return g[0] + '-' + g[1].toLowerCase() 
-          }
-        );
-      },
-
-      // instance-time
-
-      _localSubTree: function(node, host) {
-        return (node === host) ? node.childNodes :
-           (node.lightChildren || node.childNodes);
-      },
-
-      findAnnotatedNode: function(root, annote) {
-        // recursively ascend tree until we hit root
-        var parent = annote.parent && 
-          Annotations.findAnnotatedNode(root, annote.parent);
-        // unwind the stack, returning the indexed node at each level
-        return !parent ? root : 
-          Annotations._localSubTree(parent, root)[annote.index];
       }
+    },
 
-    };
+    // add annotation data from attributes to the `annotation` for node `node`
+    // TODO(sjmiles): the distinction between an `annotation` and 
+    // `annotation data` is not as clear as it could be
+    _parseNodeAttributeAnnotations: function(node, annotation) {
+      for (var i=0, a; (a=node.attributes[i]); i++) {
+        var n = a.name, v = a.value;
+        // id
+        if (n === 'id') {
+          annotation.id = v;
+        }
+        // events (on-*)
+        else if (n.slice(0, 3) === 'on-') {
+          i--;
+          node.removeAttribute(n);
+          annotation.events.push({
+            name: n.slice(3),
+            value: v
+          });
+        }
+        // bindings (other attributes)
+        else {
+          var b = this._parseNodeAttributeAnnotation(node, n, v);
+          if (b) {
+            i--;
+            annotation.bindings.push(b);
+          }
+        }
+      }
+    },
 
-    return Annotations;
+    // construct annotation data from a generic attribute, or undefined
+    _parseNodeAttributeAnnotation: function(node, n, v) {
+      var mode = '', escape = v.slice(0, 2), name = n;
+      if (escape === '{{' || escape === '[[') {
+        // Mode (one-way or two)
+        mode = escape[0];
+        v = v.slice(2, -2);
+        // Negate
+        var not = false;
+        if (v[0] == '!') {
+          v = v.substring(1);
+          not = true;
+        }
+        // Attribute or property
+        var kind = 'property';
+        if (n[n.length-1] == '$') {
+          name = n.slice(0, -1);
+          kind = 'attribute';
+        }
+        // Remove annotation
+        node.removeAttribute(n);
+        // Case hackery: attributes are lower-case, but bind targets 
+        // (properties) are case sensitive. Gambit is to map dash-case to 
+        // camel-case: `foo-bar` becomes `fooBar`.
+        // Attribute bindings are excepted.
+        if (kind === 'property') {
+          name = Polymer.Annotations.dashToCamelCase(name);
+        }
+        return {
+          kind: kind,
+          mode: mode,
+          name: name,
+          value: v,
+          negate: not
+        };
+      }
+    },
 
-  });
+    dashToCamelCase: function(dash) {
+      // TODO(sjmiles): is rejection test actually helping perf?
+      if (dash.indexOf('-') < 0) {
+        return dash;
+      }
+      return dash.replace(/-([a-z])/g, 
+        function(m) {
+          return m[1].toUpperCase(); 
+        }
+      );
+    },
+
+    camelToDashCase: function(camel) {
+      return camel.replace(/([a-z][A-Z])/g, 
+        function (g) { 
+          return g[0] + '-' + g[1].toLowerCase() 
+        }
+      );
+    },
+
+    // instance-time
+
+    _localSubTree: function(node, host) {
+      return (node === host) ? node.childNodes :
+         (node.lightChildren || node.childNodes);
+    },
+
+    findAnnotatedNode: function(root, annote) {
+      // recursively ascend tree until we hit root
+      var parent = annote.parent && 
+        Polymer.Annotations.findAnnotatedNode(root, annote.parent);
+      // unwind the stack, returning the indexed node at each level
+      return !parent ? root : 
+        Polymer.Annotations._localSubTree(parent, root)[annote.index];
+    }
+
+  };
+
 
 </script>

--- a/src/lib/array-splice.html
+++ b/src/lib/array-splice.html
@@ -8,7 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-modulate('ArraySplice', function() {
+
+Polymer.ArraySplice = (function() {
   
   function newSplice(index, removed, addedCount) {
     return {
@@ -255,8 +256,7 @@ modulate('ArraySplice', function() {
     }
   };
 
-  // exports
   return new ArraySplice();
 
-});
+})();
 </script>

--- a/src/lib/async.html
+++ b/src/lib/async.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-modulate('Async', function() {
+Polymer.Async = (function() {
   
   var currVal = 0;
   var lastVal = 0;
@@ -63,6 +63,6 @@ modulate('Async', function() {
     cancel: cancelAsync
   };
   
-});
+})();
 
 </script>

--- a/src/lib/base.html
+++ b/src/lib/base.html
@@ -9,97 +9,95 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  modulate('Base', function() {
+  Polymer.DomModule = document.createElement('dom-module');
 
-    var Base = {
+  Polymer.Base = {
 
-      telemetry: {
-        count: 0
-      },
+    // (semi-)pluggable features for Base
+    addFeature: function(feature) {
+      this.extend(this, feature);
+    },
 
-      // (semi-)pluggable features for Base
-      addFeature: function(feature) {
-        this.extend(this, feature);
-      },
+    registerCallback: function() {
+      this.registerFeatures();  // abstract
+      this.registered();
+    },
 
-      registerCallback: function() {
-        this.registerFeatures();  // abstract
-        this.registered();
-      },
+    registered: function() {
+      // for overriding
+      // `this` context is a prototype, not an instance
+    },
 
-      registered: function() {
-        // for overriding
-        // `this` context is a prototype, not an instance
-      },
+    createdCallback: function() {
+      Polymer.telemetry.instanceCount++;
+      this.root = this;
+      this.beforeCreated();
+      this.created();
+      this.afterCreated();
+      this.initFeatures(); // abstract
+    },
 
-      createdCallback: function() {
-        Base.telemetry.count++;
-        this.root = this;
-        this.beforeCreated();
-        this.created();
-        this.afterCreated();
-        this.initFeatures(); // abstract
-      },
+    beforeCreated: function() {
+      // for overriding
+    },
 
-      beforeCreated: function() {
-        // for overriding
-      },
+    created: function() {
+      // for overriding
+    },
 
-      created: function() {
-        // for overriding
-      },
+    afterCreated: function() {
+      // for overriding
+    },
 
-      afterCreated: function() {
-        // for overriding
-      },
+    attachedCallback: function() {
+      this.isAttached = true;
+      // reserved for canonical behavior
+      this.attached();
+    },
 
-      attachedCallback: function() {
-        this.isAttached = true;
-        // reserved for canonical behavior
-        this.attached();
-      },
+    attached: function() {
+      // for overriding
+    },
 
-      attached: function() {
-        // for overriding
-      },
+    detachedCallback: function() {
+      this.isAttached = false;
+      // reserved for canonical behavior
+      this.detached();
+    },
 
-      detachedCallback: function() {
-        this.isAttached = false;
-        // reserved for canonical behavior
-        this.detached();
-      },
+    detached: function() {
+      // for overriding
+    },
 
-      detached: function() {
-        // for overriding
-      },
+    attributeChangedCallback: function(name) {
+      this.setAttributeToProperty(this, name);
+      // reserved for canonical behavior
+      this.attributeChanged.apply(this, arguments);
+    },
 
-      attributeChangedCallback: function(name) {
-        this.setAttributeToProperty(this, name);
-        // reserved for canonical behavior
-        this.attributeChanged.apply(this, arguments);
-      },
+    attributeChanged: function() {
+      // for overriding
+    },
 
-      attributeChanged: function() {
-        // for overriding
-      },
-
-      // copy own properties from `api` to `prototype`
-      extend: function(prototype, api) {
-        if (prototype && api) {
-          Object.getOwnPropertyNames(api).forEach(function(n) {
-            var pd = Object.getOwnPropertyDescriptor(api, n);
-            if (pd) {
-              Object.defineProperty(prototype, n, pd);
-            }
-          });
-        }
-        return prototype || api;
+    // copy own properties from `api` to `prototype`
+    extend: function(prototype, api) {
+      if (prototype && api) {
+        Object.getOwnPropertyNames(api).forEach(function(n) {
+          var pd = Object.getOwnPropertyDescriptor(api, n);
+          if (pd) {
+            Object.defineProperty(prototype, n, pd);
+          }
+        });
       }
+      return prototype || api;
+    }
 
-    };
+  };
 
-    return Base;
+  // make Base suffix HTMLELement, other types need Base-clones
+  Polymer.Base.__proto__ = HTMLElement.prototype;
 
-  });
+  // TODO(sjmiles): ad hoc telemetry
+  Polymer.telemetry.instanceCount = 0;
 
 </script>

--- a/src/lib/bind/bind-annotations.html
+++ b/src/lib/bind/bind-annotations.html
@@ -10,71 +10,65 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  modulate('bind-annotations', ['bind'], function(Bind) {
+  /*
+   * Parses the annotations list created by `annotations` features to perform
+   * declarative desugaring.
+   *
+   * Two tasks are supported:
+   *
+   * - nodes with 'id' are described in a virtual annotation list at
+   *   registration time. This list is then concretized per instance.
+   *
+   * - Simple mustache expressions consisting of a single property name
+   *   in a `textContent` context are bound using `bind` features
+   *   `bindMethod`. In this mode, the bound method is constructed at
+   *   registration time, so marshaling is done done via the concretized
+   *   `_nodes` at every access.
+   *
+   *   TODO(sjmiles): ph3ar general confusion between registration and
+   *   instance time tasks. Is there a cleaner way to disambiguate?
+   */
 
-    /*
-     * Parses the annotations list created by `annotations` features to perform
-     * declarative desugaring.
-     *
-     * Two tasks are supported:
-     *
-     * - nodes with 'id' are described in a virtual annotation list at
-     *   registration time. This list is then concretized per instance.
-     *
-     * - Simple mustache expressions consisting of a single property name
-     *   in a `textContent` context are bound using `bind` features
-     *   `bindMethod`. In this mode, the bound method is constructed at
-     *   registration time, so marshaling is done done via the concretized
-     *   `_nodes` at every access.
-     *
-     *   TODO(sjmiles): ph3ar general confusion between registration and
-     *   instance time tasks. Is there a cleaner way to disambiguate?
-     */
+  Polymer.BindAnnotations = {
 
-    var AnnotationsBind = {
+    // construct binding meta-data 
 
-      // construct binding meta-data 
-
-      addEffects: function(scope, list) {
-        // create a virtual annotation list, must be concretized at instance time
-        scope._nodes = [];
-        // process annotations that have been parsed from template
-        list.forEach(function(annotation) {
-          // where to find the node in the concretized list
-          var index = scope._nodes.push(annotation) - 1;
-          // TODO(sjmiles): we need to support multi-bind, right now you only get
-          // one (not including kind === `id`)
-          annotation.bindings.forEach(function(binding) {
-            AnnotationsBind._bindAnnotationBinding(scope, binding, index);
-          });
+    addEffects: function(scope, list) {
+      // create a virtual annotation list, must be concretized at instance time
+      scope._nodes = [];
+      // process annotations that have been parsed from template
+      list.forEach(function(annotation) {
+        // where to find the node in the concretized list
+        var index = scope._nodes.push(annotation) - 1;
+        // TODO(sjmiles): we need to support multi-bind, right now you only get
+        // one (not including kind === `id`)
+        annotation.bindings.forEach(function(binding) {
+          Polymer.BindAnnotations._bindAnnotationBinding(scope, binding, index);
         });
-      },
+      });
+    },
 
-      // _nodes[index][<binding.name=>]{{binding.value}}
-      _bindAnnotationBinding: function(scope, binding, index) {
-        // capture the node index
-        binding.index = index;
-        // discover top-level property (model) from path
-        var path = binding.value;
-        var i = path.indexOf('.');
-        // [name=]{{model[.subpath]}}
-        var model = (i >= 0) ? path.slice(0, i) : path;
-        // add 'annotation' binding effect for property 'model'
-        Bind.addPropertyEffect(scope, model, 'annotation', binding);
-      },
+    // _nodes[index][<binding.name=>]{{binding.value}}
+    _bindAnnotationBinding: function(scope, binding, index) {
+      // capture the node index
+      binding.index = index;
+      // discover top-level property (model) from path
+      var path = binding.value;
+      var i = path.indexOf('.');
+      // [name=]{{model[.subpath]}}
+      var model = (i >= 0) ? path.slice(0, i) : path;
+      // add 'annotation' binding effect for property 'model'
+      Polymer.Bind.addPropertyEffect(scope, model, 'annotation', binding);
+    },
 
-      // concretize `_nodes` map (annotation based)
+    // concretize `_nodes` map (annotation based)
 
-      marshalAnnotatedNodes: function(nodes, root, finder) {
-        return nodes.map(function(a) {
-          return finder(root, a);
-        });
-      }
+    marshalAnnotatedNodes: function(nodes, root, finder) {
+      return nodes.map(function(a) {
+        return finder(root, a);
+      });
+    }
 
-    };
-
-    return AnnotationsBind;
-
-  });
+  };
 
 </script>

--- a/src/lib/bind/bind-effects.html
+++ b/src/lib/bind/bind-effects.html
@@ -9,179 +9,179 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  using(['Annotations', 'bind'], function(Annotations, Bind) {
-
-    Bind.addComputedPropertyEffect = function(model, name, expression) {
-      var index = expression.indexOf('(');
-      var method = expression.slice(0, index);
-      var args = expression.slice(index + 1, -1).replace(/ /g, '').split(',');
-      //console.log('%c on [%s] compute [%s] via [%s]', 'color: green', args[0], name, method);
-      var methodArgs = 'this._data.' + args.join(', this._data.');
-      var methodString = 'this.debounce(\'_' + expression + '\', function() {\n' +
-        '\t\tthis.' + name + ' = this.' + method + '(' + methodArgs + ');\n' +
-        '\t});';
-      var effect = {
-        property: name,
-        args: args,
-        methodName: method,
-        methodString: methodString
-      };
-      for (var i=0; i<args.length; i++) {
-        this.addPropertyEffect(model, args[i], 'compute', effect);
-      }
+  Polymer.Bind.addComputedPropertyEffect = function(model, name, expression) {
+    var index = expression.indexOf('(');
+    var method = expression.slice(0, index);
+    var args = expression.slice(index + 1, -1).replace(/ /g, '').split(',');
+    //console.log('%c on [%s] compute [%s] via [%s]', 'color: green', args[0], name, method);
+    var methodArgs = 'this._data.' + args.join(', this._data.');
+    var methodString = 'this.debounce(\'_' + expression + '\', function() {\n' +
+      '\t\tthis.' + name + ' = this.' + method + '(' + methodArgs + ');\n' +
+      '\t});';
+    var effect = {
+      property: name,
+      args: args,
+      methodName: method,
+      methodString: methodString
     };
+    for (var i=0; i<args.length; i++) {
+      this.addPropertyEffect(model, args[i], 'compute', effect);
+    }
+  };
 
-    // TODO(sjmiles): case shenanigans
-    // TODO(sjmiles): ad hoc?
-    Bind.mapCase = function(name) {
-      var mapd = Bind._caseMap[name];
-      if (!mapd) {
-        mapd = Bind._caseMap[name] = Annotations.camelToDashCase(name);
-      }
-      return mapd;
-    };
-    // case mapping memoizations
-    Bind._caseMap = {
-    };
-
-    // TODO(sjmiles): the effect system could be data-driven, but it evolved
-    // as code-generation because (1) we emulated hand-written application
-    // sources and (2) performance.
-    //
-    // Data-driven (machine) systems have advantages (avoiding `eval` for one)
-    // that make them generally attractive, if we can obtain performance 
-    // parity. Note that we might construct such a system even if it's 
-    // performance is degraded to satisfy CSP requirements.
-    //
-    // When using code generation, it's hard to know where how deeply to unroll
-    // vs. creating and calling a utility method. _notifyChange is an example 
-    // of a utility method invoked from generated code. This method occupies 
-    // the border between code-generation and machine techniques.   
-
-    Bind._notifyChange = function(property) {
-      // TODO(sjmiles): case shenanigans
-      var eventName = Bind.mapCase(property)+ '-changed';
-      this.fire(eventName, {
-        value: this[property]
-      }, null, false);
-    };
-
-    Bind._shouldAddListener = function(info) {
-      return info.name && 
-             info.mode === '{' && 
-             !info.negate && 
-             info.kind != 'attribute';
-    };
-
-    Bind.addBuilders({
-
-      observer: function(model, source, effect) {
-        // TODO(sjmiles): validation system requires a blessed
-        // validator effect which needs to be processed first.
-        /*
-        if (typeof this[effect] === 'function') {
-          return [
-            'var validated = this.' + effect + '(value, old)',
-            'if (validated !== undefined) {',
-            '  // recurse',
-            '  this[property] = validated;',
-            '  return;',
-            '}'
-          ].join('\n');
-        }
-        */
-        //
-        return effect.methodString;
-      },
+  // TODO(sjmiles): case shenanigans
+  // TODO(sjmiles): ad hoc?
+  // TODO(sjmiles): other places where Annotations.camelToDashCase(name)
+  // is being employed should be using this method instead
+  Polymer.Bind.mapCase = function(name) {
+    var mapped = Polymer.Bind._caseMap[name];
+    if (mapped) {
+      return mapped;
+    }
+    return Polymer.Bind._caseMap[name] = 
+      Polymer.Annotations.camelToDashCase(name);
+  };
   
-      // basic modus operandi
-      //
-      // <hostPath> %=% <targetPathValue>
-      // <model[.path]> %=% node.<property>
-      //
-      // down: model.set(...): node.<property> = <model[.path]>
-      // up:   node.on(<property>-changed): <model[.path]> = e.detail.value
-      //
-      notify: function(model, source) {
-        model._notifyChange = Bind._notifyChange;
-        return 'this._notifyChange(\'' + source + '\')';
-      },
+  // case mapping memoizations
+  Polymer.Bind._caseMap = {
+  };
 
-      compute: function(model, source, effect) {
-        return effect.methodString;
-      },
+  // TODO(sjmiles): the effect system could be data-driven, but it evolved
+  // as code-generation because (1) we emulated hand-written application
+  // sources and (2) performance.
+  //
+  // Data-driven (machine) systems have advantages (avoiding `eval` for one)
+  // that make them generally attractive, if we can obtain performance 
+  // parity. Note that we might construct such a system even if it's 
+  // performance is degraded, to satisfy CSP requirements.
+  //
+  // When using code generation, it's hard to know how deeply to unroll
+  // vs. creating and calling a utility method. _notifyChange is an example 
+  // of a utility method invoked from generated code. This method occupies 
+  // the border between code-generation and machine techniques.   
 
-      reflect: function(model, source) {
-        return 'this.reflectPropertyToAttribute(\'' +  source + '\');';
-      },
+  Polymer.Bind._notifyChange = function(property) {
+    // TODO(sjmiles): case shenanigans
+    var eventName = Polymer.Bind.mapCase(property) + '-changed';
+    this.fire(eventName, {
+      value: this[property]
+    }, null, false);
+  };
 
-      // implement effect directives from template annotations
-      // _nodes[info.index][info.name] = {{info.value}}
-      annotation: function(model, hostProperty, info) {
-        var property = info.name;
-        if (Bind._shouldAddListener(info)) {
-          // TODO(sjmiles): case shenanigans
-          var dashCaseProperty = Annotations.camelToDashCase(property);
-          // <node>.on.<dash-case-property>-changed: <path> = e.detail.value
-          Bind._addAnnotatedListener(model, info.index, 
-            dashCaseProperty, info.value);
-        }
-        //
-        if (!property) {
-          property = 'textContent';
-        }
-        if (property === 'style') {
-          property = 'style.cssText';
-        }
-        //
-        // flow-down
-        //
-        // construct the effect to occur when [property] changes:
-        // set nodes[index][name] to this[value]
-        //
-        //console.log('[_annotationEffectBuilder]: [%s] %=% [%s].[%s]', info.value, info.index, property);
-        var parts = info.value.split('.');
-        var value, setData;
-        if (parts.length <= 1) {
-          setData = '';
-          value = 'this._data.' + info.value;
-        } else {
-          // Null check intermediate paths
-          var last = parts.pop();
-          var curr = 'this._data';
-          parts = parts.map(function(s) { 
-            return curr += ('.' + s); 
-          });
-          value = parts.join('!=null && ') 
-            + '!=null ? ' 
-            + curr + '.' + last 
-            + ' : undefined'
-            ;
-          // TODO(kschaaf): Update private storage for this path, for dirty-checking 
-          // path notifications on their way up; could have been made separate PropertyEffect,
-          // but is coupled to (required for) path listeners to function, which is already
-          // bound to the annotation propertyEffect, so ROI is low
-          setData = 
-            'var val = ' + value + ';\n' + 
-            'this._data[\'' + info.value + '\'] = val;\n'
-            ;
-          value = 'val';
-        }
-        // TODO(sjmiles): being able to express logic (negate) as actual JS is 
-        // convenient when code-generating. Remember to always process a custom
-        // token stream (e.g. '!' below) instead of passing template code 
-        // directly to eval.
-        value = (info.negate ? '!' : '') + value;
-        var node = 'this._nodes[' + info.index + ']';
-        if (info.kind == 'attribute') {
-          return setData + 'this.serializeValueToAttribute(' + value + ',' + 
-            '\'' + property + '\',' + node + ');';
-        } else {
-          return setData + node + '.' + property + ' = ' + value + ';';          
-        }
+  Polymer.Bind._shouldAddListener = function(info) {
+    return info.name && 
+           info.mode === '{' && 
+           !info.negate && 
+           info.kind != 'attribute';
+  };
+
+  Polymer.Bind.addBuilders({
+
+    observer: function(model, source, effect) {
+      // TODO(sjmiles): validation system requires a blessed
+      // validator effect which needs to be processed first.
+      /*
+      if (typeof this[effect] === 'function') {
+        return [
+          'var validated = this.' + effect + '(value, old)',
+          'if (validated !== undefined) {',
+          '  // recurse',
+          '  this[property] = validated;',
+          '  return;',
+          '}'
+        ].join('\n');
       }
+      */
+      //
+      return effect.methodString;
+    },
 
-    });
+    // basic modus operandi
+    //
+    // <hostPath> %=% <targetPathValue>
+    // <model[.path]> %=% node.<property>
+    //
+    // down: model.set(...): node.<property> = <model[.path]>
+    // up:   node.on(<property>-changed): <model[.path]> = e.detail.value
+    //
+    notify: function(model, source) {
+      model._notifyChange = Polymer.Bind._notifyChange;
+      return 'this._notifyChange(\'' + source + '\')';
+    },
+
+    compute: function(model, source, effect) {
+      return effect.methodString;
+    },
+
+    reflect: function(model, source) {
+      return 'this.reflectPropertyToAttribute(\'' +  source + '\');';
+    },
+
+    // implement effect directives from template annotations
+    // _nodes[info.index][info.name] = {{info.value}}
+    annotation: function(model, hostProperty, info) {
+      var property = info.name;
+      if (Polymer.Bind._shouldAddListener(info)) {
+        // TODO(sjmiles): case shenanigans
+        var dashCaseProperty = Polymer.Bind.mapCase(property);
+        // <node>.on.<dash-case-property>-changed: <path> = e.detail.value
+        Polymer.Bind._addAnnotatedListener(model, info.index, 
+          dashCaseProperty, info.value);
+      }
+      //
+      if (!property) {
+        property = 'textContent';
+      }
+      if (property === 'style') {
+        property = 'style.cssText';
+      }
+      //
+      // flow-down
+      //
+      // construct the effect to occur when [property] changes:
+      // set nodes[index][name] to this[value]
+      //
+      //console.log('[_annotationEffectBuilder]: [%s] %=% [%s].[%s]', info.value, info.index, property);
+      var parts = info.value.split('.');
+      var value, setData;
+      if (parts.length <= 1) {
+        setData = '';
+        value = 'this._data.' + info.value;
+      } else {
+        // Null check intermediate paths
+        var last = parts.pop();
+        var curr = 'this._data';
+        parts = parts.map(function(s) { 
+          return curr += ('.' + s); 
+        });
+        value = parts.join('!=null && ') 
+          + '!=null ? ' 
+          + curr + '.' + last 
+          + ' : undefined'
+          ;
+        // TODO(kschaaf): Update private storage for this path, for dirty-checking 
+        // path notifications on their way up; could have been made separate PropertyEffect,
+        // but is coupled to (required for) path listeners to function, which is already
+        // bound to the annotation propertyEffect, so ROI is low
+        setData = 
+          'var val = ' + value + ';\n' + 
+          'this._data[\'' + info.value + '\'] = val;\n'
+          ;
+        value = 'val';
+      }
+      // TODO(sjmiles): being able to express logic (negate) as actual JS is 
+      // convenient when code-generating. Remember to always process a custom
+      // token stream (e.g. '!' below) instead of passing template code 
+      // directly to eval.
+      value = (info.negate ? '!' : '') + value;
+      var node = 'this._nodes[' + info.index + ']';
+      if (info.kind == 'attribute') {
+        return setData + 'this.serializeValueToAttribute(' + value + ',' + 
+          '\'' + property + '\',' + node + ');';
+      } else {
+        return setData + node + '.' + property + ' = ' + value + ';';          
+      }
+    }
 
   });
 

--- a/src/lib/bind/bind.html
+++ b/src/lib/bind/bind.html
@@ -9,217 +9,216 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  modulate('bind', function() {
+  Polymer.Bind = {
 
-    var Bind = {
+    // for prototypes (usually)
 
-      // for prototypes (usually)
+    prepareModel: function(model) {
+      model._propertyEffects = {};
+      model._bindListeners = [];
+      model._setData = this._setData;
+      model._clearPath = this._clearPath;
+    },
 
-      prepareModel: function(model) {
-        model._propertyEffects = {};
-        model._bindListeners = [];
-        model._setData = this._setData;
-        model._clearPath = this._clearPath;
-      },
+    _addAnnotatedListener: function(model, index, property, path) {
+      // <node>.on.<property>-changed: <path> = e.detail.value
+      //
+      var changedFn = 'this.' + path + ' = e.detail.value;';
+      if (path.indexOf('.') > 0) {
+        // TODO(kschaaf): dirty check avoids null references when the object has gone away
+        changedFn = 
+          'if (this._data[\'' + path + '\'] != e.detail.value) {\n' +
+          '\t' + changedFn + '\n' +
+          '\tthis.notifyPath(\'' + path + '\', e.detail.value)\n' +
+          '}';
+      }
+      //
+      model._bindListeners.push({
+        index: index,
+        property: property,
+        path: path,
+        changedFn: new Function('e', changedFn)
+      });
+    },
 
-      _addAnnotatedListener: function(model, index, property, path) {
-        // <node>.on.<property>-changed: <path> = e.detail.value
-        //
-        var changedFn = 'this.' + path + ' = e.detail.value;';
-        if (path.indexOf('.') > 0) {
-          // TODO(kschaaf): dirty check avoids null references when the object has gone away
-          changedFn = 
-            'if (this._data[\'' + path + '\'] != e.detail.value) {\n' +
-            '\t' + changedFn + '\n' +
-            '\tthis.notifyPath(\'' + path + '\', e.detail.value)\n' +
-            '}';
-        }
-        //
-        model._bindListeners.push({
-          index: index,
-          property: property,
-          path: path,
-          changedFn: new Function('e', changedFn)
-        });
-      },
+   // the Bind module supports pluggable effect builders
 
-     // the Bind module supports pluggable effect builders
+    _builders: {},
+    
+    addBuilder: function(kind, builder) {
+      this._builders[kind] = builder;
+    },
 
-      _builders: {},
-      
-      addBuilder: function(kind, builder) {
-        this._builders[kind] = builder;
-      },
+    addBuilders: function(builders) {
+      for (var n in builders) {
+        this._builders[n] = builders[n];
+      }
+    },
 
-      addBuilders: function(builders) {
-        for (var n in builders) {
-          this._builders[n] = builders[n];
-        }
-      },
+    // a prepared model can acquire effects
 
-      // a prepared model can acquire effects
+    addPropertyEffect: function(model, property, kind, effect) {
+      var fx = model._propertyEffects[property];
+      if (!fx) {
+        fx = model._propertyEffects[property] = [];
+      }
+      fx.push({
+        kind: kind,
+        effect: effect
+      });
+    },
 
-      addPropertyEffect: function(model, property, kind, effect) {
-        var fx = model._propertyEffects[property];
-        if (!fx) {
-          fx = model._propertyEffects[property] = [];
-        }
-        fx.push({
-          kind: kind,
-          effect: effect
-        });
-      },
-
-      createBindings: function(model) {
-        var fx$ = model._propertyEffects;
-        if (fx$) {
-          //console.group(this.name);
-          for (var n in fx$) {
-            //console.group(n);
-            var fx = fx$[n];
-            fx.sort(this._sortPropertyEffects);
-            //console.log(fx);
-            //
-            var compiledEffects = fx.map(function(x) {
-              return this._buildEffect(model, n, x);
-            }, this);
-            //
-            this._bindPropertyEffects(model, n, compiledEffects);
-            //console.log(fxt.join('\n'));
-            //console.groupEnd();
-          }
+    createBindings: function(model) {
+      var fx$ = model._propertyEffects;
+      if (fx$) {
+        //console.group(this.name);
+        for (var n in fx$) {
+          //console.group(n);
+          var fx = fx$[n];
+          fx.sort(this._sortPropertyEffects);
+          //console.log(fx);
+          //
+          var compiledEffects = fx.map(function(x) {
+            return this._buildEffect(model, n, x);
+          }, this);
+          //
+          this._bindPropertyEffects(model, n, compiledEffects);
+          //console.log(fxt.join('\n'));
           //console.groupEnd();
         }
-      },
+        //console.groupEnd();
+      }
+    },
 
-      _sortPropertyEffects: function(a, b) {
-        return PROPERTY_EFFECT_ORDER[a.kind] - PROPERTY_EFFECT_ORDER[b.kind];
-      },
+    _sortPropertyEffects: (function() {
+      // TODO(sjmiles): EFFECT_ORDER buried this way is not ideal,
+      // but presumably the sort method is going to be a hot path and not
+      // have a `this`. There is also a problematic dependency on effect.kind
+      // values here, which are otherwise pluggable. 
+      var EFFECT_ORDER = {
+        'compute': 0,
+        'annotation': 1,
+        'reflect': 2,
+        'notify': 3,
+        'observer': 4
+      };
+      return function(a, b) {
+        return EFFECT_ORDER[a.kind] - EFFECT_ORDER[b.kind];
+      };
+    })(),
 
-      _buildEffect: function(model, property, fx) {
-        var b = this._builders[fx.kind];
-        if (b) {
-          return b(model, property, fx.effect);
-        } else {
-          throw('bind._buildEffect: missing builder kind [' + fx.kind + ']');
+    _buildEffect: function(model, property, fx) {
+      var b = this._builders[fx.kind];
+      if (b) {
+        return b(model, property, fx.effect);
+      } else {
+        throw('bind._buildEffect: missing builder kind [' + fx.kind + ']');
+      }
+    },
+
+    // create accessors that implement effects
+    _bindPropertyEffects: function(model, property, effects) {
+      var defun = {
+        get: function() {
+          return this._data[property];
         }
-      },
-
-      // create accessors that implement effects
-      _bindPropertyEffects: function(model, property, effects) {
-        var defun = {
-          get: function() {
-            return this._data[property];
-          }
-        };
-        if (effects.length) {
-          // combine effects
-          // var group = '\'' + this.is + ':' + property + '\'';
-          // effects.unshift('console.group(' + group + ');');
-          // effects.push('console.groupEnd(' + group + ');');
-          effects = '\t' + effects.join('\n\t');
-          // construct effector
-          var effector = '_' + property + 'Effector';
-          model[effector] = new Function('old', effects);
-          // construct setter body
-          var body  = [ 
-            'var old = this._setData(\'' + property + '\', value);',
-            'if (value !== old) {',
-            '  this.' + effector + '(old);',
-            '}'
-          ].join('\n');
-          var setter = new Function('value', body);
-          // ReadOnly properties have a private setter only
-          // TODO(kschaaf): Per current Bind factoring, we shouldn't
-          // be interrogating the prototype here
-          if (model.isReadOnlyProperty && model.isReadOnlyProperty(property)) {
-            model['_set' + this.upper(property)] = setter;
-          }
-          // other properties have a proper setter
-          else {
-            defun.set = setter;
-          }
+      };
+      if (effects.length) {
+        // combine effects
+        // var group = '\'' + this.is + ':' + property + '\'';
+        // effects.unshift('console.group(' + group + ');');
+        // effects.push('console.groupEnd(' + group + ');');
+        effects = '\t' + effects.join('\n\t');
+        // construct effector
+        var effector = '_' + property + 'Effector';
+        model[effector] = new Function('old', effects);
+        // construct setter body
+        var body  = [ 
+          'var old = this._setData(\'' + property + '\', value);',
+          'if (value !== old) {',
+          '  this.' + effector + '(old);',
+          '}'
+        ].join('\n');
+        var setter = new Function('value', body);
+        // ReadOnly properties have a private setter only
+        // TODO(kschaaf): Per current Bind factoring, we shouldn't
+        // be interrogating the prototype here
+        if (model.isReadOnlyProperty && model.isReadOnlyProperty(property)) {
+          model['_set' + this.upper(property)] = setter;
         }
-        Object.defineProperty(model, property, defun);
-        //console.log(prop.set ? prop.set.toString() : '(read-only)');
-      },
-
-      upper: function(name) {
-        return name[0].toUpperCase() + name.substring(1);
-      },
-
-      // for instances
-
-      prepareInstance: function(inst) {
-        inst._data = Object.create(null);
-      },
-
-      setupBindListeners: function(inst) {
-        inst._bindListeners.forEach(function(info) {
-          // Property listeners:
-          // <node>.on.<property>-changed: <path]> = e.detail.value
-          //console.log('[_setupBindListener]: [%s][%s] listening for [%s][%s-changed]', this.localName, info.path, info.id || info.index, info.property);
-          var node = inst._nodes[info.index];
-          node.addEventListener(info.property + '-changed', inst._notifyListener.bind(inst, info.changedFn));
-          // Path listeners:
-          var type = node.getPropertyType && node.getPropertyType(info.property);
-          if (type == Object || type == Array) {
-            node.addEventListener(info.property + '-path-changed', inst._notifyListener.bind(inst, function(e) {
-              // re-jigger path
-              // binding.path == item
-              // binding.property == zizz
-              // if no e.detail.path, path === binding.path
-              // else replace binding.name with binding.path in e.detail.path
-              var path = this._fixPath(info.path, info.property, e.detail.path);
-              this.notifyPath(path, e.detail.value);
-            }));
-          }
-        });
-      },
-
-      // NOTE: exists as a hook for processing listeners 
-      _notifyListener: function(fn, e) {
-        return fn.call(this, e);
-      },
-
-      // TODO(sjmiles): ad-hoc
-      _telemetry: {
-        _setDataCalls: 0
-      },
-
-      _setData: function(property, value) {
-        // TODO(sjmiles): ad-hoc
-        //Base._telemetry._setDataCalls++;
-        var old = this._data[property];
-        if (old !== value) {
-          this._data[property] = value;
-          if (typeof value == 'object') {
-            this._clearPath(property);
-          }
-        }
-        return old;
-      },
-
-      _clearPath: function(path) {
-        for (var prop in this._data) {
-          if (prop.indexOf(path + '.') === 0) {
-            this._data[prop] = undefined;
-          }
+        // other properties have a proper setter
+        else {
+          defun.set = setter;
         }
       }
+      Object.defineProperty(model, property, defun);
+      //console.log(prop.set ? prop.set.toString() : '(read-only)');
+    },
 
-    };
+    upper: function(name) {
+      return name[0].toUpperCase() + name.substring(1);
+    },
 
-    var PROPERTY_EFFECT_ORDER = {
-      'compute': 0,
-      'annotation': 1,
-      'reflect': 2,
-      'notify': 3,
-      'observer': 4
-    };
+    // for instances
 
-    return Bind;
+    prepareInstance: function(inst) {
+      inst._data = Object.create(null);
+    },
 
-  });
+    setupBindListeners: function(inst) {
+      inst._bindListeners.forEach(function(info) {
+        // Property listeners:
+        // <node>.on.<property>-changed: <path]> = e.detail.value
+        //console.log('[_setupBindListener]: [%s][%s] listening for [%s][%s-changed]', this.localName, info.path, info.id || info.index, info.property);
+        var node = inst._nodes[info.index];
+        node.addEventListener(info.property + '-changed', inst._notifyListener.bind(inst, info.changedFn));
+        // Path listeners:
+        var type = node.getPropertyType && node.getPropertyType(info.property);
+        if (type == Object || type == Array) {
+          node.addEventListener(info.property + '-path-changed', inst._notifyListener.bind(inst, function(e) {
+            // re-jigger path
+            // binding.path == item
+            // binding.property == zizz
+            // if no e.detail.path, path === binding.path
+            // else replace binding.name with binding.path in e.detail.path
+            var path = this._fixPath(info.path, info.property, e.detail.path);
+            this.notifyPath(path, e.detail.value);
+          }));
+        }
+      });
+    },
+
+    // NOTE: exists as a hook for processing listeners 
+    _notifyListener: function(fn, e) {
+      return fn.call(this, e);
+    },
+
+    // TODO(sjmiles): ad-hoc
+    _telemetry: {
+      _setDataCalls: 0
+    },
+
+    _setData: function(property, value) {
+      // TODO(sjmiles): ad-hoc
+      //Base._telemetry._setDataCalls++;
+      var old = this._data[property];
+      if (old !== value) {
+        this._data[property] = value;
+        if (typeof value == 'object') {
+          this._clearPath(property);
+        }
+      }
+      return old;
+    },
+
+    _clearPath: function(path) {
+      for (var prop in this._data) {
+        if (prop.indexOf(path + '.') === 0) {
+          this._data[prop] = undefined;
+        }
+      }
+    }
+
+  };
 
 </script>

--- a/src/lib/collection.html
+++ b/src/lib/collection.html
@@ -13,12 +13,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, ArrayObserve, Debounce) {
+  Polymer._collections = new WeakMap();
 
-  var collections = new WeakMap();
-
-  function Collection(userArray, noObserve) {
-    collections.set(userArray, this);
+  Polymer.Collection = function(userArray, noObserve) {
+    Polymer._collections.set(userArray, this);
     this.userArray = userArray;
     this.store = userArray.slice();
     this.callbacks = [];
@@ -26,17 +24,14 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
     this.map = null;
     this.added = [];
     this.removed = [];
-
     if (!noObserve) {
-      ArrayObserve.observe(userArray, this.applySplices.bind(this));
+      Polymer.ArrayObserve.observe(userArray, this.applySplices.bind(this));
       this.initMap();
     }
   }
 
-  Collection.prototype = Object.create(null);
-  Collection.prototype.constructor = Collection;
-
-  Base.extend(Collection.prototype, {
+  Polymer.Collection.prototype = {
+    constructor: Polymer.Collection,
 
     initMap: function() {
       var map = this.map = new WeakMap();
@@ -57,7 +52,7 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
       }
       if (!squelch) {
         this.added.push(key);
-        this.debounce = Debounce(this.debounce, this.notify.bind(this));
+        this.debounce = Polymer.Debounce(this.debounce, this.notify.bind(this));
       }
       return key;
     },
@@ -68,7 +63,7 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
       }
       delete this.store[key];
       this.removed.push(key);
-      this.debounce = Debounce(this.debounce, this.notify.bind(this));
+      this.debounce = Polymer.Debounce(this.debounce, this.notify.bind(this));
     },
 
     remove: function(item, squelch) {
@@ -79,7 +74,7 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
       delete this.store[key];
       if (!squelch) {
         this.removed.push(key);
-        this.debounce = Debounce(this.debounce, this.notify.bind(this));
+        this.debounce = Polymer.Debounce(this.debounce, this.notify.bind(this));
       }
       return key;
     },
@@ -159,16 +154,11 @@ modulate('Collection', ['Base', 'ArrayObserve', 'Debounce'], function(Base, Arra
       this.notify(keySplices);
     }
 
-  });
-
-  function getCollection(userArray, noObserve) {
-    return collections.get(userArray) || new Collection(userArray, noObserve);
-  }
-
-  return {
-    get: getCollection
   };
-  
-});
+
+  Polymer.Collection.get = function(userArray, noObserve) {
+    return Polymer._collections.get(userArray) 
+      || new Collection(userArray, noObserve);
+  };
 
 </script>

--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -4,7 +4,7 @@
   Extremely simple css parser. Intended to be not more than what we need
   and definitely not necessarly correct =).
 */
-modulate('CssParse', function() {
+(function() {
 
   // given a string of css, return a simple rule tree
   function parse(text) {
@@ -121,11 +121,11 @@ modulate('CssParse', function() {
   };
 
   // exports 
-  return {
+  Polymer.CssParse = {
     parse: parse,
     stringify: stringify
   };
 
-});
+})();
 
 </script>

--- a/src/lib/debounce.html
+++ b/src/lib/debounce.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-modulate('Debounce', 'Async', function(Async) {
+Polymer.Debounce = (function() {
   
   // usage
   
@@ -20,6 +20,8 @@ modulate('Debounce', 'Async', function(Async) {
   //
   // returns a handle which can be used to re-register a job
 
+  var Async = Polymer.Async;
+  
   var Debouncer = function(context) {
     this.context = context;
     this.boundComplete = this.complete.bind(this);
@@ -62,6 +64,6 @@ modulate('Debounce', 'Async', function(Async) {
 
   return debounce;
   
-});
+})();
 
 </script>

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -10,7 +10,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="settings.html">
 <script>
 
-  modulate('DomApi', ['Debounce', 'Settings'], function(Debounce, settings) {
+  Polymer.DomApi = (function() {
+
+    var Debounce = Polymer.Debounce;
+    var Settings = Polymer.Settings;
 
     var DomApi = function() {
       this._dirty = [];
@@ -307,7 +310,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             
     }; 
 
-    if (settings.useShadow) {
+    if (Settings.useShadow) {
 
       DomApi.prototype.querySelectorAll = function(selector, node) {
         node = node || document;
@@ -354,6 +357,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       matchesSelector: matchesSelector
     };
 
-  });
+  })();
 
 </script>

--- a/src/lib/polymer.html
+++ b/src/lib/polymer.html
@@ -1,0 +1,68 @@
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>
+
+  // until ES6 modules become standard, we follow Occam and simply stake out 
+  // a global namespace
+
+  // Polymer is a Function, but of course this is also an Object, so we 
+  // hang various other objects off of Polymer.*
+
+  window.Polymer = function(prototype) {
+    var ctor = desugar(prototype);
+    // native Custom Elements treats 'undefined' extends property
+    // as valued, the property must not exist to be ignored
+    var options = {
+      prototype: prototype
+    };
+    if (prototype.extends) {
+      options.extends = prototype.extends;
+    }
+    Polymer.telemetry._registrate(prototype);
+    document.registerElement(prototype.is, options);
+    return ctor;
+  };
+
+  var desugar = function(prototype) {
+    prototype.__proto__ = Polymer.Base;
+    prototype.registerCallback();
+    return prototype.constructor;
+  };
+
+  window.Polymer = Polymer;
+  Polymer.Class = desugar;
+
+  /*
+  // Raw usage
+  [ctor =] Polymer.Class(prototype);
+  document.registerElement(name, ctor);
+  
+  // Simplified usage
+  [ctor = ] Polymer(prototype);
+  */
+
+  // telemetry: statistics, logging, and debug
+
+  Polymer.telemetry = {
+    registrations: [],
+    _regLog: function(prototype) {
+      console.log('[' + prototype.is + ']: registered')
+    },
+    _registrate: function(prototype) {
+      this.registrations.push(prototype);
+      Polymer.log && this._regLog(prototype);
+    },
+    dumpRegistrations: function() {
+      this.registrations.forEach(this._regLog);
+    }
+  };
+
+</script>
+

--- a/src/lib/resolve-url.html
+++ b/src/lib/resolve-url.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script>
 
-  modulate('ResolveUrl', function() {
+  (function() {
 
     // path fixup for urls in cssText that's expected to 
     // come from a given ownerDocument
@@ -59,10 +59,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var BINDING_RX = /\{\{|\[\[/;
 
     // exports
-    return {
+    Polymer.ResolveUrl = {
       resolveCss: resolveCss,
       resolveAttrs: resolveAttrs
     };
 
-  });
+  })();
+
 </script>

--- a/src/lib/settings.html
+++ b/src/lib/settings.html
@@ -8,7 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-  modulate('Settings', function() {
+
+  Polymer.Settings = (function() {
     // NOTE: Users must currently opt into using ShadowDOM. They do so by doing:
     // Polymer = {dom: 'shadow'};
     // TODO(sorvell): Decide if this should be auto-use when available.
@@ -40,5 +41,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       useNativeShadow: useShadow && nativeShadow,
       useNativeImports: useNativeImports
     };
-  });
+  })();
+
 </script>

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -7,10 +7,12 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
 <link rel="import" href="style-util.html">
+
 <script>
 
-  modulate('StyleTransformer', ['StyleUtil'], function(styleUtil) {
+  (function() {
 
     /* Transforms ShadowDOM styling into ShadyDOM styling
 
@@ -63,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // a class created from the scope. ShadowDOM selectors are also transformed
     // (e.g. :host) to use the scoping selector.
     function transformCss(rules, scope, callback) {
-      return styleUtil.toCssText(rules, function(rule) {
+      return Polymer.StyleUtil.toCssText(rules, function(rule) {
         transformRule(rule, scope);
         if (callback) {
           callback(rule, scope);
@@ -147,7 +149,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var SCOPING_CLASS = /(?:^|\s)([\S]*?-x)(?:$|\s)/;
 
     // exports
-    return {
+    Polymer.StyleTransformer = {
       element: transformElement,
       dom: transformDom,
       host: transformHost,
@@ -155,5 +157,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       SCOPE_SUFFIX: SCOPE_SUFFIX
     };
 
-  });
+  })();
+
 </script>

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -7,19 +7,21 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+
 <link rel="import" href="css-parse.html">
+
 <script>
 
-  modulate('StyleUtil', ['CssParse'], function(parser) {
+  (function() {
 
     function toCssText(rules, callback) {
       if (typeof rules === 'string') {
-        rules = parser.parse(rules);
+        rules = Polymer.CssParse.parse(rules);
       } 
       if (callback) {
         forEachStyleRule(rules, callback);
       }
-      return parser.stringify(rules);
+      return Polymer.CssParse.stringify(rules);
     }
 
     function forEachStyleRule(node, cb) {
@@ -60,12 +62,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var MIXIN_SELECTOR = '--';
 
     // exports
-    return {
-      parser: parser,
+    Polymer.StyleUtil = {
+      parser: Polymer.CssParse,
       applyCss: applyCss,
       forEachStyleRule: forEachStyleRule,
       toCssText: toCssText
     };
 
-  });
+  })();
+
 </script>

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -10,9 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-modulate('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
-
-  Templatizer = {
+  Polymer.Templatizer = {
 
     templatize: function(template) {
       // TODO(sjmiles): supply _alternate_ content reference missing from root
@@ -29,7 +27,7 @@ modulate('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
       }
       // `archetype` is the prototype of the anonymous
       // class created by the templatizer 
-      var archetype = Object.create(Base);
+      var archetype = Object.create(Polymer.Base);
       // normally Annotations.parseAnnotations(template) but
       // archetypes do special caching
       this.customPrepAnnotations(archetype, template);
@@ -67,12 +65,13 @@ modulate('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
         var c = template._content;
         if (c) {
           if (this.host) {
-            Annotations.prepElement = this.host._prepElement.bind(this.host);
+            Polymer.Annotations.prepElement = 
+              this.host._prepElement.bind(this.host);
           }
           archetype._annotes = c._annotes ||
-            Annotations.parseAnnotations(template);
+            Polymer.Annotations.parseAnnotations(template);
           c._annotes = archetype._annotes;
-          Annotations.prepElement = null;
+          Polymer.Annotations.prepElement = null;
         } 
         else {
           console.warn('no _content');
@@ -114,9 +113,5 @@ modulate('Templatizer', ['Base', 'Annotations'], function(Base, Annotations) {
     }
 
   };
-
-  return Templatizer;
-
-});
 
 </script>

--- a/src/lib/template/x-repeat.html
+++ b/src/lib/template/x-repeat.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       mixins: [
-        'Templatizer'
+        Polymer.Templatizer
       ],
 
       observers: {

--- a/src/lib/template/x-template.html
+++ b/src/lib/template/x-template.html
@@ -27,7 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     extends: 'template',
 
     mixins: [
-      'Templatizer'
+      Polymer.Templatizer
     ],
 
     ready: function() {

--- a/src/polymer.html
+++ b/src/polymer.html
@@ -7,55 +7,8 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link rel="import" href="lib/module.html">
+
+<link rel="import" href="lib/polymer.html">
 <link rel="import" href="lib/settings.html">
 <link rel="import" href="lib/lang.html">
 <link rel="import" href="lib/base.html">
-
-<script>
-
-  modulate('Polymer', ['Base'], function(Base) {
-
-    // make Base suffix HTMLELement, other types need Base-clones
-    Base.__proto__ = HTMLElement.prototype;
-
-    var Polymer = function(prototype) {
-      // TODO(sjmiles): `elementClass` used to be `ctor`, but it seems like
-      // this symbol can show up in the debugger as the type of the object 
-      var elementClass = desugar(prototype);
-      // native Custom Elements treats 'undefined' extends property
-      // as valued, the property must not exist to be ignored
-      var options = {
-        prototype: prototype
-      };
-      if (prototype.extends) {
-        options.extends = prototype.extends;
-      }
-      // console.log('[' + prototype.is + ']: registered');
-      document.registerElement(prototype.is, options);
-      return elementClass;
-    };
-
-    var desugar = function(prototype) {
-      prototype.__proto__ = Base;
-      prototype.registerCallback();
-      return prototype.constructor;
-    };
-
-    window.Polymer = Polymer;
-    Polymer.Class = desugar;
-    
-    return Polymer;
-
-  });
-
-  /*
-  // Raw usage
-  [ctor =] Polymer.Class(prototype);
-  document.registerElement(name, ctor);
-
-  // Simplified usage
-  [ctor = ] Polymer(prototype);
-  */
-  
-</script>

--- a/test/unit/async.html
+++ b/test/unit/async.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
-  <link rel="import" href="../../src/lib/module.html">
+  <link rel="import" href="../../src/lib/polymer.html">
   <link rel="import" href="../../src/lib/async.html">
 </head>
 <body>
@@ -21,9 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   
   beforeEach(function() {
-    using('Async', function(Async) {
-      window.Async = Async;
-    });
+    window.Async = Polymer.Async;
   });
 
   afterEach(function() {

--- a/test/unit/base.html
+++ b/test/unit/base.html
@@ -10,12 +10,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <html>
 <head>
+
   <meta charset="utf-8">
+
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
-  <link rel="import" href="../../src/lib/module.html">
+
+  <link rel="import" href="../../src/lib/polymer.html">
   <link rel="import" href="../../src/lib/lang.html">
   <link rel="import" href="../../src/lib/base.html">
+  
 </head>
 <body>
 <script>
@@ -24,15 +28,13 @@ var Child;
 var instance;
 
 beforeEach(function() {
-  using('Base', function(Base) {
-    // Ensure a clean environment for each test.
-    window.Base = Base;
-    window.Child = Object.create(Base);
-    Child.registerFeatures = function() {};
-    Child.initFeatures = function() {};
-    Child.setAttributeToProperty = function() {};
-    window.instance = Object.create(Child);
-  });
+  // Ensure a clean environment for each test.
+  window.Base = Polymer.Base;
+  window.Child = Object.create(Base);
+  Child.registerFeatures = function() {};
+  Child.initFeatures = function() {};
+  Child.setAttributeToProperty = function() {};
+  window.instance = Object.create(Child);
 });
 
 suite('addFeature', function() {

--- a/test/unit/css-parse.html
+++ b/test/unit/css-parse.html
@@ -10,13 +10,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <html>
 <head>
+
   <meta charset="utf-8">
+
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
+
   <title>css-parse</title>
+
   <link rel="import" href="../../polymer.html">
+
 </head>
 <body>
+
   <style id="test">
     :host {
       background: red;
@@ -63,9 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('css-parse', function() {
 
     before(function() {
-      using('CssParse', function(c) {
-        css = c;
-      });
+      css = Polymer.CssParse;
       s = document.querySelector('style#test');
       tree = css.parse(s.textContent);
     });
@@ -108,5 +112,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   });
 </script>
+
 </body>
 </html>

--- a/test/unit/micro.html
+++ b/test/unit/micro.html
@@ -10,11 +10,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <html>
 <head>
+
   <meta charset="utf-8">
+
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
+
   <link rel="import" href="../../polymer-micro.html">
   <link rel="import" href="micro-elements.html">
+
 </head>
 <body>
 
@@ -56,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.instanceOf(el, HTMLElement, 'Instance of HTMLInputElement');
     });
 
+    // TODO(sjmiles): add test for user supplied constructor
   });
 
 </script>


### PR DESCRIPTION
Replaces `using` and `modulate` with Polymer.<module name>.

We like modules, but until native modules are supported we would have to rely on some polyfill or other placeholder. Occam says: instead just use Polymer namespace.