### PR TITLE
Fixed polymer.import issue

### DIFF
--- a/src/declaration/queue.js
+++ b/src/declaration/queue.js
@@ -186,6 +186,7 @@
   var importQueue = [];
   var mainQueue = [];
   var readyCallbacks = [];
+  var numberOfErrorImportsProcessed = 0;
 
   function queueForElement(element) {
     return document.contains(element) ? mainQueue : importQueue;
@@ -198,8 +199,14 @@
   function whenReady(callback) {
     queue.waitToReady = true;
     Polymer.endOfMicrotask(function() {
-      HTMLImports.whenReady(function() {
-        queue.addReadyCallback(callback);
+      HTMLImports.whenReady(function(args) {
+	  
+        if(args != undefined && args != null && args.errorImports.constructor === Array) {
+		  args.errorImports.length == numberOfErrorImportsProcessed ? queue.addReadyCallback(callback) : numberOfErrorImportsProcessed++;				
+		}
+		else {
+		  queue.addReadyCallback(callback);
+		}
         queue.waitToReady = false;
         queue.check();
     });


### PR DESCRIPTION
Fix for https://github.com/webcomponents/webcomponentsjs/issues/219 . Arguments passed to the callback (which gets called when HTML import is loaded) by webcomponents.js were not handled in polymer.js. Modified the code to accept the arguments and check errorImports to see if there is any import which encountered an error while loading. Following considerations are made in the fix:
1. If Polymer.import(['path/to/webcomponent'], callback) encounters an error then callback is not called. 
2. Example: If there are 3 imports, import1, import2 and import3 and only import2 encounters an error. The callback of import3 will be called. HTML import loading won't stop if Polymer encounters an error during loading of an import.