### PR TITLE
Fix for IE.

### DIFF
--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -107,7 +107,7 @@ Note, all features of `custom-style` are available when defining styles as part 
             rule.selector = 'body';
           }
           var css = rule.cssText = rule.parsedCssText;
-          if (rule.propertyInfo.cssText) {
+          if (rule.propertyInfo && rule.propertyInfo.cssText) {
             // TODO(sorvell): factor better
             // remove property assignments so next function isn't confused
             css = css.replace(propertyUtils.rx.VAR_ASSIGN, '');

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -165,7 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       applyProperties: function(rule, props) {
         var output = '';
         // dynamically added sheets may not be decorated so ensure they are.
-        if (!rule.properties) {
+        if (!rule.propertyInfo) {
           this.decorateRule(rule);
         }
         if (rule.propertyInfo.cssText) {


### PR DESCRIPTION
My website was not working on IE because the styles were missing -- and the IE javascript console said that it could not read "cssText" property. I dig down a little bit and found that this simple two-line patch makes it working perfectly on IE 11 as well as Chrome and Firefox. I haven't tested this on other versions of IE.

 * Ensure `rule.propertyInfo` is correctly set in style-properties.html.  It was checking a wrong attribute: `rule.properties` instead of `rule.propertyInfo` before calling `decorateRule()`.
 * Fix a condition check in custom-style.html when `rule.propertyInfo` is null or undefined.