### PR TITLE
Add commands to test build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,8 @@
 var gulp = require('gulp');
 var replace = require('gulp-replace');
 var shell = require('gulp-shell');
+var rename = require('gulp-rename');
+var runseq = require('run-sequence');
 var del = require('del');
 var fs = require('fs');
 var path = require('path');
@@ -13,7 +15,6 @@ function vulcanize(filename, dstdir, excludes) {
     excludes.forEach(function(exclude) {
       cmd = cmd + ' --exclude ' + exclude;
     });
-    cmd = cmd + ' --implicit-strip';
   }
   cmd = cmd + ' --strip-comments';
   cmd = cmd + ' ' + filename + ' > ' + path.join(dstdir, filename);
@@ -30,7 +31,7 @@ gulp.task('mini', ['mkdir'], shell.task(vulcanize(mini, workdir, [micro])));
 gulp.task('max', ['mkdir'], shell.task(vulcanize(max, workdir, [mini, micro])));
 
 gulp.task('strip', ['micro', 'mini', 'max'], function() {
-  return gulp.src(['dist/'+micro, 'dist/' + mini, 'dist/' + max])
+  return gulp.src(['dist/' + micro, 'dist/' + mini, 'dist/' + max])
     .pipe(polyclean.cleanJsComments())
     // Collapse newlines
     .pipe(replace(/\n\s*\n/g, '\n'))
@@ -40,16 +41,13 @@ gulp.task('strip', ['micro', 'mini', 'max'], function() {
     .pipe(replace('</head><body>\n</body></html>', ''))
     // Collapse leading spaces+tabs.
     .pipe(replace(/^[ \t]+/gm, ''))
-    // Restore important newlines
-    .pipe(replace(/(-->|<script>)/g, '$1\n'))
-    .pipe(replace(/<\/script>/g, '\n$1'))
     // put the out
     .pipe(gulp.dest('dist'))
     ;
 });
 
 gulp.task('clean', function(cb) {
-  del([workdir+'/'+micro, workdir+'/'+mini, workdir+'/'+max], cb);
+  del(workdir, cb);
 });
 
 gulp.task('mkdir', ['clean'], function(cb) {
@@ -60,3 +58,44 @@ gulp.task('mkdir', ['clean'], function(cb) {
 
 // Default Task
 gulp.task('default', ['strip']);
+
+// switch src and build for testing
+gulp.task('save-src', function() {
+  return gulp.src([mini, micro, max])
+  .pipe(rename(function (p) {
+    p.extname += '.bak';
+  }))
+  .pipe(gulp.dest('.'))
+  ;
+});
+
+gulp.task('restore-src', function() {
+  return gulp.src([mini + '.bak', micro + '.bak', max + '.bak'])
+  .pipe(rename(function (p) {
+    p.extname = '';
+  }))
+  .pipe(gulp.dest('.'))
+  ;
+});
+
+gulp.task('cleanup-switch', function(cb) {
+  del([mini + '.bak', micro + '.bak', max + '.bak'], cb);
+});
+
+gulp.task('switch-build', function() {
+  return gulp.src(['dist/' + mini, 'dist/' + micro, 'dist/' + max])
+  .pipe(gulp.dest('.'));
+});
+
+gulp.task('restore-build', function() {
+  return gulp.src([mini, micro, max])
+  .pipe(gulp.dest('dist'));
+});
+
+gulp.task('switch', ['default'], function(cb) {
+  runseq('save-src', 'switch-build', cb);
+});
+
+gulp.task('restore', ['clean'], function(cb) {
+  runseq('restore-build', 'restore-src', 'cleanup-switch', cb);
+});

--- a/package.json
+++ b/package.json
@@ -10,14 +10,17 @@
   "devDependencies": {
     "del": "^1.1.1",
     "gulp": "^3.8.11",
+    "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
     "gulp-shell": "^0.4.0",
     "polyclean": "0.0.1",
+    "run-sequence": "^1.1.0",
     "vulcanize": "^1.4.0"
   },
   "scripts": {
     "build": "node_modules/gulp/bin/gulp.js",
-    "test": "wct"
+    "test": "wct",
+    "test-build": "node_modules/gulp/bin/gulp.js switch && wct && node_modules/gulp/bin/gulp.js restore"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add gulp switch and gulp restore to swap between builds and src for testing
Add `npm run test-build` to automate it all
Fix build generation by removing newline inserter