### PR TITLE
Fix incorrect test for `toggle`. Fixes #1810.

### DIFF
--- a/src/lib/template/array-selector.html
+++ b/src/lib/template/array-selector.html
@@ -153,8 +153,10 @@ is false, `selected` is a property representing the last selected item.  When
         var scol = Polymer.Collection.get(this.selected);
         var skey = scol.getKey(item);
         if (skey >= 0) {
-          this.deselect(item);
-        } else if (this.toggle) {
+          if (this.toggle) {
+            this.deselect(item);
+          }
+        } else {
           this.push('selected', item);
           // this.linkPaths('selected.' + sidx, 'items.' + skey);
           // skey = Polymer.Collection.get(this.selected).add(item);


### PR DESCRIPTION
Testing `toggle` on the incorrect branch of the `if` statement meant that  multi-select `array-selector` didn't work unless `toggle` was enabled. 

There don't appear to be any unit tests for `array-selector`, but with this fix the sample shown in #1810 works correctly without `toggle`.