### PR TITLE
Allow user prevention of `tap` and `track` gestures from `down`

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -152,7 +152,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _unlisten: function(node, eventName, handler) {
       node.removeEventListener(eventName, handler);
+    },
+
+    // IE does not set `defaultPrevented` on CustomEvents
+    __BROKEN_PREVENT_DEFAULT: (function() {
+      var ev = new CustomEvent('foo', {cancelable: true});
+      ev.preventDefault();
+      return !ev.defaultPrevented;
+    })(),
+
+    // fix IE's broken preventDefault()
+    __fixPreventDefault: function(ev) {
+      ev.preventDefault = function() {
+        Object.defineProperty(this, 'defaultPrevented', {
+          get: function() {
+            return true;
+          }
+        });
+      };
     }
+
   });
 
 </script>

--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -152,26 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _unlisten: function(node, eventName, handler) {
       node.removeEventListener(eventName, handler);
-    },
-
-    // IE does not set `defaultPrevented` on CustomEvents
-    __BROKEN_PREVENT_DEFAULT: (function() {
-      var ev = new CustomEvent('foo', {cancelable: true});
-      ev.preventDefault();
-      return !ev.defaultPrevented;
-    })(),
-
-    // fix IE's broken preventDefault()
-    __fixPreventDefault: function(ev) {
-      ev.preventDefault = function() {
-        Object.defineProperty(this, 'defaultPrevented', {
-          get: function() {
-            return true;
-          }
-        });
-      };
     }
-
   });
 
 </script>

--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -273,12 +273,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     fire: function(target, type, detail) {
-      var ev = new CustomEvent(type, {
-        detail: detail,
+      var ev = Polymer.Base.fire(type, detail, {
+        node: target,
         bubbles: true,
         cancelable: true
       });
-      target.dispatchEvent(ev);
 
       // forward `preventDefault` in a clean way
       if (ev.defaultPrevented) {

--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -73,7 +73,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   var POINTERSTATE = {
-    tapPrevented: false,
     mouse: {
       target: null,
       mouseIgnoreJob: null
@@ -98,7 +97,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     return ta;
   }
-
 
   var Gestures = {
     gestures: {},
@@ -252,6 +250,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    findRecognizerByEvent: function(evName) {
+      for (var i = 0, r; i < this.recognizers.length; i++) {
+        r = this.recognizers[i];
+        for (var j = 0, n; j < r.emits.length; j++) {
+          n = r.emits[j];
+          if (n === evName) {
+            return r;
+          }
+        }
+      }
+      return null;
+    },
+
     // set scrolling direction on node to check later on first move
     // must call this before adding event listeners!
     setTouchAction: function(node, value) {
@@ -268,6 +279,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         cancelable: true
       });
       target.dispatchEvent(ev);
+
+      // forward `preventDefault` in a clean way
+      if (ev.defaultPrevented) {
+        var se = detail.sourceEvent;
+        // sourceEvent may be a touch, which is not preventable this way
+        if (se && se.preventDefault) {
+          se.preventDefault();
+        }
+      }
+    },
+
+    prevent: function(evName) {
+      var recognizer = this.findRecognizerByEvent(evName);
+      if (recognizer.info) {
+        recognizer.info.prevent = true;
+      }
     }
   };
 
@@ -293,10 +320,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.fire('up', e.currentTarget, e.changedTouches[0]);
     },
     fire: function(type, target, event) {
+      var self = this;
       Gestures.fire(target, type, {
         x: event.clientX,
         y: event.clientY,
-        sourceEvent: event
+        sourceEvent: event,
+        prevent: Gestures.prevent.bind(Gestures)
       });
     }
   });
@@ -318,7 +347,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.moves.shift();
         }
         this.moves.push(move);
