### PR TITLE
Fix jsdoc for splice

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -404,7 +404,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {number} start Index from which to start removing/inserting.
        * @param {number} deleteCount Number of items to remove.
        * @param {...any} var_args Items to insert into array.
-       * @return {number} New length of the array.
+       * @return {Array} Array of removed items.
        */
       splice: function(path, start, deleteCount) {
         var array = this.get(path);


### PR DESCRIPTION
`Array.prototype.splice` returns an Array, not a Number. You could also change the code to do what the docs say instead.