### PR TITLE
Separate attributes function from annotations

### DIFF
--- a/src/features/micro/attributes.html
+++ b/src/features/micro/attributes.html
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../lib/annotations/annotations.html">
+<link rel="import" href="../../lib/attributes.html"> 
 
 <script>
 
@@ -80,7 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _takeAttributesToModel: function(model) {
       for (var propName in this.properties) {
-        var attrName = Polymer.Annotations.camelToDashCase(propName);
+        var attrName = Polymer.Attributes.camelToDashCase(propName);
         if (this.hasAttribute(attrName)) {
           var val = this.getAttribute(attrName);
           var type = this.getPropertyType(propName);
@@ -92,7 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     setAttributeToProperty: function(model, attrName) {
       // Don't deserialize back to property if currently reflecting
       if (!this._serializing) {
-        var propName = Polymer.Annotations.dashToCamelCase(attrName);
+        var propName = Polymer.Attributes.dashToCamelCase(attrName);
         if (propName in this.properties) {
           var type = this.getPropertyType(propName);
           var val = this.getAttribute(attrName);
@@ -112,7 +112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var str = this.serialize(value);
       (node || this)
         [str === undefined ? 'removeAttribute' : 'setAttribute']
-          (Polymer.Annotations.camelToDashCase(attribute), str);
+          (Polymer.Attributes.camelToDashCase(attribute), str);
     },
 
     deserialize: function(value, type) {

--- a/src/features/standard/notify-path.html
+++ b/src/features/standard/notify-path.html
@@ -247,7 +247,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _notifyPath: function(path, value) {
       var rootName = this._modelForPath(path);
-      var dashCaseName = Polymer.Annotations.camelToDashCase(rootName); 
+      var dashCaseName = Polymer.Attributes.camelToDashCase(rootName); 
       var eventName = dashCaseName + this._EVENT_CHANGED;
       this.fire(eventName, { 
         path: path, 

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -8,6 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../module.html">
+<link rel="import" href="../attributes.html"> 
 
 <script>
 /**
@@ -219,7 +220,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // camel-case: `foo-bar` becomes `fooBar`.
         // Attribute bindings are excepted.
         if (kind === 'property') {
-          name = Polymer.Annotations.dashToCamelCase(name);
+          name = Polymer.Attributes.dashToCamelCase(name);
         }
         return {
           kind: kind,
@@ -229,26 +230,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           negate: not
         };
       }
-    },
-
-    dashToCamelCase: function(dash) {
-      // TODO(sjmiles): is rejection test actually helping perf?
-      if (dash.indexOf('-') < 0) {
-        return dash;
-      }
-      return dash.replace(/-([a-z])/g, 
-        function(m) {
-          return m[1].toUpperCase(); 
-        }
-      );
-    },
-
-    camelToDashCase: function(camel) {
-      return camel.replace(/([a-z][A-Z])/g, 
-        function (g) { 
-          return g[0] + '-' + g[1].toLowerCase() 
-        }
-      );
     },
 
     // instance-time

--- a/src/lib/attributes.html
+++ b/src/lib/attributes.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>
+
+  Polymer.Attributes = {
+
+    dashToCamelCase: function(dash) {
+      // TODO(sjmiles): is rejection test actually helping perf?
+      if (dash.indexOf('-') < 0) {
+        return dash;
+      }
+      return dash.replace(/-([a-z])/g, 
+        function(m) {
+          return m[1].toUpperCase(); 
+        }
+      );
+    },
+
+    camelToDashCase: function(camel) {
+      return camel.replace(/([a-z][A-Z])/g, 
+        function (g) { 
+          return g[0] + '-' + g[1].toLowerCase() 
+        }
+      );
+    }
+
+  };
+
+</script>

--- a/src/lib/bind/bind-effects.html
+++ b/src/lib/bind/bind-effects.html
@@ -31,7 +31,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   // TODO(sjmiles): case shenanigans
   // TODO(sjmiles): ad hoc?
-  // TODO(sjmiles): other places where Annotations.camelToDashCase(name)
   // is being employed should be using this method instead
   Polymer.Bind.mapCase = function(name) {
     var mapped = Polymer.Bind._caseMap[name];
@@ -39,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return mapped;
     }
     return Polymer.Bind._caseMap[name] = 
-      Polymer.Annotations.camelToDashCase(name);
+      Polymer.Attributes.camelToDashCase(name);
   };
   
   // case mapping memoizations

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   >
 </x-basic>
 
-<x-reflect id="reflectDefault"></x-basic>
+<x-reflect id="reflectDefault"></x-reflect>
 
 <x-reflect id="reflectConfigured"
   object='{"foo": "bar", "nested": {"meaning": 42}, "arr": [0, "foo", true]}'
@@ -44,7 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   dash-case="The quick brown fox"
   no-type="Should be String"
   >
-</x-basic>
+</x-reflect>
 
 <script>
 
@@ -157,6 +157,11 @@ suite('imperative attribute change (no-reflect)', function() {
     assert.strictEqual(el.bool, false);
   });
 
+  test('basic change dashCase attribute', function() {
+    el.setAttribute('dash-case', 'Changed');
+    assert.strictEqual(el.dashCase, 'Changed');
+  });
+
 });
 
 suite('imperative attribute change (reflect)', function() {
@@ -203,8 +208,15 @@ suite('imperative attribute change (reflect)', function() {
   });
 
   test('basic change boolean attribute false', function() {
+    el.setAttribute('bool', '');
+    assert.strictEqual(el.bool, true);
     el.removeAttribute('bool');
     assert.strictEqual(el.bool, false);
+  });
+
+  test('basic change dashCase attribute', function() {
+    el.setAttribute('dash-case', 'Changed');
+    assert.strictEqual(el.dashCase, 'Changed');
   });
 
   test('change non-`properties` property that natively reflects', function() {


### PR DESCRIPTION
It is repeated pull request, after rebase upstream branch.

Original vulcanized polymer-micro and polymer-mini has size 10 kb and 30 kb. After merge my pull request vulcanized polymer-micro and polymer-mini will have size 6 kb and 26 kb.

It is not good idea include all `annotations` features in polymer-micro and polymer-mini, i think.

@kevinpschaaf, @sorvell, @nevir, @sjmiles, @ebidel, can you comment?