### PR TITLE
0.8 x style

### DIFF
--- a/polymer.html
+++ b/polymer.html
@@ -86,7 +86,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </script>
 
-<link rel="import" href="src/lib/x-style.html">
+<link rel="import" href="src/lib/custom-style.html">
 <link rel="import" href="src/lib/template/x-autobind.html">
 <link rel="import" href="src/lib/template/x-template.html">
 <link rel="import" href="src/lib/template/x-repeat.html">

--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -55,14 +55,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // add selectors/cssText to node tree
   function parseCss(node, text) {
     var t = text.substring(node.start, node.end-1);
-    node.cssText = t.trim();
+    node.parsedCssText = node.cssText = t.trim();
     if (node.parent) {
       var ss = node.previous ? node.previous.end : node.parent.start;
       t = text.substring(ss, node.start-1);
       // TODO(sorvell): ad hoc; make selector include only after last ;
       // helps with mixin syntax
       t = t.substring(t.lastIndexOf(';')+1);
-      node.selector = t.trim();
+      node.parsedSelector = node.selector = t.trim();
     }
     var r$ = node.rules;
     if (r$) {
@@ -74,18 +74,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   // stringify parsed css.
-  function stringify(node, text) {
+  function stringify(node, preserveProperties, text) {
     text = text || '';
     // calc rule cssText
     var cssText = '';
     if (node.cssText || node.rules) {
       var r$ = node.rules;
-      if (r$ && !hasMixinRules(r$)) {
+      if (r$ && (preserveProperties || !hasMixinRules(r$))) {
         for (var i=0, l=r$.length, r; (i<l) && (r=r$[i]); i++) {
-          cssText = stringify(r, cssText);
+          cssText = stringify(r, preserveProperties, cssText);
         }  
       } else {
-        cssText = removeCustomProps(node.cssText).trim();
+        cssText = preserveProperties ? node.cssText : 
+          removeCustomProps(node.cssText);  
+        cssText = cssText.trim();
         if (cssText) {
           cssText = '  ' + cssText + '\n';
         }
@@ -126,7 +128,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     port: /@import[^;]*;/gim,
     customProp: /--[^;{]*?:[^{};]*?;/gim,
     mixinProp: /--[^;{]*?:[^{;]*?{[^}]*?};?/gim,
-    mixinApply: /@mixin[\s]*\([^)]*?\)[\s]*;/gim
+    mixinApply: /@apply[\s]*\([^)]*?\)[\s]*;/gim
   };
 
   // exports 

--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -125,7 +125,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     comments: /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim,
     port: /@import[^;]*;/gim,
     customProp: /--[^;{]*?:[^{};]*?;/gim,
-    mixinProp: /--[^;{]*?:[^{;]*?{[^}]*?}/gim,
+    mixinProp: /--[^;{]*?:[^{;]*?{[^}]*?};?/gim,
     mixinApply: /@mixin[\s]*\([^)]*?\)[\s]*;/gim
   };
 

--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -33,7 +33,7 @@ Example:
   <script src="components/webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="components/polymer/polymer.html">
 
-  <style is="x-style">
+  <style is="custom-style">
     
     /* Will be prevented from affecting local DOM of Polymer elements */
     * {
@@ -61,42 +61,59 @@ Example:
 </html>
 ```
 
-Note, all features of `x-style` are available when defining styles as part of Polymer elements (e.g. `<style>` elements within `<dom-module>`'s used for defining Polymer elements. The `x-style` extension should only be used for defining document styles, outside of a custom element's local DOM.
+Note, all features of `custom-style` are available when defining styles as part of Polymer elements (e.g. `<style>` elements within `<dom-module>`'s used for defining Polymer elements. The `custom-style` extension should only be used for defining document styles, outside of a custom element's local DOM.
 
 -->
 
 <script>
 (function() {
 
+  var nativeShadow = Polymer.Settings.useNativeShadow;
+
   Polymer({
 
-    is: 'x-style',
+    is: 'custom-style',
     extends: 'style',
 
     created: function() {
       if (this.parentNode.localName === 'dom-module') {
-        return;
+        this._inert = true;
+      } else {
+        var rules = Polymer.StyleUtil.parser.parse(this.textContent);
+        this._rulesToDefaultProperties(rules);
       }
-      var rules = Polymer.StyleUtil.parser.parse(this.textContent);
-      this.applyProperties(rules);
-      // TODO(sorvell): since custom rules must match directly, they tend to be
-      // made with selectors like `*`.
-      // We *remove them here* so they don't apply too widely and nerf recalc.
-      // This means that normal properties mix in rules with custom 
-      // properties will *not* apply.
-      var cssText = Polymer.StyleUtil.parser.stringify(rules);
-      this.textContent = this.scopeCssText(cssText);
     },
 
-    scopeCssText: function(cssText) {
-      return Polymer.Settings.useNativeShadow ?
-        cssText :
-        Polymer.StyleUtil.toCssText(cssText, function(rule) {
-          Polymer.StyleTransformer.rootRule(rule);
-      });
+    attached: function() {
+      // go async to give a chance to collect properties into the StyleDefaults
+      // before applying
+      if (!this._inert) {
+        this.async(this._applyStyle);
+      }
     },
 
-    applyProperties: function(rules) {
+    // polyfill this style with root scoping and 
+    // apply custom properties!
+    _applyStyle: function() {
+      var e = this._appliedElement || this;
+      var props = this._styleProperties = this._computeStyleProperties();
+      var self = this;
+      e.textContent = Polymer.StyleUtil.toCssText(e.textContent, 
+        function(rule) {
+          // polyfill lack of support for :root
+          if (rule.selector === ':root') {
+            rule.selector = 'body';
+          }
+          if (rule.cssText.match(CUSTOM_RULE_RX)) {
+            rule.cssText = self._applyPropertiesToText(rule.cssText, props);
+          }
+          if (!nativeShadow) {
+            Polymer.StyleTransformer.rootRule(rule);
+          }
+        });
+    },
+
+    _rulesToDefaultProperties: function(rules) {
       var cssText = '';
       Polymer.StyleUtil.forEachStyleRule(rules, function(rule) {
         if (rule.cssText.match(CUSTOM_RULE)) {
@@ -112,6 +129,7 @@ Note, all features of `x-style` are available when defining styles as part of Po
 
   });
 
+  var CUSTOM_RULE_RX = /^(?![{}])(mixin|var)/m;
   var CUSTOM_RULE = /--[^;{'"]*\:/;
 
 })();

--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -69,6 +69,7 @@ Note, all features of `custom-style` are available when defining styles as part 
 (function() {
 
   var nativeShadow = Polymer.Settings.useNativeShadow;
+  var propertyUtils = Polymer.StyleProperties;
 
   Polymer({
 
@@ -76,18 +77,14 @@ Note, all features of `custom-style` are available when defining styles as part 
     extends: 'style',
 
     created: function() {
-      if (this.parentNode.localName === 'dom-module') {
-        this._inert = true;
-      } else {
-        var rules = Polymer.StyleUtil.parser.parse(this.textContent);
-        this._rulesToDefaultProperties(rules);
-      }
-    },
-
-    attached: function() {
-      // go async to give a chance to collect properties into the StyleDefaults
-      // before applying
-      if (!this._inert) {
+      this._appliesToDocument = (this.parentNode.localName !== 'dom-module');
+      if (this._appliesToDocument) {
+        var e = this.__appliedElement || this;
+        this.__cssRules = Polymer.StyleUtil.parser.parse(e.textContent);
+        propertyUtils.decorateRules(this.__cssRules);
+        this._rulesToDefaultProperties(this.__cssRules);
+        // NOTE: go async to give a chance to collect properties into 
+        // the StyleDefaults before applying
         this.async(this._applyStyle);
       }
     },
@@ -95,17 +92,22 @@ Note, all features of `custom-style` are available when defining styles as part 
     // polyfill this style with root scoping and 
     // apply custom properties!
     _applyStyle: function() {
-      var e = this._appliedElement || this;
+      var e = this.__appliedElement || this;
       var props = this._styleProperties = this._computeStyleProperties();
       var self = this;
-      e.textContent = Polymer.StyleUtil.toCssText(e.textContent, 
+      e.textContent = Polymer.StyleUtil.toCssText(this.__cssRules, 
         function(rule) {
           // polyfill lack of support for :root
           if (rule.selector === ':root') {
             rule.selector = 'body';
           }
-          if (rule.cssText.match(CUSTOM_RULE_RX)) {
-            rule.cssText = self._applyPropertiesToText(rule.cssText, props);
+          var css = rule.cssText = rule.parsedCssText;
+          if (rule.properties.consumes) {
+            // TODO(sorvell): factor better
+            // remove property assignments so next function isn't confused
+            css = css.replace(propertyUtils.rx.VAR_ASSIGN, '');
+            // replace with reified properties, scenario is same as mixin
+            rule.cssText = propertyUtils.valueForMixin(css, props);
           }
           if (!nativeShadow) {
             Polymer.StyleTransformer.rootRule(rule);
@@ -114,23 +116,20 @@ Note, all features of `custom-style` are available when defining styles as part 
     },
 
     _rulesToDefaultProperties: function(rules) {
-      var cssText = '';
+      // produce css containing only property assignments.
       Polymer.StyleUtil.forEachStyleRule(rules, function(rule) {
-        if (rule.cssText.match(CUSTOM_RULE)) {
-          // TODO(sorvell): use parser.stringify, it needs an option not to
-          // strip custom properties.
-          cssText += rule.selector + ' {\n' + rule.cssText + '\n}\n';
+        if (!rule.properties.produces) {
+          rule.cssText = '';
         }
       });
+      // tell parser to emit css that includes properties.
+      var cssText = Polymer.StyleUtil.parser.stringify(rules, true);
       if (cssText) {
         Polymer.StyleDefaults.applyCss(cssText);
       }
     }
 
   });
-
-  var CUSTOM_RULE_RX = /^(?![{}])(mixin|var)/m;
-  var CUSTOM_RULE = /--[^;{'"]*\:/;
 
 })();
 </script>

--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -79,6 +79,7 @@ Note, all features of `custom-style` are available when defining styles as part 
     created: function() {
       this._appliesToDocument = (this.parentNode.localName !== 'dom-module');
       if (this._appliesToDocument) {
+        // used applied element from HTMLImports polyfill or this
         var e = this.__appliedElement || this;
         this.__cssRules = Polymer.StyleUtil.parser.parse(e.textContent);
         propertyUtils.decorateRules(this.__cssRules);
@@ -92,6 +93,7 @@ Note, all features of `custom-style` are available when defining styles as part 
     // polyfill this style with root scoping and 
     // apply custom properties!
     _applyStyle: function() {
+      // used applied element from HTMLImports polyfill or this
       var e = this.__appliedElement || this;
       var props = this._styleProperties = this._computeStyleProperties();
       var self = this;

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -265,8 +265,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _removeOwnerShadyRoot: function(node) {
-        // TODO(sorvell): need to clear any children of element?
+        // TODO(sorvell): why does this break polymer-dom tests?
+        //var hasCachedRoot = factory(node).getOwnerRoot() !== undefined;
         node._ownerShadyRoot = undefined;
+        //if (hasCachedRoot) {
+          var c$ = factory(node).childNodes;
+          for (var i=0, l=c$.length, n; (i<l) && (n=c$[i]); i++) {
+            this._removeOwnerShadyRoot(n);
+          }
+        //}
       },
 
       // TODO(sorvell): This will fail if distribution that affects this

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -302,6 +302,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _query: function(matcher, node) {
+        node = node || this.node;
         var list = [];
         this._queryElements(factory(node).childNodes, matcher, list);
         return list;

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -265,15 +265,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _removeOwnerShadyRoot: function(node) {
-        // TODO(sorvell): why does this break polymer-dom tests?
-        //var hasCachedRoot = factory(node).getOwnerRoot() !== undefined;
-        node._ownerShadyRoot = undefined;
-        //if (hasCachedRoot) {
+        // optimization: only reset the tree if node is actually in a root
+        var hasCachedRoot = factory(node).getOwnerRoot() !== undefined;
+        if (hasCachedRoot) {
           var c$ = factory(node).childNodes;
           for (var i=0, l=c$.length, n; (i<l) && (n=c$[i]); i++) {
             this._removeOwnerShadyRoot(n);
           }
-        //}
+        }
+        node._ownerShadyRoot = undefined;
       },
 
       // TODO(sorvell): This will fail if distribution that affects this

--- a/src/lib/style-defaults.html
+++ b/src/lib/style-defaults.html
@@ -18,8 +18,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function applyCss(cssText) {
       style.textContent += cssText;
       properties = null;
+      // TODO(sorvell): make this lazy at the point of consumption
+      // or better yet, pass in pre-parsed rules here.
       style.__cssRules =
         Polymer.StyleUtil.parser.parse(style.textContent);
+      Polymer.StyleProperties.decorateRules(style.__cssRules);
     }
 
     function getProperties() {
@@ -27,7 +30,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         properties = {};
         Polymer.StyleUtil.forEachStyleRule(style.__cssRules, 
           function(rule) {
-            Polymer.StyleProperties.decorateRule(rule);
             Polymer.Base._rootCustomPropertiesFromRule(properties, rule);
         });
         Polymer.StyleProperties.reify(properties);

--- a/src/lib/style-defaults.html
+++ b/src/lib/style-defaults.html
@@ -12,12 +12,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   (function() {
     
-    var defaultSheet = document.createElement('style'); 
+    var style = document.createElement('style'); 
+    var properties;
 
     function applyCss(cssText) {
-      defaultSheet.textContent += cssText;
-      defaultSheet.__cssRules =
-        Polymer.StyleUtil.parser.parse(defaultSheet.textContent);
+      style.textContent += cssText;
+      properties = null;
+      style.__cssRules =
+        Polymer.StyleUtil.parser.parse(style.textContent);
+    }
+
+    function getProperties() {
+      if (!properties) {
+        properties = {};
+        Polymer.StyleUtil.forEachStyleRule(style.__cssRules, 
+          function(rule) {
+            Polymer.StyleProperties.decorateRule(rule);
+            Polymer.Base._rootCustomPropertiesFromRule(properties, rule);
+        });
+        Polymer.StyleProperties.reify(properties);
+      }
+      return properties;
     }
 
     applyCss('');
@@ -25,7 +40,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // exports
     Polymer.StyleDefaults = {
       applyCss: applyCss,
-      defaultSheet: defaultSheet
+      style: style,
+      styles: [style],
+      getProperties: getProperties
     };
 
   })();

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -18,6 +18,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return {
 
+      // decorate rules with property info: whether it produces or consumes them
+      decorateRules: function(rules) {
+        if (rules.properties) {
+          return;
+        }
+        var pp = {};
+        var self = this;
+        Polymer.StyleUtil.forEachStyleRule(rules, function(rule) {
+          var p = self.decorateRule(rule);
+          pp.consumes = pp.consumes || p.consumes;
+          pp.produces = pp.produces || p.produces;
+        });
+        rules.properties = pp;
+      },
+
+      // decorate a single rule with property info
+      decorateRule: function(rule) {
+        if (rule.properties) {
+          return;
+        }
+        var cssText = rule.parsedCssText;
+        var rx = this.rx;
+        // NOTE: we support consumption inside mixin assignment
+        // but not production, so strip out {...}
+        var cleanCss = cssText.replace(rx.BRACKETED, '');
+        var p = rule.properties = {
+          produces: cssText.match(rx.VAR_ASSIGN),
+          consumes: cleanCss.match(rx.VAR_USE) || cleanCss.match(rx.MIXIN_USE)
+        };
+        // TODO(sorvell): workaround parser seeing mixins as additional rules
+        if (p.produces) {
+          rule.rules = null;
+        }
+        return p;
+      },
+
       // collects the custom properties from a rule's cssText
       collect: function(rule, properties) {
         if (rule.properties.produces) {
@@ -37,40 +73,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (var i in props) {
           props[i] = this.valueForProperty(props[i], props);
         }
-      },
-
-      decorateRules: function(rules) {
-        if (rules.properties) {
-          return;
-        }
-        var pp = {};
-        var self = this;
-        Polymer.StyleUtil.forEachStyleRule(rules, function(rule) {
-          var p = self.decorateRule(rule);
-          pp.consumes = pp.consumes || p.consumes;
-          pp.produces = pp.produces || p.produces;
-        });
-        rules.properties = pp;
-      },
-
-      decorateRule: function(rule) {
-        if (rule.properties) {
-          return;
-        }
-        var cssText = rule.parsedCssText;
-        var rx = this.rx;
-        // NOTE: we support consumption inside mixin assignment
-        // but not production, so strip out {...}
-        var cleanCss = cssText.replace(rx.BRACKETED, '');
-        var p = rule.properties = {
-          produces: cssText.match(rx.VAR_ASSIGN),
-          consumes: cleanCss.match(rx.VAR_USE) || cleanCss.match(rx.MIXIN_USE)
-        };
-        // TODO(sorvell): workaround parser seeing mixins as additional rules
-        if (p.produces) {
-          rule.rules = null;
-        }
-        return p;
       },
 
       // given a property value, returns the reified value
@@ -119,11 +121,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return parts.join(';');
       },
 
+      // TODO(srovell): make this go away by pre-processing rules
+      // to contain specifically only the css that consumes properties 
+      // for use here.
+      //
       // returns cssText with properties applied;
       // if no properties apply, returns nothing
       applyProperties: function(rule, props) {
         var cssText = rule.parsedCssText;
         var output = '';
+        // dynamically added sheets may not be decorated so ensure they are.
         if (!rule.properties) {
           this.decorateRule(rule);
         }

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -1,0 +1,177 @@
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="style-transformer.html">
+
+<script>
+
+  Polymer.StyleProperties = (function() {
+
+    var nativeShadow = Polymer.Settings.useNativeShadow;
+
+    return {
+
+      // collects the custom properties from a rule's cssText
+      collect: function(rule, properties) {
+        if (rule.properties.produces) {
+          var m, rx = this.rx.VAR_ASSIGN;
+          // cssText may be modified but in this case
+          // raw version is saved for processing
+          var cssText = rule.parsedCssText;
+          while (m = rx.exec(cssText)) {
+            // note: group 2 is var, 3 is mixin
+            properties[m[1]] = (m[2] || m[3]).trim();
+          }
+        }
+      },
+
+      // turns custom properties into realized values.
+      reify: function(props) {
+        for (var i in props) {
+          props[i] = this.valueForProperty(props[i], props);
+        }
+      },
+
+      decorateRules: function(rules) {
+        if (rules.properties) {
+          return;
+        }
+        var pp = {};
+        var self = this;
+        Polymer.StyleUtil.forEachStyleRule(rules, function(rule) {
+          var p = self.decorateRule(rule);
+          pp.consumes = pp.consumes || p.consumes;
+          pp.produces = pp.produces || p.produces;
+        });
+        rules.properties = pp;
+      },
+
+      decorateRule: function(rule) {
+        if (rule.properties) {
+          return;
+        }
+        var cssText = rule.parsedCssText;
+        var rx = this.rx;
+        // NOTE: we support consumption inside mixin assignment
+        // but not production, so strip out {...}
+        var cleanCss = cssText.replace(rx.BRACKETED, '');
+        var p = rule.properties = {
+          produces: cssText.match(rx.VAR_ASSIGN),
+          consumes: cleanCss.match(rx.VAR_USE) || cleanCss.match(rx.MIXIN_USE)
+        };
+        // TODO(sorvell): workaround parser seeing mixins as additional rules
+        if (p.produces) {
+          rule.rules = null;
+        }
+        return p;
+      },
+
+      // given a property value, returns the reified value
+      // a property value may be:
+      // (1) a literal value like: red or 5px;
+      // (2) a variable value like: var(--a), var(--a, red), or var(--a, --b);
+      // (3) a literal mixin value like { properties }. Each of these properties
+      // can have values that are: (a) literal, (b) variables, (c) @apply mixins.
+      valueForProperty: function(property, props) {
+        // case (1) default
+        // case (3) defines a mixin and we have to reify the internals
+        if (property && property.indexOf(';') >=0) {
+          property = this.valueForMixin(property, props);
+        } else {
+          // case (2) variable
+          var m = property && property.match(this.rx.VAR_VALUE);
+          if (m) {
+            var value = m[1], def = m[2];
+            property = this.valueForProperty(props[value], props) ||
+              (props[def] ? this.valueForProperty(props[def], props) : def);
+          }
+        }
+        return property && property.trim();
+      },
+      
+      // note: we do not yet support mixin within mixin
+      valueForMixin: function(property, props) {
+        var parts = property.split(';');
+        for (var i=0, p, m; (i<parts.length) && (p=parts[i]); i++) {
+          m = p.match(this.rx.MIXIN_MATCH);
+          if (m) {
+            p = this.valueForProperty(props[m[1]], props);
+          } else {
+            var pp = p.split(':');
+            if (pp[1]) {
+              pp[1] = pp[1].trim();
+              pp[1] = this.valueForProperty(pp[1], props) || pp[1];
+            }
+            p = pp.join(': ');
+          }
+          parts[i] = (p && p.lastIndexOf(';') === p.length - 1) ? 
+            // strip trailing ;
+            p.slice(0, -1) :
+            p || '';
+        }
+        return parts.join(';');
+      },
+
+      // returns cssText with properties applied;
+      // if no properties apply, returns nothing
+      applyProperties: function(rule, props) {
+        var cssText = rule.parsedCssText;
+        var output = '';
+        if (!rule.properties) {
+          this.decorateRule(rule);
+        }
+        if (rule.properties.consumes) {
+          var m, v;
+          // cssText including {...} will confuse this function so we lim it
+          cssText = cssText.replace(this.rx.BRACKETED, '');
+          // e.g. color: var(--color);
+          while (m = this.rx.VAR_USE.exec(cssText)) {
+            v = this.valueForProperty(m[2], props);
+            if (v) {
+              output += '\t' + m[1].trim() + ': ' + this.propertyToCss(v);
+            }
+          }
+          // e.g. @apply(--stuff);
+          while (m = this.rx.MIXIN_USE.exec(cssText)) {
+            v = m[1];
+            if (v) {
+              var parts = v.split(' ');
+              for (var i=0, p; i < parts.length; i++) {
+                p = props[parts[i].trim()];
+                if (p) {
+                  output += '\t' + this.propertyToCss(p);
+                }
+              }
+            }
+          }
+        }
+        rule.cssText = output;
+      },
+
+      propertyToCss: function(property) {
+        var p = property.trim();
+        p = p[p.length-1] === ';' ? p : p + ';';
+        return p + '\n';
+      },
+
+      rx: {
+        VAR_ASSIGN: /(?:^|;\s*)(--[^\:;]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?=;)/gim,
+        VAR_VALUE: /^var\([\s]*([^,)]*)[\s]*,?[\s]*([^,)]*)[\s]*?\);?/,
+        VAR_USE: /(?:^|[;}\s])([^;{}]*?):[\s]*?(var\([^)]*?\))/gim,
+        MIXIN_USE: /@apply\(([^)]*)\);?/gim, 
+        MIXIN_MATCH: /@apply\(([^)]*)\);?/im, 
+        BRACKETED: /\{[^}]*\}/g
+      }
+    };
+
+
+  })();
+
+</script>

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -85,7 +85,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var hostScope = calcHostScope(scope, ext);
       scope = calcElementScope(scope, useAttr);
       return Polymer.StyleUtil.toCssText(rules, function(rule) {
-        transformRule(rule, scope, hostScope);
+        if (!rule.isScoped) {
+          transformRule(rule, scope, hostScope);
+          rule.isScoped = true;
+        }
         if (callback) {
           callback(rule, scope, hostScope);
         }

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -12,64 +12,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  (function() {
+  Polymer.StyleUtil = (function() {
 
-    function toCssText(rules, callback) {
-      if (typeof rules === 'string') {
-        rules = Polymer.CssParse.parse(rules);
-      } 
-      if (callback) {
-        forEachStyleRule(rules, callback);
-      }
-      return Polymer.CssParse.stringify(rules);
-    }
-
-    function forEachStyleRule(node, cb) {
-      var s = node.selector;
-      var skipRules = false;
-      if (s) {
-        if ((s.indexOf(AT_RULE) !== 0) && (s.indexOf(MIXIN_SELECTOR) !== 0)) {
-          cb(node);
+    return {
+      toCssText: function(rules, callback) {
+        if (typeof rules === 'string') {
+          rules = Polymer.CssParse.parse(rules);
+        } 
+        if (callback) {
+          this.forEachStyleRule(rules, callback);
         }
-        skipRules = (s.indexOf(KEYFRAME_RULE) >= 0) || 
-          (s.indexOf(MIXIN_SELECTOR) >= 0);
-      }
-      var r$ = node.rules;
-      if (r$ && !skipRules) {
-        for (var i=0, l=r$.length, r; (i<l) && (r=r$[i]); i++) {
-          forEachStyleRule(r, cb);
+        return Polymer.CssParse.stringify(rules);
+      },
+
+      forEachStyleRule: function(node, cb) {
+        var s = node.selector;
+        var skipRules = false;
+        if (s) {
+          if ((s.indexOf(this.AT_RULE) !== 0) && (s.indexOf(this.MIXIN_SELECTOR) !== 0)) {
+            cb(node);
+          }
+          skipRules = (s.indexOf(this.KEYFRAME_RULE) >= 0) || 
+            (s.indexOf(this.MIXIN_SELECTOR) >= 0);
         }
-      }
-    }
+        var r$ = node.rules;
+        if (r$ && !skipRules) {
+          for (var i=0, l=r$.length, r; (i<l) && (r=r$[i]); i++) {
+            this.forEachStyleRule(r, cb);
+          }
+        }
+      },
 
-    // add a string of cssText to the document.
-    function applyCss(cssText, moniker, target, lowPriority) {
-      var style = document.createElement('style');
-      if (moniker) {
-        style.setAttribute('scope', moniker);
-      }
-      style.textContent = cssText;
-      target = target || document.head;
-      if (lowPriority) {
-        var n$ = target.querySelectorAll('style[scope]');
-        var ref = n$.length ? n$[n$.length-1].nextSibling : target.firstChild;
-        target.insertBefore(style, ref);
-     } else {
-        target.appendChild(style);
-      }
-      return style;
-    }
+      // add a string of cssText to the document.
+      applyCss: function(cssText, moniker, target, lowPriority) {
+        var style = document.createElement('style');
+        if (moniker) {
+          style.setAttribute('scope', moniker);
+        }
+        style.textContent = cssText;
+        target = target || document.head;
+        if (lowPriority) {
+          var n$ = target.querySelectorAll('style[scope]');
+          var ref = n$.length ? n$[n$.length-1].nextSibling : target.firstChild;
+          target.insertBefore(style, ref);
+       } else {
+          target.appendChild(style);
+        }
+        return style;
+      },
 
-    var AT_RULE = '@';
-    var KEYFRAME_RULE = 'keyframe';
-    var MIXIN_SELECTOR = '--';
-
-    // exports
-    Polymer.StyleUtil = {
-      parser: Polymer.CssParse,
-      applyCss: applyCss,
-      forEachStyleRule: forEachStyleRule,
-      toCssText: toCssText
+      AT_RULE: '@',
+      KEYFRAME_RULE: 'keyframe',
+      MIXIN_SELECTOR: '--',
+      parser: Polymer.CssParse
     };
 
   })();

--- a/src/lib/x-style.html
+++ b/src/lib/x-style.html
@@ -74,12 +74,15 @@ Note, all features of `x-style` are available when defining styles as part of Po
     extends: 'style',
 
     created: function() {
+      if (this.parentNode.localName === 'dom-module') {
+        return;
+      }
       var rules = Polymer.StyleUtil.parser.parse(this.textContent);
       this.applyProperties(rules);
       // TODO(sorvell): since custom rules must match directly, they tend to be
       // made with selectors like `*`.
       // We *remove them here* so they don't apply too widely and nerf recalc.
-      // This means that normal properties mixe in rules with custom 
+      // This means that normal properties mix in rules with custom 
       // properties will *not* apply.
       var cssText = Polymer.StyleUtil.parser.stringify(rules);
       this.textContent = this.scopeCssText(cssText);

--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -40,6 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // called as part of content initialization, after template stamping
       _setupRoot: function() {
         if (this._useContent) {
+          this.setAttribute('is-host', '');
           this._createLocalRoot();
         }
       },

--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -40,7 +40,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // called as part of content initialization, after template stamping
       _setupRoot: function() {
         if (this._useContent) {
-          this.setAttribute('is-host', '');
           this._createLocalRoot();
         }
       },

--- a/src/standard/styling.html
+++ b/src/standard/styling.html
@@ -27,15 +27,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // declaration-y
       _prepTemplate: function() {
         prepTemplate.call(this);
-        var port = Polymer.DomModule.import(this.is);
-        if (this._encapsulateStyle === undefined) {
-          this._encapsulateStyle = 
-            Boolean(port && !nativeShadow);
-        }
         // scope css
-        // NOTE: dom scoped via annotations
-        if (nativeShadow || this._encapsulateStyle) {
-          this._scopeCss();
+        this._styles = this._prepareStyles();
+        var cssText = this._transformStyles(this._styles);
+        if (this._encapsulateStyle === undefined) {
+          this._encapsulateStyle = !nativeShadow && 
+            Boolean(this._template);
+        }
+        if (cssText && this._template) {
+          Polymer.StyleUtil.applyCss(cssText, this.is, 
+            nativeShadow ? this._template.content : null, true);
         }
       },
 
@@ -45,11 +46,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._scopeCssViaAttr);
         }
         prepElement.call(this, element);
-      },
-
-      _scopeCss: function() {
-        this._styles = this._prepareStyles();
-        this._scopeStyles(this._styles);
       },
 
       // search for extra style modules via `styleModules`
@@ -79,8 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var e$ = Array.prototype.slice.call(m.querySelectorAll('style'));
           this._unapplyStyles(e$);
           e$ = e$.concat(Array.prototype.map.call(
+            //TODO(sorvell): add test for 404'ing import
             m.querySelectorAll(REMOTE_SHEET_SELECTOR), function(l) {
-              return l.import.body;
+              return l.import && l.import.body;
             }));
           m._cssText = this._cssFromStyles(e$);
         }
@@ -105,21 +102,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      _scopeStyles: function(styles) {
-        for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
-          // transform style if necessary and place in correct place
-          if (nativeShadow) {
-            if (this._template) {
-              this._template.content.appendChild(s);
-            }
-          } else {
-            var rules = this._rulesForStyle(s);
-            Polymer.StyleUtil.applyCss(
-              Polymer.StyleTransformer.css(rules, this.is, this.extends, 
-              null, this._scopeCssViaAttr), 
-              this.is, null, true);
-          }
+      _transformStyles: function(styles, callback) {
+        var cssText = '';
+        for (var i=0, l=styles.length, s, text; (i<l) && (s=styles[i]); i++) {
+          var rules = this._rulesForStyle(s);
+          cssText += nativeShadow ?
+            Polymer.StyleUtil.toCssText(rules, callback) :
+            Polymer.StyleTransformer.css(rules, this.is, this.extends, callback,
+            this._scopeCssViaAttr) + '\n\n';
         }
+        return cssText.trim();
       },
 
       _rulesForStyle: function(style) {
@@ -127,6 +119,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           style.__cssRules = Polymer.StyleUtil.parser.parse(style.textContent);
         }
         return style.__cssRules;
+      },
+
+      _forRulesInStyles: function(styles, cb) {
+        if (styles) {
+          for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
+            Polymer.StyleUtil.forEachStyleRule(this._rulesForStyle(s), cb);
+          }
+        }
       },
 
       // instance-y

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -7,8 +7,7 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link rel="import" href="../lib/style-util.html">
-<link rel="import" href="../lib/style-transformer.html">
+<link rel="import" href="../lib/style-properties.html">
 <link rel="import" href="../lib/settings.html">
 <link rel="import" href="../lib/style-defaults.html">
 <script>
@@ -18,33 +17,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var baseSerializeValueToAttribute = Polymer.Base.serializeValueToAttribute;
     var prepTemplate = Polymer.Base._prepTemplate;
 
+    var propertyUtils = Polymer.StyleProperties;
+
     var nativeShadow = Polymer.Settings.useNativeShadow;
 
-    // TODO(sorvell): consider if calculating properties and applying
-    // styles with properties should be separate modules.
     Polymer.Base._addFeature({
 
+      // TODO(sorvell): consider tracking which rules have properties so that
+      // instances can skip those that don't.
       _prepTemplate: function() {
         prepTemplate.call(this);
         // determine if element contains x-scope styling
-        this._hasXScopeStyles = this._styles && this._styles.some(function(s) {
-          return this._styleHasCustomRules(s);
-        }, this);
-      },
-
-      _styleHasCustomRules: function(style) {
-        return style.textContent.match(CUSTOM_RULE_RX);
+        var consumes;
+        if (this._styles) {
+          this._styles.forEach(function(s) {
+            var rules = this._rulesForStyle(s);
+            propertyUtils.decorateRules(rules);
+            if (rules.properties.consumes) {
+              consumes = true;
+            }
+          }, this);
+        }
+        this._usesStyleProperties = consumes;
       },
 
       attachedCallback: function() {
         baseAttachedCallback.call(this);
+        // note: do this once automatically,
+        // then requires calling `updateStyles`
         if (!this._xScopeSelector) {
           this._updateOwnStyles();
         }
       },
 
       _updateOwnStyles: function() {
-        if (this._hasXScopeStyles) {
+        if (this._usesStyleProperties) {
           this._styleProperties = this._computeStyleProperties();
           this._applyStyleProperties(this._styleProperties);
         }
@@ -52,101 +59,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _computeStyleProperties: function() {
         var props = {};
-        this.mixin(props, this._computeStylePropertiesFromHost());
+        // properties come from host/defaults
+        this.mixin(props, this._computeScopeStyleProperties());
         this.mixin(props, this._computeOwnStyleProperties());
-        this._reifyCustomProperties(props);
+        propertyUtils.reify(props);
         return props;
       },
 
-      _computeStylePropertiesFromHost: function() {
-        // TODO(sorvell): experimental feature, global defaults!
-        var props = {}, styles = [Polymer.StyleDefaults.defaultSheet];
+      _computeScopeStyleProperties: function() {
         var host = this.domHost;
-        if (host) {
-          if (!host._styleProperties) {
-            host._styleProperties = host._computeStyleProperties();
-          }
-          props = Object.create(host._styleProperties);
-          styles = host._styles;
+        // ensure host has styleProperties
+        if (host && !host._styleProperties) {
+          host._styleProperties = host._computeStyleProperties();
         }
-        this.mixin(props,
-          this._customPropertiesFromStyles(styles, host));
+        // get props and styles from host or defaults
+        var styles = host ? host._styles : Polymer.StyleDefaults.styles;
+        var props = Object.create(host ? host._styleProperties : 
+          Polymer.StyleDefaults.getProperties());
+        // now match this element in these styles and add those properties
+        var cb = this._elementCustomPropertiesFromRule.bind(this, props, this);
+        this._forRulesInStyles(styles, cb);
         return props;
-
       },
 
       _computeOwnStyleProperties: function() {
         var props = {};
-        this.mixin(props, this._customPropertiesFromStyles(this._styles));
-        if (this.styleProperties) {
-          for (var i in this.styleProperties) {
-            props[i] = this.styleProperties[i];
-          }
-        }
+        var cb = this._rootCustomPropertiesFromRule.bind(this, props);
+        this._forRulesInStyles(this._styles, cb);
         return props;
       },
 
-      _customPropertiesFromStyles: function(styles, hostNode) {
-        var props = {};
-        var p = this._customPropertiesFromRule.bind(this, props, hostNode);
-        if (styles) {
-          for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
-            Polymer.StyleUtil.forEachStyleRule(this._rulesForStyle(s), p);
-          }
-        }
-        return props;
-      },
-
-      // test if a rule matches the given node and if so,
-      // collect any custom properties
-      // TODO(sorvell): support custom variable assignment within mixins
-      _customPropertiesFromRule: function(props, hostNode, rule) {
-        hostNode = hostNode || this;
-        // TODO(sorvell): file crbug, ':host' does not match element.
-        if (this.elementMatches(rule.selector) ||
-          ((hostNode === this) && 
-          (rule.selector === HOST || rule.selector === ROOT))) {
-          // --g: var(--b); or --g: 5;
-          this._collectPropertiesFromRule(rule, CUSTOM_VAR_ASSIGN, props);
-          // --g: { ... }
-          this._collectPropertiesFromRule(rule, CUSTOM_MIXIN_ASSIGN, props);
+      // Test if a rule matches the given `element` and if so,
+      // collect any custom properties into `props`.
+      _elementCustomPropertiesFromRule: function(props, element, rule) {
+        if (element && this.elementMatches(rule.selector, element)) {
+          propertyUtils.collect(rule, props);
         }
       },
 
-      // given a rule and rx that matches key and value, set key in properties
-      // to value
-      _collectPropertiesFromRule: function(rule, rx, properties) {
-        var m;
-        while (m = rx.exec(rule.cssText)) {
-          properties[m[1]] = m[2].trim();
-        }
-      },
-
-      _reifyCustomProperties: function(props) {
-        for (var i in props) {
-          props[i] = this._valueForCustomProperty(props[i], props);
-        }
-      },
-
-      // given: --bar: red; --foo: var(--bar);
-      // make: --foo: red;
-      _valueForCustomProperty: function(property, props) {
-        var cv;
-        if (property.match(';')) {
-          var parts = property.split(';');
-          for (var i=0; i<parts.length; i++) {
-            if (parts[i].match(CUSTOM_RULE_RX)) {
-              // remove trailing ;return
-              parts[i] = this._applyPropertiesToText(parts[i], props).slice(0, -2);
-            }
-          }
-          return parts.join(';');
-        } else {
-          while ((typeof property === 'string') &&
-            (cv = property.match(CUSTOM_VAR_VALUE))) {
-            property = props[cv[1]];
-          }
-          return property;
+      // Test if a rule matches root crteria (:host or :root) and if so,
+      // collect any custom properties into `props`.
+      // these rules may already be shimmed and it's $ to reparse, 
+      // so we check `is` value as a fallback
+      _rootCustomPropertiesFromRule: function(props, rule) {
+        var s = rule.parsedSelector;
+        if (s === HOST || s === ROOT) {
+          propertyUtils.collect(rule, props);
         }
       },
 
@@ -158,7 +116,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var old = this._xScopeSelector;
           this._ensureScopeSelector(style ? style._scope : null);
           if (!style) {
-            var cssText = this._generateCustomStyleCss(bag, s$);
+            var cb = this._applyPropertiesToRule.bind(this, bag);
+            var cssText = this._transformStyles(s$, cb);
             style = cssText ? this._applyCustomCss(cssText) : {};
             cacheStyle(this.is, style, this._xScopeSelector,
               this._styleProperties, s$);
@@ -169,6 +128,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._applyXScopeSelector(this._xScopeSelector, old);
           }
         }
+      },
+
+      _applyPropertiesToRule: function(properties, rule) {
+        propertyUtils.applyProperties(rule, properties);
+        if (rule.cssText && !nativeShadow) {
+          this._scopifyRule(rule);
+        }
+      },
+
+      // Strategy: x scope shim a selector e.g. to scope `.x-foo-42` (via classes):
+      // non-host selector: .a.x-foo -> .x-foo-42 .a.x-foo
+      // host selector: x-foo.wide -> x-foo.x-foo-42.wide
+      _scopifyRule: function(rule) {
+        rule.transformedSelector = rule.transformedSelector || rule.selector;
+        var selector = rule.transformedSelector;
+        var host = this.is;
+        var rx = new RegExp(HOST_SELECTOR_PREFIX + host + HOST_SELECTOR_SUFFIX);
+        var parts = selector.split(',');
+        var scope = this._scopeCssViaAttr ?
+          SCOPE_PREFIX + this._xScopeSelector + SCOPE_SUFFIX :
+          '.' + this._xScopeSelector;
+        for (var i=0, l=parts.length, p; (i<l) && (p=parts[i]); i++) {
+          parts[i] = p.match(rx) ?
+            p.replace(host, host + scope) :
+            scope + ' ' + p;
+        }
+        rule.selector = parts.join(',');
       },
 
       _applyXScopeSelector: function(selector, old) {
@@ -183,24 +169,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.className = v;
           }
         }
-      },
-
-      _generateCustomStyleCss: function(properties, styles) {
-        var b = this._applyPropertiesToRule.bind(this, properties);
-        var cssText = '';
-        // TODO(sorvell): don't redo parsing work each time as below;
-        // instead create a sheet with just custom properties
-        for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
-          cssText += this._transformCss(s.textContent, b) + '\n\n';
-        }
-        return cssText.trim();
-      },
-
-      _transformCss: function(cssText, callback) {
-        return nativeShadow ?
-          Polymer.StyleUtil.toCssText(cssText, callback) :
-          Polymer.StyleTransformer.css(cssText, this.is, this.extends, callback,
-            this._scopeCssViaAttr);
       },
 
       _xScopeCount: 0,
@@ -220,69 +188,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             nativeShadow ? this.root : null);
         }
         return this._customStyle;
-      },
-
-      _applyPropertiesToRule: function(properties, rule) {
-        if (!nativeShadow) {
-          this._scopifyRule(rule);
-        }
-        if (rule.cssText.match(CUSTOM_RULE_RX)) {
-          rule.cssText = this._applyPropertiesToText(rule.cssText, properties);
-        } else {
-          rule.cssText = '';
-        }
-        //console.log(rule.cssText);
-      },
-
-      _applyPropertiesToText: function(cssText, props) {
-        var output = '';
-        var m, v;
-        // e.g. color: var(--color);
-        while (m = CUSTOM_VAR_USE.exec(cssText)) {
-          v = props[m[2]];
-          if (v) {
-            output += '\t' + m[1].trim() + ': ' + this._propertyToCss(v);
-          }
-        }
-        // e.g. mixin(--stuff);
-        while (m = CUSTOM_MIXIN_USE.exec(cssText)) {
-          v = m[1];
-          if (v) {
-            var parts = v.split(' ');
-            for (var i=0, p; i < parts.length; i++) {
-              p = props[parts[i].trim()];
-              if (p) {
-                output += '\t' + this._propertyToCss(p);
-              }
-            }
-          }
-        }
-        return output;
-      },
-
-      _propertyToCss: function(property) {
-        var p = property.trim();
-        p = p[p.length-1] === ';' ? p : p + ';';
-        return p + '\n';
-      },
-
-      // Strategy: x scope shim a selector e.g. to scope `.x-foo-42` (via classes):
-      // non-host selector: .a.x-foo -> .x-foo-42 .a.x-foo
-      // host selector: x-foo.wide -> x-foo.x-foo-42.wide
-      _scopifyRule: function(rule) {
-        var selector = rule.selector;
-        var host = this.is;
-        var rx = new RegExp(HOST_SELECTOR_PREFIX + host + HOST_SELECTOR_SUFFIX);
-        var parts = selector.split(',');
-        var scope = this._scopeCssViaAttr ?
-          SCOPE_PREFIX + this._xScopeSelector + SCOPE_SUFFIX :
-          '.' + this._xScopeSelector;
-        for (var i=0, l=parts.length, p; (i<l) && (p=parts[i]); i++) {
-          parts[i] = p.match(rx) ?
-            p.replace(host, host + scope) :
-            scope + ' ' + p;
-        }
-        rule.selector = parts.join(',');
       },
 
       _scopeElementClass: function(element, selector) {
@@ -323,12 +228,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _updateRootStyles: function(root) {
-        // TODO(sorvell): temporary way to find local dom that needs
-        // x-scope styling.
-        // var scopeSelector = this._scopeCssViaAttr ?
-        //   '[' + SCOPE_NAME + '~=' + XSCOPE_NAME + ']' : '.' + XSCOPE_NAME;
-        // var c$ = Polymer.dom(root).querySelectorAll(scopeSelector);
-        var c$ = Polymer.dom(root).querySelectorAll('[is-host]');
+        root = root || this.root;
+        var c$ = Polymer.dom(root)._query(function(e) {
+          return e.shadyRoot || e.shadowRoot;
+        });
         for (var i=0, l= c$.length, c; (i<l) && (c=c$[i]); i++) {
           if (c.updateStyles) {
             c.updateStyles();
@@ -390,12 +293,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var SCOPE_SUFFIX = ']';
     var HOST_SELECTOR_PREFIX = '(?:^|[^.])';
     var HOST_SELECTOR_SUFFIX = '($|[.:[\\s>+~])';
-    var CUSTOM_RULE_RX = /mixin|var/;
-    var CUSTOM_VAR_ASSIGN = /(--[^\:;]*?):\s*?([^;{]*?);/g;
-    var CUSTOM_MIXIN_ASSIGN = /(--[^\:;]*?):[^{;]*?{([^}]*?)};?/g;
-    var CUSTOM_VAR_VALUE = /^var\(([^)]*?)\);?/;
-    var CUSTOM_VAR_USE = /(?:^|[;}\s])([^;{}]*?):[\s]*?var\(([^)]*)?\)/gim;
-    var CUSTOM_MIXIN_USE = /mixin\(([^)]*)\);?/gim;
+    // in order to tell if a rule uses a custom property, match
+      // ([\s\S]*var|@apply) and pass if there's not a { in the match
+    var CUSTOM_RULE_RX = /@apply|var/;
 
   })();
 </script>

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -16,12 +16,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     var baseAttachedCallback = Polymer.Base.attachedCallback;
     var baseSerializeValueToAttribute = Polymer.Base.serializeValueToAttribute;
+    var prepTemplate = Polymer.Base._prepTemplate;
 
     var nativeShadow = Polymer.Settings.useNativeShadow;
 
     // TODO(sorvell): consider if calculating properties and applying
     // styles with properties should be separate modules.
     Polymer.Base._addFeature({
+
+      _prepTemplate: function() {
+        prepTemplate.call(this);
+        // determine if element contains x-scope styling
+        this._hasXScopeStyles = this._styles && this._styles.some(function(s) {
+          return s.textContent.match(CUSTOM_RULE_RX);
+        });
+      },
 
       attachedCallback: function() {
         baseAttachedCallback.call(this);
@@ -31,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _updateOwnStyles: function() {
-        if (this.enableCustomStyleProperties) {
+        if (this._hasXScopeStyles) {
           this._styleProperties = this._computeStyleProperties();
           this._applyStyleProperties(this._styleProperties);
         }
@@ -50,7 +59,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var props = {}, styles = [Polymer.StyleDefaults.defaultSheet];
         var host = this.domHost;
         if (host) {
-          // enable finding styles in hosts without `enableStyleCustomProperties`
           if (!host._styleProperties) {
             host._styleProperties = host._computeStyleProperties();
           }
@@ -92,7 +100,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         hostNode = hostNode || this;
         // TODO(sorvell): file crbug, ':host' does not match element.
         if (this.elementMatches(rule.selector) ||
-          ((hostNode === this) && (rule.selector === ':host'))) {
+          ((hostNode === this) && 
+          (rule.selector === HOST || rule.selector === ROOT))) {
           // --g: var(--b); or --g: 5;
           this._collectPropertiesFromRule(rule, CUSTOM_VAR_ASSIGN, props);
           // --g: { ... }
@@ -115,13 +124,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      // given: --bar: red; --foo: var(--bar);
+      // make: --foo: red;
       _valueForCustomProperty: function(property, props) {
         var cv;
-        while ((typeof property === 'string') &&
-          (cv = property.match(CUSTOM_VAR_VALUE))) {
-          property = props[cv[1]];
+        if (property.match(';')) {
+          var parts = property.split(';');
+          for (var i=0; i<parts.length; i++) {
+            if (parts[i].match(CUSTOM_RULE_RX)) {
+              parts[i] = this._applyPropertiesToText(parts[i], props);
+            }
+          }
+          return parts.join(';');
+        } else {
+          while ((typeof property === 'string') &&
+            (cv = property.match(CUSTOM_VAR_VALUE))) {
+            property = props[cv[1]];
+          }
+          return property;
         }
-        return property;
       },
 
       // apply styles
@@ -299,9 +320,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _updateRootStyles: function(root) {
         // TODO(sorvell): temporary way to find local dom that needs
         // x-scope styling.
-        var scopeSelector = this._scopeCssViaAttr ?
-          '[' + SCOPE_NAME + '~=' + XSCOPE_NAME + ']' : '.' + XSCOPE_NAME;
-        var c$ = Polymer.dom(root).querySelectorAll(scopeSelector);
+        // var scopeSelector = this._scopeCssViaAttr ?
+        //   '[' + SCOPE_NAME + '~=' + XSCOPE_NAME + ']' : '.' + XSCOPE_NAME;
+        // var c$ = Polymer.dom(root).querySelectorAll(scopeSelector);
+        var c$ = Polymer.dom(root).querySelectorAll('[is-host]');
         for (var i=0, l= c$.length, c; (i<l) && (c=c$[i]); i++) {
           if (c.updateStyles) {
             c.updateStyles();
@@ -310,6 +332,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     });
+
+    /**
+     * Force all custom elements using cross scope custom properties,
+     * to update styling.
+     */
+    Polymer.updateStyles = function() {
+      Polymer.Base._updateRootStyles(document);
+    };
 
     var styleCache = {};
     function cacheStyle(is, style, scope, bag, styles) {
@@ -347,6 +377,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return true;
     }
 
+    var HOST = ':host';
+    var ROOT = ':root';
     var SCOPE_NAME= Polymer.StyleTransformer.SCOPE_NAME;
     var XSCOPE_NAME = 'x-scope';
     var SCOPE_PREFIX = '[' + SCOPE_NAME + '~=';

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -97,6 +97,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      // TODO(sorvell): optimization, this collection could 
+      // be done at prototype time!
+      // 
       // Test if a rule matches root crteria (:host or :root) and if so,
       // collect any custom properties into `props`.
       // these rules may already be shimmed and it's $ to reparse, 
@@ -293,9 +296,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var SCOPE_SUFFIX = ']';
     var HOST_SELECTOR_PREFIX = '(?:^|[^.])';
     var HOST_SELECTOR_SUFFIX = '($|[.:[\\s>+~])';
-    // in order to tell if a rule uses a custom property, match
-      // ([\s\S]*var|@apply) and pass if there's not a { in the match
-    var CUSTOM_RULE_RX = /@apply|var/;
 
   })();
 </script>

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -28,8 +28,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         prepTemplate.call(this);
         // determine if element contains x-scope styling
         this._hasXScopeStyles = this._styles && this._styles.some(function(s) {
-          return s.textContent.match(CUSTOM_RULE_RX);
-        });
+          return this._styleHasCustomRules(s);
+        }, this);
+      },
+
+      _styleHasCustomRules: function(style) {
+        return style.textContent.match(CUSTOM_RULE_RX);
       },
 
       attachedCallback: function() {
@@ -132,7 +136,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var parts = property.split(';');
           for (var i=0; i<parts.length; i++) {
             if (parts[i].match(CUSTOM_RULE_RX)) {
-              parts[i] = this._applyPropertiesToText(parts[i], props);
+              // remove trailing ;return
+              parts[i] = this._applyPropertiesToText(parts[i], props).slice(0, -2);
             }
           }
           return parts.join(';');
@@ -239,7 +244,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             output += '\t' + m[1].trim() + ': ' + this._propertyToCss(v);
           }
         }
-        // e.g. @mixin(--stuff);
+        // e.g. mixin(--stuff);
         while (m = CUSTOM_MIXIN_USE.exec(cssText)) {
           v = m[1];
           if (v) {
@@ -387,10 +392,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var HOST_SELECTOR_SUFFIX = '($|[.:[\\s>+~])';
     var CUSTOM_RULE_RX = /mixin|var/;
     var CUSTOM_VAR_ASSIGN = /(--[^\:;]*?):\s*?([^;{]*?);/g;
-    var CUSTOM_MIXIN_ASSIGN = /(--[^\:;]*?):[^{;]*?{([^}]*?)}/g;
-    var CUSTOM_VAR_VALUE = /^var\(([^)]*?)\)/;
+    var CUSTOM_MIXIN_ASSIGN = /(--[^\:;]*?):[^{;]*?{([^}]*?)};?/g;
+    var CUSTOM_VAR_VALUE = /^var\(([^)]*?)\);?/;
     var CUSTOM_VAR_USE = /(?:^|[;}\s])([^;{}]*?):[\s]*?var\(([^)]*)?\)/gim;
-    var CUSTOM_MIXIN_USE = /mixin\(([^)]*)\)/gim;
+    var CUSTOM_MIXIN_USE = /mixin\(([^)]*)\);?/gim;
 
   })();
 </script>

--- a/test/runner.html
+++ b/test/runner.html
@@ -38,7 +38,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/css-parse.html',
       'unit/styling-scoped.html',
       'unit/styling-remote.html',
-      'unit/x-style.html',
+      'unit/styling-cross-scope-var.html',
+      'unit/styling-cross-scope-apply.html',
+      'unit/custom-style.html',
       'unit/dynamic-import.html',
       'unit/x-repeat.html',
       'unit/x-if.html'

--- a/test/unit/custom-style-import.html
+++ b/test/unit/custom-style-import.html
@@ -1,0 +1,12 @@
+<style is="custom-style">
+  :root {
+
+    --import-var: 3px solid orange;
+
+    --import-mixin: {
+      border: 4px solid blue;
+    };
+
+    padding: 10px;
+  }
+</style>

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../polymer.html">
+  <link rel="import" href="custom-style-import.html">
   <style is="custom-style">
     x-bar {
       border: 1px solid red;
@@ -27,35 +28,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     :root {
 
-      /* broken within a mixin */
-      /*--shpoo: var(--nug);*/
-      
-      --nug: italic;
+      --italic: italic;
 
-      --boo: {
-        background-color: blue;        
+      --bag: {
+        margin: 1px;
+        border: 1px solid black;
       };
 
-      --zonk: {
-        mixin(--boo);
-      };
-
-      --foo: {
-        margin: 10px;
-        mixin(--zonk);
-      };
-
-      background: orange;
+      margin: 10px;
+      width: auto;
     }
   </style>
   <style is="custom-style">
-    .foo {
-      mixin(--foo);
+    .bag {
+      @apply(--bag);
+    }
+
+    .italic {
+      font-style: var(--italic);
+    }
+
+    .import-mixin {
+      @apply(--import-mixin);
+    }
+
+    .import-var {
+      border: var(--import-var);
     }
   </style>
 </head>
 <body>
-  <div class="foo">Hi there</div>
+  <div class="italic">italic</div>
+  <div class="bag">bag</div>
+
+  <div class="import-mixin">import-mixin</div>
+  <div class="import-var">import-var</div>
 
   <x-bar></x-bar>
 
@@ -63,16 +70,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <dom-module id="x-foo">
     <style>
-      div {
-        mixin(--foo);
+      :host {
+        display: block;
       }
 
-      x-bar {
-        mixin(--foo);
+      div {
+        @apply(--bag);
       }
     </style>
     <template>
-      <div>x-foo</div>
+      <div id="me">x-foo</div>
       <x-bar id="bar1"></x-bar>
       <x-bar id="bar2"></x-bar>
     </template>
@@ -80,8 +87,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <dom-module id="x-bar">
     <style>
-      div {
-        font-style: var(--shpoo);
+      :host {
+        display: block;
       }
     </style>
     <template>
@@ -120,11 +127,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertComputed(xFoo.$.bar2, '2px');
       });
 
+      test('custom properties registered as defaults', function() {
+        var props = Polymer.StyleDefaults.getProperties();
+        assert.property(props, '--italic');
+        assert.property(props, '--bag');
+      });
+
+      test('custom-styles apply normal and property values to main document', function() {
+        var bag = document.querySelector('.bag');
+        var italic = document.querySelector('.italic');
+        assertComputed(document.body, '10px', 'margin');
+        assertComputed(bag, '1px');
+        assertComputed(italic, 'italic', 'font-style');
+      });
+
+      test('imported custom-styles apply', function() {
+        assertComputed(document.body, '10px', 'padding');
+        var v = document.querySelector('.import-var');
+        var m = document.querySelector('.import-mixin');
+        assertComputed(v, '3px');
+        assertComputed(m, '4px');
+      });
+
+      test('custom-styles apply normal and property values to elements', function() {
+        var e = document.querySelector('x-foo').$.me;
+        assertComputed(e, '1px');
+      });
+
     });
 
-    function assertComputed(element, value) {
+
+    function assertComputed(element, value, property) {
       var computed = getComputedStyle(element);
-      assert.equal(computed['border-top-width'], value, 'computed style incorrect');
+      property = property || 'border-top-width';
+      assert.equal(computed[property], value, 'computed style incorrect');
     }
 
   </script>

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../polymer.html">
-  <style is="x-style">
+  <style is="custom-style">
     x-bar {
       border: 1px solid red;
       display: block;
@@ -26,12 +26,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     :root {
+
+      /* broken within a mixin */
+      /*--shpoo: var(--nug);*/
+      
       --nug: italic;
 
       --boo: {
-        background-color: tomato;
-        /* broken */
-        --shpoo: var(--nug);
+        background-color: blue;        
       };
 
       --zonk: {
@@ -41,12 +43,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       --foo: {
         margin: 10px;
         mixin(--zonk);
-      }
+      };
 
+      background: orange;
+    }
+  </style>
+  <style is="custom-style">
+    .foo {
+      mixin(--foo);
     }
   </style>
 </head>
 <body>
+  <div class="foo">Hi there</div>
+
   <x-bar></x-bar>
 
   <x-foo></x-foo>

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -480,6 +480,43 @@ suite('Polymer.dom non-distributed elements', function() {
     assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
+  test('getOwnerRoot when out of tree', function() {
+    var test = document.createElement('div');
+    assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect when not in root');
+    var c1 = document.createElement('x-compose');
+    var project = c1.$.project;
+    Polymer.dom(project).appendChild(test);
+    Polymer.dom.flush();
+    assert.equal(Polymer.dom(test).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for child added to element in root');
+    Polymer.dom(project).removeChild(test);
+    Polymer.dom.flush();
+    assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect for child moved from a root to no root');
+    Polymer.dom(project).appendChild(test);
+    Polymer.dom.flush();
+    assert.equal(Polymer.dom(test).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for child added to element in root');
+  });
+
+  test('getOwnerRoot, subtree', function() {
+    var test = document.createElement('div');
+    var testChild = document.createElement('div');
+    test.appendChild(testChild);
+    assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect when not in root');
+    var c1 = document.createElement('x-compose');
+    var project = c1.$.project;
+    Polymer.dom(project).appendChild(test);
+    Polymer.dom.flush();
+    assert.equal(Polymer.dom(test).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(Polymer.dom(testChild).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for sub-child added to element in root');
+    Polymer.dom(project).removeChild(test);
+    Polymer.dom.flush();
+    assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.notOk(Polymer.dom(testChild).getOwnerRoot(), 'getOwnerRoot incorrect for sub-child moved from a root to no root');
+    Polymer.dom(project).appendChild(test);
+    Polymer.dom.flush();
+    assert.equal(Polymer.dom(test).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(Polymer.dom(testChild).getOwnerRoot(), c1.root, 'getOwnerRoot incorrect for sub-child added to element in root');
+  });
+
   test('getOwnerRoot (paper-ripple use case)', function() {
     var test = document.createElement('div');
     // child

--- a/test/unit/shady.html
+++ b/test/unit/shady.html
@@ -27,7 +27,8 @@ function registerTestElement() {
   Polymer({
     is: 'x-content-test',
     _useContent: true,
-    _template: template
+    _template: template,
+    _encapsulateStyle: false
   });
   registered = true;
 }

--- a/test/unit/styling-cross-scope-apply.html
+++ b/test/unit/styling-cross-scope-apply.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+
+  <x-scope></x-scope>
+
+  <dom-module id="x-child-scope">
+    <style>
+      :host {
+        display: block;
+
+        --mixin2: {
+          border: 3px solid seagreen;
+        };
+      }
+      
+      #mixin1 {
+        @apply(--mixin1);
+      }
+
+      #mixin2 {
+        @apply(--mixin2);
+      }
+
+      #mixin3 {
+        padding: 3px;
+        @apply(--mixin3);
+      }
+
+      #mixin4 {
+        @apply(--mixin4);
+      }
+    </style>
+
+    <template>
+      <div id="mixin1">mixin1</div>
+      <div id="mixin2">mixin2</div>
+      <div id="mixin3">mixin3</div>
+      <div id="mixin4">mixin4</div>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-child-scope'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-scope">
+    <style>
+      :host {
+        display: block;
+        padding: 8px;
+
+        --mixin1: {
+          border: 1px solid black;
+        };
+
+        --b: 2px solid orange;
+
+        --m1: 1px;
+
+        --m2: 2px;
+
+        --mixin2: {
+          border: var(--b);
+        };
+
+        --mixin3: {
+          @apply(--mixin2);
+        };
+
+        --mixin4: {
+          padding: 2px;
+          @apply(--mixin3);
+          margin: var(--m2);
+        };
+      }
+
+      #mixin1 {
+        @apply(--mixin1);
+      }
+
+      #mixin2 {
+        @apply(--mixin2);
+      }
+
+      #mixin3 {
+        padding: 1px;
+        margin: var(--m1);
+        @apply(--mixin3);
+      }
+
+      #mixin4 {
+        @apply(--mixin4);
+      }
+
+      x-child-scope {
+        padding: 10px;
+      }
+
+    </style>
+
+    <template>
+      <div id="mixin1">mixin1</div>
+      <div id="mixin2">mixin2</div>
+      <div id="mixin3">mixin3</div>
+      <div id="mixin4">mixin4</div>
+      <hr>
+      <x-child-scope id="child"></x-child-scope>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-scope'});
+    });
+    </script>
+  </dom-module>
+
+
+<script>
+suite('scoped-styling-apply', function() {
+
+  function assertComputed(element, value, property) {
+    var computed = getComputedStyle(element);
+    property = property || 'border-top-width';
+    assert.equal(computed[property], value, 'computed style incorrect');
+  }
+
+  var styled = document.querySelector('x-scope');
+
+  test('variable mixins calculated correctly and inherit', function() {
+     var e = styled;
+     assert.property(e._styleProperties, '--mixin1');
+     assert.property(e._styleProperties, '--mixin2');
+     assert.property(e._styleProperties, '--mixin3');
+     assert.property(e._styleProperties, '--mixin4');
+     e = styled.$.child;
+     assert.property(e._styleProperties, '--mixin1');
+     assert.property(e._styleProperties, '--mixin2');
+     assert.property(e._styleProperties, '--mixin3');
+     assert.property(e._styleProperties, '--mixin4');
+  });
+
+  test('variable mixins apply', function() {
+    assertComputed(styled.$.mixin1, '1px');
+    assertComputed(styled.$.mixin2, '2px');
+    assertComputed(styled.$.mixin3, '2px');
+    assertComputed(styled.$.mixin3, '1px', 'padding');
+    assertComputed(styled.$.mixin3, '1px', 'margin');
+    assertComputed(styled.$.mixin4, '2px');
+    assertComputed(styled.$.mixin4, '2px', 'padding');
+    assertComputed(styled.$.mixin4, '2px', 'margin');
+  });
+
+  test('variable mixins inherit and override', function() {
+    var e = styled.$.child;
+    assertComputed(e.$.mixin1, '1px');
+    assertComputed(e.$.mixin2, '3px');
+    assertComputed(e.$.mixin3, '2px');
+    assertComputed(e.$.mixin3, '3px', 'padding');
+    assertComputed(e.$.mixin4, '2px');
+    assertComputed(e.$.mixin4, '2px', 'padding');
+    assertComputed(e.$.mixin4, '2px', 'margin');
+  });
+  
+});
+
+</script>
+</body>
+</html>

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+
+  <x-scope></x-scope>
+
+  <dom-module id="x-grand-child-scope">
+    <style>
+      :host {
+        display: block;
+        padding: 8px;
+      }
+
+      #scope {
+        border: var(--scope-var);
+      }
+
+      #child {
+        border: var(--child-scope-var);
+      }
+
+      #me {
+        border: var(--grand-child-scope-var);
+      }
+
+    </style>
+
+    <template>
+      <div id="me">x-grand-child-scope</div>
+      <div id="scope">From x-scope</div>
+      <div id="child">From x-child-scope</div>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-grand-child-scope'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-child-scope">
+    <style>
+      :host {
+        display: block;
+        padding: 8px;
+        --gc3-scope: 5px solid green;
+      }
+
+      #me {
+        border: var(--child-scope-var);
+      }
+
+      #gc2 {
+        --grand-child-scope-var: 4px solid seagreen;
+      }
+
+      #gc3 {
+        --grand-child-scope-var: var(--gc3-scope);
+      }
+    </style>
+
+    <template>
+      <div id="me">x-child-scope</div>
+      <x-grand-child-scope id="gc1"></x-grand-child-scope>
+      <x-grand-child-scope id="gc2"></x-grand-child-scope>
+      <x-grand-child-scope id="gc3"></x-grand-child-scope>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-child-scope'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-rename">
+    <style>
+      :host {
+        --grand-child-scope-var: var(--rename);
+      }
+    </style>
+
+    <template>
+      <x-grand-child-scope id="gc1"></x-grand-child-scope>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-rename'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-scope">
+    <style>
+      :host {
+        display: block;
+        padding: 8px;
+        --scope-var: 1px solid black;
+        --fallback: 7px solid orange;
+        --default1: var(--undefined, 6px solid yellow);
+        --default2: var(--undefined, --fallback);
+      }
+
+      #me {
+        border: var(--scope-var);
+      }
+
+      x-child-scope {
+        --child-scope-var: 2px solid orange;
+        --grand-child-scope-var: 3px solid steelblue;
+      }
+
+      #applyDefault1 {
+        border: var(--undefined, 6px solid yellow);
+      }
+
+      #applyDefault2 {
+        border: var(--undefined, --fallback);
+      }
+
+      #default1 {
+        border: var(--default1);
+      }
+
+      #default2 {
+        border: var(--default2);
+      }
+
+      #rename {
+        --rename: 8px solid navy;
+      }
+    </style>
+
+    <template>
+      <div id="me">x-scope</div>
+      <x-child-scope id="child"></x-child-scope>
+      <x-rename id="rename"></x-rename>
+      <div id="default1">default</div>
+      <div id="default2">var default</div>
+      <div id="applyDefault1">default</div>
+      <div id="applyDefault2">var default</div>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-scope'});
+    });
+    </script>
+  </dom-module>
+
+<script>
+  suite('scoped-styling-var', function() {
+
+  function assertComputed(element, value) {
+    var computed = getComputedStyle(element);
+    assert.equal(computed['border-top-width'], value, 'computed style incorrect');
+  }
+
+  function assertStylePropertyValue(properties, name, includeValue) {
+    assert.property(properties, name);
+    assert.include(properties[name], includeValue);
+  }
+
+  var styled = document.querySelector('x-scope');
+
+  test('simple variables calculated correctly between scopes', function() {
+     assertStylePropertyValue(styled._styleProperties, '--scope-var', '1px');
+     //
+     var child = styled.$.child;
+     assertStylePropertyValue(child._styleProperties, '--scope-var', '1px');
+     assertStylePropertyValue(child._styleProperties, '--child-scope-var', '2px');
+     assertStylePropertyValue(child._styleProperties, '--grand-child-scope-var', '3px');
+     //
+     var gc1 = child.$.gc1;
+     assertStylePropertyValue(gc1._styleProperties, '--scope-var', '1px');
+     assertStylePropertyValue(gc1._styleProperties, '--child-scope-var', '2px');
+     assertStylePropertyValue(gc1._styleProperties, '--grand-child-scope-var', '3px');
+     //
+     var gc2 = child.$.gc2;
+     assertStylePropertyValue(gc2._styleProperties, '--scope-var', '1px');
+     assertStylePropertyValue(gc2._styleProperties, '--child-scope-var', '2px');
+     assertStylePropertyValue(gc2._styleProperties, '--grand-child-scope-var', '4px');
+
+  });
+
+  test('simple variables applied correctly between scopes', function() {
+     assertComputed(styled.$.me, '1px');
+     assertComputed(styled.$.child.$.me, '2px');
+     assertComputed(styled.$.child.$.gc1.$.me, '3px');
+     assertComputed(styled.$.child.$.gc1.$.scope, '1px');
+     assertComputed(styled.$.child.$.gc1.$.child, '2px');
+     assertComputed(styled.$.child.$.gc2.$.me, '4px');
+     assertComputed(styled.$.child.$.gc2.$.scope, '1px');
+     assertComputed(styled.$.child.$.gc2.$.child, '2px');
+  });
+
+  test('variable can be set to another variable', function() {
+    var gc3 = styled.$.child.$.gc3;
+    assertStylePropertyValue(gc3._styleProperties, '--grand-child-scope-var', '5px');
+    assertComputed(gc3.$.me, '5px');
+  });
+
+  test('variable default values can be assigned to other variables', function() {
+    assertStylePropertyValue(styled._styleProperties, '--default1', '6px');
+    assertStylePropertyValue(styled._styleProperties, '--default2', '7px');
+    assertComputed(styled.$.default1, '6px');
+    assertComputed(styled.$.default2, '7px');
+    assertComputed(styled.$.applyDefault1, '6px');
+    assertComputed(styled.$.applyDefault2, '7px');
+  });
+  
+});
+
+</script>
+</body>
+</html>

--- a/test/unit/x-style.html
+++ b/test/unit/x-style.html
@@ -24,6 +24,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       border: 2px solid orange;
       display: block;
     }
+
+    :root {
+      --nug: italic;
+
+      --boo: {
+        background-color: tomato;
+        /* broken */
+        --shpoo: var(--nug);
+      };
+
+      --zonk: {
+        mixin(--boo);
+      };
+
+      --foo: {
+        margin: 10px;
+        mixin(--zonk);
+      }
+
+    }
   </style>
 </head>
 <body>
@@ -32,6 +52,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <x-foo></x-foo>
 
   <dom-module id="x-foo">
+    <style>
+      div {
+        mixin(--foo);
+      }
+
+      x-bar {
+        mixin(--foo);
+      }
+    </style>
     <template>
       <div>x-foo</div>
       <x-bar id="bar1"></x-bar>
@@ -40,6 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </dom-module>
 
   <dom-module id="x-bar">
+    <style>
+      div {
+        font-style: var(--shpoo);
+      }
+    </style>
     <template>
       <div>x-bar</div>
     </template>


### PR DESCRIPTION
* rename `x-style` --> `custom-style`
* rename `mixin` --> `@apply`
* support `:root` selector
* variable defaults` var(--a, red)`
* fixes bug: `c--foo:` is seen as a custom property
* consume variable, mixin inside mixin

   ```css
   --foo: {
      color: var(--my-color);
      @apply(--my-theme);
   };
   ```
* consume custom properties in `custom-style` (short-term workaround to support `@extend`-use case style sharing