### PR TITLE
Should camelize id names when creating this.$ automatic node finding object.

### DIFF
--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -226,11 +226,20 @@ TODO(sjmiles): this module should produce either syntactic metadata
     // construct `$` map (from id annotations)
     _marshalIdNodes: function() {
       this.$ = {};
-      this._notes.forEach(function(a) {
-        if (a.id) {
-          this.$[a.id] = this._findAnnotatedNode(this.root, a);
-        }
-      }, this);
+
+      if (this.camelizeIds === true) {
+        this._notes.forEach(function(a) {
+          if (a.id) {
+            this.$[Polymer.CaseMap.dashToCamelCase(a.id)] = this._findAnnotatedNode(this.root, a);
+          }
+        }, this);
+      } else {
+        this._notes.forEach(function(a) {
+          if (a.id) {
+            this.$[a.id] = this._findAnnotatedNode(this.root, a);
+          }
+        }, this);
+      }
     },
 
     // concretize `_nodes` map (from anonymous annotations)

--- a/test/runner.html
+++ b/test/runner.html
@@ -48,7 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dynamic-import.html',
       'unit/dom-repeat.html',
       'unit/dom-if.html',
-      'unit/dom-bind.html'
+      'unit/dom-bind.html',
+      'unit/node-id-marshaling.html'
     ]);
   </script>
 </body>

--- a/test/unit/node-id-marshaling-elements.html
+++ b/test/unit/node-id-marshaling-elements.html
@@ -1,0 +1,19 @@
+<dom-module id="x-node-id-marshaling">
+  <template>
+    <div id="node-with-dashes"></div>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is : 'x-node-id-marshaling',
+    camelizeIds: true,
+    ready: function () {
+
+      console.log('this.$.nodeWithDashes');
+      console.log(this.$.nodeWithDashes);
+      console.log("this.$['node-wtih-dashes']");
+      console.log(this.$['node-wtih-dashes']);
+    }
+  });
+</script>

--- a/test/unit/node-id-marshaling.html
+++ b/test/unit/node-id-marshaling.html
@@ -1,0 +1,29 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../../polymer.html">
+    <link rel="import" href="./node-id-marshaling-elements.html" />
+  </head>
+  <body>
+
+    <x-node-id-marshaling id="xNodeIdMarshaling"></x-node-id-marshaling>
+  </body>
+
+  <script>
+    describe('camelize node marshaling when assigning to this.$', function () {
+      var el;
+      beforeEach(function () {
+        el = document.querySelector('#xNodeIdMarshaling');
+      });
+
+      it ('should convert id="node-with-dashes" to this.$.nodeWithDashes', function () {
+
+        expect(el.$).to.not.be.undefined;
+        expect(el.$.nodeWithDashes).not.to.be.undefined;
+        expect(el.$['node-with-dashes']).to.be.undefined;
+      });
+    });
+  </script>
+</html>


### PR DESCRIPTION
I mentioned this in issue #1747 .

This PR would not make a breaking change. In order for ids with dashes to be camelized you would have to opt in by setting camelizeIds: true in your element.

```html
  <dom-module id="my-cool-element">
    <template>
      <div id="foo-element"></div>
    </template>
  </dom-module>
```
```javascript
Polymer({
  is: 'my-cool-element',
  camelizeIds: true,
  ready: function () {
    this.$.fooElement.innerHtml = 'foo';
  }
});
```
I wanted to figure out a way to set this config globally but I'm not sure if that makes sense.

This is the first PR I'm proposing to Polymer so please let me know if I should be doing anything differently.

Feedback appreciated.