### PR TITLE
Make webcomponentsjs a bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,11 @@
     "type": "git",
     "url": "https://github.com/Polymer/polymer.git"
   },
-  "devDependencies": {
-    "web-component-tester": "*",
+  "dependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#master"
+  },
+  "devDependencies": {
+    "web-component-tester": "*"
   },
   "private": true
 }


### PR DESCRIPTION
This change would make it so webcomponentsjs is installed when I bower install polymer