### PR TITLE
Includes element defaults in the list of own properties by which elements are styled.

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -98,6 +98,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var m;
         while (m = this.rx.VAR_CAPTURE.exec(cssText)) {
           props[m[1]] = true;
+          var def = m[2];
+          if (def && def.match(this.rx.IS_VAR)) {
+            props[def] = true;
+          }
         }
       },
 
@@ -336,6 +340,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // var(--a, fallback-literal(with-one-nested-parens))
         VAR_MATCH: /(^|\W+)var\([\s]*([^,)]*)[\s]*,?[\s]*((?:[^,)]*)|(?:[^;]*\([^;)]*\)))[\s]*?\)/gim,
         VAR_CAPTURE: /\([\s]*(--[^,\s)]*)(?:,[\s]*(--[^,\s)]*))?(?:\)|,)/gim,
+        IS_VAR: /^--/,
         BRACKETED: /\{[^}]*\}/g,
         HOST_PREFIX: '(?:^|[^.])',
         HOST_SUFFIX: '($|[.:[\\s>+~])'

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -199,6 +199,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </script>
   </dom-module>
 
+  <dom-module id="x-has-def">
+    <style>
+      :host {
+        border: var(--border, --defaultBorder);
+        margin: 8px;
+        padding: 8px;
+        display: block;
+      }
+    </style>
+
+    <template>
+      Element with default variable.
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-has-def'});
+    });
+    </script>
+  </dom-module>
+
   <dom-module id="x-has-if">
     <style>
       .iffy {
@@ -254,6 +274,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         --default1: var(--undefined, 6px solid yellow);
         --default2: var(--undefined, --fallback);
         --default3: var(--undefined, rgb(128, 200, 250));
+        --defaultBorder: 22px solid green;
         --a: 10px;
         --b: 5px;
         --primary-color: rgb(128, 128, 128);
@@ -295,6 +316,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       #default3 {
         padding: 8px;
         background-color: var(--default3);
+      }
+
+      #defaultElement2 {
+        --defaultBorder: 23px solid goldenrod;
       }
 
       #overrides1a, #overrides1b, #overrides2 {
@@ -341,6 +366,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div id="default1">default</div>
       <div id="default2">var default</div>
       <div id="default3">tricky property rgb(...) default</div>
+      <x-has-def id="defaultElement1"></x-has-def>
+      <x-has-def id="defaultElement2"></x-has-def>
       <div id="applyDefault1">default</div>
       <div id="applyDefault2">var default</div>
       <div id="calc">Calc</div>
@@ -502,6 +529,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   test('pseudo-elements can consume custom properties', function() {
     assertComputed(styled.$.after, '17px', '::after');
+  });
+
+  test('elements using only variable defaults are styled properly', function() {
+    assertComputed(styled.$.defaultElement1, '22px');
+    assertComputed(styled.$.defaultElement2, '23px');
   });
   
 });


### PR DESCRIPTION
Fixes #1752 where an element that uses only values supplied by variable defaults can be incorrectly styled.