-      }
+      },
+      prevent: false
     },
 
     clearInfo: function() {
@@ -327,9 +357,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.info.moves = [];
       this.info.x = 0;
       this.info.y = 0;
+      this.info.prevent = false;
     },
 
     hasMovedEnough: function(x, y) {
+      if (this.info.prevent) {
+        return false;
+      }
       if (this.info.started) {
         return true;
       }
@@ -348,13 +382,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           self.info.state = self.info.started ? (e.type === 'mouseup' ? 'end' : 'track') : 'start';
           self.info.addMove({x: x, y: y});
           self.fire(t, e);
-          e.preventDefault();
           self.info.started = true;
         }
       };
       var upfn = function upfn(e) {
         if (self.info.started) {
-          POINTERSTATE.tapPrevented = true;
+          Gestures.prevent('tap');
           movefn(e);
         }
         self.clearInfo();
@@ -393,7 +426,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // only trackend if track was started and not aborted
       if (this.info.started) {
         // iff tracking, always prevent tap
-        POINTERSTATE.tapPrevented = true;
+        Gestures.prevent('tap');
         // reset started state on up
         this.info.state = 'end';
         this.info.addMove({x: ct.clientX, y: ct.clientY});
@@ -433,21 +466,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     name: 'tap',
     deps: ['mousedown', 'click', 'touchstart', 'touchend'],
     emits: ['tap'],
-    start: {
+    info: {
       x: NaN,
-      y: NaN
+      y: NaN,
+      prevent: false
     },
     reset: function() {
-      this.start.x = NaN;
-      this.start.y = NaN;
+      this.info.x = NaN;
+      this.info.y = NaN;
+      this.info.prevent = false;
     },
     save: function(e) {
-      this.start.x = e.clientX;
-      this.start.y = e.clientY;
+      this.info.x = e.clientX;
+      this.info.y = e.clientY;
     },
 
     mousedown: function(e) {
-      POINTERSTATE.tapPrevented = false;
       this.save(e);
     },
 
@@ -456,7 +490,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     touchstart: function(e) {
-      POINTERSTATE.tapPrevented = false;
       this.save(e.changedTouches[0]);
     },
     touchend: function(e) {
@@ -464,12 +497,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     forward: function(e) {
-      var dx = Math.abs(e.clientX - this.start.x);
-      var dy = Math.abs(e.clientY - this.start.y);
+      var dx = Math.abs(e.clientX - this.info.x);
+      var dy = Math.abs(e.clientY - this.info.y);
       // dx,dy can be NaN if `click` has been simulated and there was no `down` for `start`
       if (isNaN(dx) || isNaN(dy) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE)) {
         // prevent taps from being generated if an event has canceled them
-        if (!POINTERSTATE.tapPrevented) {
+        if (!this.info.prevent) {
           Gestures.fire(e.target, 'tap', {
             x: e.clientX,
             y: e.clientY,

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -164,9 +164,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         cancelable: cancelable,
         detail: detail
       });
-      if (cancelable && Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
-        Polymer.Base.__fixPreventDefault(event);
-      }
       node.dispatchEvent(event);
       return event;
     },

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -158,11 +158,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var node = options.node || this;
       var detail = (detail === null || detail === undefined) ? Polymer.nob : detail;
       var bubbles = options.bubbles === undefined ? true : options.bubbles;
+      var cancelable = Boolean(options.cancelable);
       var event = new CustomEvent(type, {
         bubbles: Boolean(bubbles),
-        cancelable: Boolean(options.cancelable),
+        cancelable: cancelable,
         detail: detail
       });
+      if (cancelable && Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
+        Polymer.Base.__fixPreventDefault(event);
+      }
       node.dispatchEvent(event);
       return event;
     },

--- a/test/smoke/gesture-import.html
+++ b/test/smoke/gesture-import.html
@@ -1,0 +1,58 @@
+<link rel="import" href="../../polymer.html">
+
+<dom-module id="x-gestures">
+  <template>
+    <style>
+      #inner {
+        height: 20px;
+        width: 20px;
+        background: blue;
+      }
+      #prevent {
+        height: 20px;
+        width: 20px;
+        background: red;
+      }
+    </style>
+    <div id="prevent" on-down="preventTap"></div>
+    <a href="#" on-click="linkclick" on-touchend="removeLink">LINK</a>
+    <div id="inner" on-tap="divtap"></div>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'x-gestures',
+    listeners: {
+      'tap': 'logger',
+      'down': 'logger',
+      'up': 'logger',
+      'click': 'logger',
+      'track': 'track'
+    },
+    preventTap: function(e, detail) {
+      detail.prevent('tap');
+      detail.prevent('track');
+      e.preventDefault();
+    },
+    logger: function(e, detail) {
+      console.log(e.type);
+      console.log(detail);
+    },
+    track: function(e, detail) {
+      this.logger(e, detail);
+      if (detail.state === 'end') {
+        console.log(detail.hover());
+      }
+    },
+    linkclick: function(e) {
+      console.log('CLICK!');
+    },
+    removeLink: function(e) {
+      console.log('REMOVE!');
+      e.target.remove();
+    },
+    divtap: function(e) {
+      console.log('div tap!');
+    }
+  });
+</script>

--- a/test/smoke/gestures.html
+++ b/test/smoke/gestures.html
@@ -24,7 +24,13 @@
             width: 20px;
             background: blue;
           }
