### PR TITLE
Fixes #1757, do not resolve hash-only urls used for routing

### DIFF
--- a/src/lib/resolve-url.html
+++ b/src/lib/resolve-url.html
@@ -41,6 +41,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function resolve(url, ownerDocument) {
+      // do not resolve '#' links, they are used for routing
+      if (url && url[0] === '#') {
+        return url;
+      }      
       var resolver = getUrlResolver(ownerDocument);
       resolver.href = url;
       return resolver.href || url;


### PR DESCRIPTION
Fixes #1757 by applying the same fix that was used in 0.5 in #651:

https://github.com/Polymer/polymer/blob/c7169640c567fb9bc709207ecbd9f747f8df48d5/src/lib/url.js#L103-L106