### PR TITLE
Fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Beyond Github, we try to have a variety of different lines of communication open
 * [Twitter](https://twitter.com/polymer)
 * [Google+ Community](https://plus.sandbox.google.com/u/0/communities/115626364525706131031?cfem=1)
 * [Mailing list](https://groups.google.com/forum/#!forum/polymer-dev)
-* [Slack channel](bit.ly/polymerslack)
+* [Slack channel](https://bit.ly/polymerslack)
 
 ## The Polymer Repositories
 


### PR DESCRIPTION
Fix broken Slack Channel link by adding the protocol.