### PR TITLE
Bugfix: bracket spaces in computed expressions

### DIFF
--- a/src/standard/effects.html
+++ b/src/standard/effects.html
@@ -78,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (m) {
         return {
           method: m[1],
-          args: m[2].split(/[^\w.*]+/).map(this._parseArg)
+          args: m[2].replace(' ','').split(/[^\w.*]+/).map(this._parseArg)
         };        
       }
     },


### PR DESCRIPTION
computeCalStyle(item.backgroundColor) worked, computeCalStyle( item.backgroundColor) did not.
This fix removes all spaces from text inside the brackets.