### PR TITLE
[0.8] ready isn't bottom-up for elements in the same scope

### DIFF
--- a/test/unit/ready.js
+++ b/test/unit/ready.js
@@ -1,7 +1,7 @@
 suite('ready', function() {
 
   var configure = ['x-ready', 'x-zot#a', 'x-zot#b', 'x-zot#c', 'x-zot#d', 'x-foo#foo', 'x-bar#bar1', 'x-zot', 'x-bar#bar2', 'x-zot'];
-  var ready = ['x-zot#a', 'x-zot#b', 'x-zot#c', 'x-zot#d', 'x-zot', 'x-bar#bar1', 'x-zot', 'x-bar#bar2', 'x-foo#foo', 'x-ready'];
+  var ready = ['x-zot#d', 'x-zot#c', 'x-zot#b', 'x-zot#a', 'x-zot', 'x-bar#bar1', 'x-zot', 'x-bar#bar2', 'x-foo#foo', 'x-ready'];
 
   test('element create in dom calls configure/ready/attached in proper order', function() {
     assert.deepEqual(configureList, configure);


### PR DESCRIPTION
We [advertise](https://github.com/Polymer/polymer/blob/0.8-preview/PRIMER.md#ready-callback) the `ready` callback as being bottom up. And it is, for every shadow/shady root. However, for elements declared in the same scope, `ready` fires top-down. The tests indicate this too.

Is this WAI? It certainly seems a bit wonky. The primer does seem to word things to support top-down inside each element template (we might want to add a caveat if it is WAI)

I've updated the tests to what I would _expect_ to be the order (though `'x-zot#d', 'x-zot#b', 'x-zot#c', 'x-zot#a'` would also be proper)