### PR TITLE
simplify splice

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -412,9 +412,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       splice: function(path, start, deleteCount) {
         var array = this.get(path);
         var args = Array.prototype.slice.call(arguments, 1);
-        var rem = array.slice(start, start + deleteCount);
         var ret = array.splice.apply(array, args);
-        this._notifySplice(array, path, start, args.length - 2, rem);
+        this._notifySplice(array, path, start, args.length - 2, ret);
         return ret;
       },
 


### PR DESCRIPTION
After #1820, I now noticed that `rem` and `ret` are actually the same.