+          #prevent {
+            height: 20px;
+            width: 20px;
+            background: red;
+          }
         </style>
+        <div id="prevent" on-down="preventTap"></div>
         <a href="#" on-click="linkclick" on-touchend="removeLink">LINK</a>
         <div id="inner" on-tap="divtap"></div>
       </template>
@@ -38,6 +44,11 @@
           'up': 'logger',
           'click': 'logger',
           'track': 'track'
+        },
+        preventTap: function(e, detail) {
+          detail.prevent('tap');
+          detail.prevent('track');
+          e.preventDefault();
         },
         logger: function(e, detail) {
           console.log(e.type);

--- a/test/smoke/gestures.html
+++ b/test/smoke/gestures.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
-    <link rel="import" href="../../polymer.html">
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="gesture-import.html">
     <title>Gestures Demo</title>
     <style>
       x-gestures {
@@ -16,61 +17,5 @@
   </head>
   <body>
     <x-gestures id="host"></x-gestures>
-    <dom-module id="x-gestures">
-      <template>
-        <style>
-          #inner {
-            height: 20px;
-            width: 20px;
-            background: blue;
-          }
-          #prevent {
-            height: 20px;
-            width: 20px;
-            background: red;
-          }
-        </style>
-        <div id="prevent" on-down="preventTap"></div>
-        <a href="#" on-click="linkclick" on-touchend="removeLink">LINK</a>
-        <div id="inner" on-tap="divtap"></div>
-      </template>
-    </dom-module>
-    <script>
-      Polymer({
-        is: 'x-gestures',
-        listeners: {
-          'tap': 'logger',
-          'down': 'logger',
-          'up': 'logger',
-          'click': 'logger',
-          'track': 'track'
-        },
-        preventTap: function(e, detail) {
-          detail.prevent('tap');
-          detail.prevent('track');
-          e.preventDefault();
-        },
-        logger: function(e, detail) {
-          console.log(e.type);
-          console.log(detail);
-        },
-        track: function(e, detail) {
-          this.logger(e, detail);
-          if (detail.state === 'end') {
-            console.log(detail.hover());
-          }
-        },
-        linkclick: function(e) {
-          console.log('CLICK!');
-        },
-        removeLink: function(e) {
-          console.log('REMOVE!');
-          e.target.remove();
-        },
-        divtap: function(e) {
-          console.log('div tap!');
-        }
-      });
-    </script>
   </body>
 </html>

