### PR TITLE
ensure module's behaviors list is a unique list of behaviors

### DIFF
--- a/src/micro/behaviors.html
+++ b/src/micro/behaviors.html
@@ -60,9 +60,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _prepBehaviors: function() {
       if (this.behaviors.length) {
-        this.behaviors = this._flattenBehaviorsList(this.behaviors);
+        this.behaviors = this._behaviorsSet(this._flattenBehaviorsList(this.behaviors));
       }
       this._prepAllBehaviors(this.behaviors);
+    },
+
+    _behaviorsSet: function (array) {
+        var setArr = [];
+        // reverse loop to ensure we keep the last duplicated behaviors in the list 
+        // rather than the first for methods invocation order
+        for (var i = array.length - 1; i >= 0; i--) {
+            if (setArr.indexOf(array[i]) == -1) {
+                setArr.splice(0, 0, array[i]);
+            }
+        }
+        return setArr;
     },
 
     _flattenBehaviorsList: function(behaviors) {

--- a/test/unit/behaviors-elements.html
+++ b/test/unit/behaviors-elements.html
@@ -139,6 +139,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       behaviors: [
         Polymer.BehaviorA,
+        Polymer.BehaviorA,
+        null,
+        Polymer.BehaviorB,
         null,
         Polymer.BehaviorB
       ],
@@ -209,7 +212,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
 
       behaviors: [
-        [[Polymer.BehaviorC, Polymer.BehaviorB], Polymer.BehaviorA],
+        [[Polymer.BehaviorC, Polymer.BehaviorB], Polymer.BehaviorB, Polymer.BehaviorA], Polymer.BehaviorA, Polymer.BehaviorC,
         Polymer.BehaviorD
       ]
 

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -117,6 +117,10 @@ suite('multi-behaviors element', function() {
     assert.equal(el.attributes.user.value, 'user', 'Behavior hostAttribute overrode user attribute');
   });
 
+  test('behaviors duplicates filtering', function() {
+    assert.equal(el.behaviors.length, 2, 'Behavior list contains duplicates');
+  });
+
 });
 
 
@@ -140,6 +144,15 @@ suite('nested-behaviors element', function() {
     assert.ok(el.hasBehaviorD, "missing BehaviorD");
     assert.equal(el._simpleProperty, 'D', 'Behavior simple property was not overridden by sub-behavior');
   });
+
+  test('behaviors duplicates filtering', function() {
+    assert.equal(el.behaviors.length, 4, 'Behavior list contains duplicates');
+  });
+
+  test('behaviors duplicates filtering keeps last duplicated behavior', function() {
+    assert(el.behaviors[2].properties.hasBehaviorC, 'Duplicate filtered behavior list order wrong');
+  });
+
 
 });
 


### PR DESCRIPTION
I came into an issue while using behaviors in my project where I end up having modules that have their in memory behaviors array containing multiple instance of the same behavior.
This is partly due to how I use behaviors, but I also think _flattenBehaviorsList should make sure the final array of behaviors a module is assigned to is a set of unique behaviors.

Here's why I end up with duplicate behaviors:
Module A has behaviors B1 and B2
Behaviors B1 itself has behavior B2.

Module A in memory behaviors array currently ends up being [B1, B2, B2].

Now I did write my code that way because from Module A POV, I do not think it should make the assumption that behavior B1 already it "behaviored" with B2. If Module A needs behavior B2 functionality, it just makes it clear in its behaviors list rather than relying on B1 already having B2.

This is a problem because on any property change with observers on behavior B2, change callback will be called twice! Which in my implementation case ends up being two HTTP request being fired.