### PR TITLE
Bring back tests for <x-template>, and fix it so `stamp()` doesn't throw

### DIFF
--- a/src/lib/template/x-template.html
+++ b/src/lib/template/x-template.html
@@ -31,6 +31,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     ready: function() {
+      this._template = this;
+      this.dataHost  = this;
       this.templatize(this);
     }
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -38,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/styling-scoped.html',
       'unit/styling-remote.html',
       'unit/x-style.html',
+      'unit/template/x-template.html',
       'unit/dynamic-import.html'
     ]);
   </script>


### PR DESCRIPTION
Fixes https://github.com/Polymer/test-fixture/issues/9