--- a/test/unit/gestures-elements.html
+++ b/test/unit/gestures-elements.html
@@ -85,3 +85,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </dom-module>
+
+<dom-module id="x-prevent">
+  <script>
+    Polymer({
+      listeners: {
+        'down': 'prevent',
+        'up': 'handle',
+        'tap': 'handle',
+        'track': 'handle'
+      },
+      is: 'x-prevent',
+      created: function() {
+        this.stream = [];
+      },
+      handle: function(e) {
+        this.stream.push(e);
+      },
+      prevent: function(e, detail) {
+        detail.prevent('tap');
+        detail.prevent('track');
+        e.preventDefault();
+        this.handle(e);
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -218,6 +218,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    suite('Prevention', function() {
+      var el;
+      setup(function() {
+        el = document.createElement('x-prevent');
+        document.body.appendChild(el);
+      });
+      teardown(function() {
+        el.parentNode.removeChild(el);
+      });
+
+      test('tap', function() {
+        var ev = new CustomEvent('mousedown', {
+          cancelable: true
+        });
+        el.dispatchEvent(ev);
+        assert.equal(el.stream.length, 1);
+        assert.equal(el.stream[0].type, 'down');
+        assert.equal(el.stream[0].defaultPrevented, true);
+        assert.equal(ev.defaultPrevented, true);
+      });
+
+      test('track', function() {
+        var ev = new CustomEvent('mousedown', {
+          cancelable: true
+        });
+        ev.clientX = ev.clientY = 0;
+        el.dispatchEvent(ev);
+        assert.equal(el.stream.length, 1);
+        for (var i = 0; i < 10; i++) {
+          ev = new CustomEvent(
+            i === 9 ? 'mouseup' : 'mousemove',
+            {bubbles: true}
+          );
+          ev.clientX = ev.clientY = 10 * i;
+          el.dispatchEvent(ev);
+        }
+        assert.equal(el.stream.length, 2);
+        assert.equal(el.stream[0].type, 'down');
+        assert.equal(el.stream[0].defaultPrevented, true);
+        assert.equal(el.stream[1].type, 'up');
+      });
+    });
+
     // TODO(dfreedm): Add more gesture tests!
 
   </script>

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -230,39 +230,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('tap', function() {
         var ev = new CustomEvent('mousedown', {
+          bubbles: true,
           cancelable: true
         });
+        if (Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
+          Polymer.Base.__fixPreventDefault(ev);
+        }
         el.dispatchEvent(ev);
-        assert.equal(el.stream.length, 1);
-        assert.equal(el.stream[0].type, 'down');
-        assert.equal(el.stream[0].defaultPrevented, true);
-        assert.equal(ev.defaultPrevented, true);
+        assert.equal(el.stream.length, 1, 'one event dispatched');
+        assert.equal(el.stream[0].type, 'down', 'was down event');
+        assert.equal(el.stream[0].defaultPrevented, true, 'was prevented');
+        assert.equal(ev.defaultPrevented, true, 'base event was prevented');
       });
 
       test('track', function() {
         var ev = new CustomEvent('mousedown', {
+          bubbles: true,
           cancelable: true
         });
+        if (Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
+          Polymer.Base.__fixPreventDefault(ev);
+        }
         ev.clientX = ev.clientY = 0;
         el.dispatchEvent(ev);
         assert.equal(el.stream.length, 1);
         for (var i = 0; i < 10; i++) {
           ev = new CustomEvent(
             i === 9 ? 'mouseup' : 'mousemove',
-            {bubbles: true}
+            {bubbles: true, cancelable: true}
           );
           ev.clientX = ev.clientY = 10 * i;
           el.dispatchEvent(ev);
         }
-        assert.equal(el.stream.length, 2);
-        assert.equal(el.stream[0].type, 'down');
-        assert.equal(el.stream[0].defaultPrevented, true);
-        assert.equal(el.stream[1].type, 'up');
+        assert.equal(el.stream.length, 2, 'expected only down and up');
+        assert.equal(el.stream[0].type, 'down', 'down was found');
+        assert.equal(el.stream[0].defaultPrevented, true, 'down was prevented');
+        assert.equal(el.stream[1].type, 'up', 'up was found');
       });
     });
-
-    // TODO(dfreedm): Add more gesture tests!
-
   </script>
 
 </body>

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -233,9 +233,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           bubbles: true,
           cancelable: true
         });
-        if (Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
-          Polymer.Base.__fixPreventDefault(ev);
-        }
         el.dispatchEvent(ev);
         assert.equal(el.stream.length, 1, 'one event dispatched');
         assert.equal(el.stream[0].type, 'down', 'was down event');
@@ -248,9 +245,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           bubbles: true,
           cancelable: true
         });
-        if (Polymer.Base.__BROKEN_PREVENT_DEFAULT) {
-          Polymer.Base.__fixPreventDefault(ev);
-        }
         ev.clientX = ev.clientY = 0;
         el.dispatchEvent(ev);
         assert.equal(el.stream.length, 1);


### PR DESCRIPTION
New API: `event.detail.prevent('tap')` and `event.detail.prevent('track')`
Fixes #1823

Forward `preventDefault` from gesture events to source events

`gesture.preventDefault()` is equivalent to
`gesture.detail.sourceEvent.preventDefault()`

Remove `preventDefault()` on mousemove in track, user must use
`track.preventDefault()` to hide user selection or use `user-select:none`
Fixes #1824
Fixes https://github.com/PolymerElements/paper-drawer-panel/issues/50