### PR TITLE
Remove unused keyCodes enum

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -71,17 +71,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       node.addEventListener(eventName, handler);
     },
 
-    // TODO(dfreedm): remove when a11y keys element is ported
-    keyCodes: {
-      ESC_KEY: 27,
-      ENTER_KEY: 13,
-      LEFT: 37,
-      UP: 38,
-      RIGHT: 39,
-      DOWN: 40,
-      SPACE: 32
-    }
-
   });
 
 </script>


### PR DESCRIPTION
This depends on https://github.com/PolymerElements/iron-behaviors/pull/11 which removes the only usage of this enum.