### PR TITLE
Allow _prepMixins to accept either functions or objects.

### DIFF
--- a/src/micro/mixins.html
+++ b/src/micro/mixins.html
@@ -30,7 +30,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _prepMixins: function() {
       if (this.mixins) {
         this.mixins.forEach(function(m) {
-          Polymer.Base.extend(this, m);
+          if (typeof m === 'function') {
+            // a caching mixin will itself add the
+            // api properties to the object.
+            m.call(this);
+          }
+          else
+          {
+            Polymer.Base.extend(this, m);
+          }
         }, this);
       }
     }


### PR DESCRIPTION
Functions will allow for a caching mixin pattern of the form:

```js
  var myMixin = (function() {
    function blah () { }
    return function () {
      this.blah = blah;
      return blah;
    }
  })();
```

Function caching in this form is highly performant, and since Polymer should encourage mixins, this seems like a worthy pattern to encourage/support.