### PR TITLE
Use gulp-vulcanize concurrently for faster builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-audit": "^1.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
-    "gulp-vulcanize": "^6.0.0",
+    "gulp-vulcanize": "^6.0.1",
     "lazypipe": "^0.2.3",
     "polyclean": "^1.2.0",
     "run-sequence": "^1.1.0"


### PR DESCRIPTION
Remove mkdir task, gulp.dest does that for us
Make clean an optional task, it is not necessary for most things