### PR TITLE
Fix undeclared variable exception in _distributeInsertionPoint.

### DIFF
--- a/src/features/mini/shady.html
+++ b/src/features/mini/shady.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } else {
             if (!this.shadyRoot._hasDistributed) {
               this.textContent = '';
-              this.appendChild(this.shadyRoot);  
+              this.appendChild(this.shadyRoot);
             } else {
               // simplified non-tree walk composition
               var children = this._composeNode(this);
@@ -172,7 +172,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // skip nodes that were already used
           if (!node) {
             continue;
-          } 
+          }
           // distribute this node if it matches
           if (this._matchesContentSelect(node, content)) {
             distributeNodeInto(node, content);
@@ -182,7 +182,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             anyDistributed = true;
             var parent = content.lightParent;
             // dirty a shadyRoot if a change may trigger reprojection!
-            if (parent && parent.shadyRoot && 
+            if (parent && parent.shadyRoot &&
               hasInsertionPoint(parent.shadyRoot)) {
               parent._distributionClean = false;
             }
@@ -190,7 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // Fallback content if nothing was distributed here
         if (!anyDistributed) {
-          children = getLightChildren(content);
+          var children = getLightChildren(content);
           for (var j = 0; j < children.length; j++) {
             distributeNodeInto(children[j], content);
           }
@@ -209,8 +209,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._updateChildNodes(this, this._composeNode(this));
         var p$ = this.shadyRoot._insertionPoints;
         for (var i=0, l=p$.length, p, parent; (i<l) && (p=p$[i]); i++) {
-          var parent = p.lightParent || p.parentNode;
-          if (!parent._useContent && (parent !== this) && 
+          parent = p.lightParent || p.parentNode;
+          if (!parent._useContent && (parent !== this) &&
             (parent !== this.shadyRoot)) {
             this._updateChildNodes(parent, this._composeNode(parent));
           }
@@ -240,7 +240,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Ensures that the rendered node list inside `node` is `children`.
       _updateChildNodes: function(node, children) {
-        var splices = 
+        var splices =
           Polymer.ArraySplice.calculateSplices(children, node.childNodes);
         for (var i=0; i<splices.length; i++) {
           var s = splices[i];
@@ -252,13 +252,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
           // insert
-          for (var idx=s.index, c, o; idx < s.index + s.addedCount; idx++) {
-            c = children[idx];
+          for (var idx=s.index, ch, o; idx < s.index + s.addedCount; idx++) {
+            ch = children[idx];
             o = node.childNodes[idx];
-            while (o && o === c) {
+            while (o && o === ch) {
               o = o.nextSibling;
             }
-            insertBefore(node, c, o);
+            insertBefore(node, ch, o);
           }
         }
       },


### PR DESCRIPTION

- Fix `children` is an undefined variable in `_distributeInsertionPoint`.
  - This caused an exception to be thrown when you instantiate a polymer element that uses localdom without any distributed childNodes.
- Removed trailing whitespace and removed unnecessary variable redeclarations.