### PR TITLE
dom-template: parentProps should not override argument based props

### DIFF
--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -277,7 +277,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       model = model || {};
       if (this._parentProps) {
         for (var prop in this._parentProps) {
-          model[prop] = this['_parent_' + prop];
+          if (!model[prop]) {
+            model[prop] = this['_parent_' + prop];
+          }
         }
       }
       return new this.ctor(model, this);

--- a/test/unit/template/dom-template.html
+++ b/test/unit/template/dom-template.html
@@ -21,6 +21,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <span>{{text}}</span>
 </template>
 
+<dom-module id="test-dom-template">
+  <template>
+    <template is="dom-template" id="tmpl">
+      <span>{{text}}</span>
+    </template>
+  </template>
+  <script>
+    Polymer({
+      is: 'test-dom-template',
+
+      properties: {
+        value: String
+      },
+
+      ready: function() {
+
+        var tmpl = this.$.tmpl.stamp({
+          text: 'ohai'
+        });
+
+        this.value = tmpl.root.textContent.trim();
+      }
+    });
+  </script>
+</dom-module>
+
+<test-dom-template id="testDom"></test-dom-template>
+
 <script>
 
 suite('<dom-template>', function() {
@@ -29,6 +57,11 @@ suite('<dom-template>', function() {
     var template = document.querySelector('#bound');
     var row = template.stamp({text: 'ohai'});
     assert.equal(row.root.textContent.trim(), 'ohai');
+  });
+
+  test('stamps within an element', function() {
+    var template = document.querySelector('#testDom');
+    assert.equal(template.value, 'ohai');
   });
 
 });


### PR DESCRIPTION
found an issue in dom-template in which parentProps overrides the model that is provided in arguments