### PR TITLE
Allow host to override custom properties

### DIFF
--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -39,8 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _computeStyleProperties: function() {
         var props = {};
-        this.mixin(props, this._computeStylePropertiesFromHost());
         this.mixin(props, this._computeOwnStyleProperties());
+        this.mixin(props, this._computeStylePropertiesFromHost());
         this._reifyCustomProperties(props);
         return props;
       },


### PR DESCRIPTION
I've been working with custom properties and I noticed that a host could not override the custom properties defined by the element.  For example:
```html
<style is="x-style">
 html  x-demo{
   --foo: 1px;
   color: red;
}
</style>
```
Now, imagine ``x-demo`` defined a default value for ``--foo``

```css
:host {
   --foo: 2px;
   color: blue;
}
.read-foo {
      /** color is red which is correct **/
    /** but var(--foo) is 2px  **/
}
```
``var(--foo)`` should be ``1px`` to be compliant with standard css properties.