### PR TITLE
Use var keyword when declaring local variable so it doesn't leak to global scope.

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -270,7 +270,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       applyElementScopeSelector: function(element, selector, old, viaAttr) {
         var c = viaAttr ? element.getAttribute(styleTransformer.SCOPE_NAME) :
           element.className;
-        v = old ? c.replace(old, selector) :
+        var v = old ? c.replace(old, selector) :
           (c ? c + ' ' : '') + this.XSCOPE_NAME + ' ' + selector;
         if (c !== v) {
           if (viaAttr) {

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var globalCached = Boolean(info) && !scopeCached;
         // now we have properties and a cached style if one
         // is available.
-        style = this._applyStyleProperties(info);
+        var style = this._applyStyleProperties(info);
         // no cache so store in cache
         //console.warn(this, scopeCached, globalCached, info && info._scopeSelector);
         if (!scopeCached) {


### PR DESCRIPTION
It looks like `var` was forgotten in a couple places, causing `v` and `style` to leak to the global scope.