### PR TITLE
Pass the index into the user defined filter function

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -370,7 +370,7 @@ Then the `observe` property should be configured as follows:
       // Apply user filter to keys
       if (this._filterFn) {
         this._orderedKeys = this._orderedKeys.filter(function(a) {
-          return this._filterFn(c.getItem(a));
+          return this._filterFn(c.getItem(a), a);
         }, this);
       }
       // Apply user sort to keys


### PR DESCRIPTION
This patch passes the index into the user defined filter function, this allows the user to define any function and receive the similiar signature that they would expect in a Array.filter call