### PR TITLE
Refer to globals explicitly using window.[property].

### DIFF
--- a/src/lib/async.html
+++ b/src/lib/async.html
@@ -52,7 +52,7 @@ Polymer.Async = (function() {
     lastVal += len;
   }
 
-  new (window.MutationObserver || JsMutationObserver)(atEndOfMicrotask)
+  new (window.MutationObserver || window.JsMutationObserver)(atEndOfMicrotask)
     .observe(twiddle, {characterData: true})
     ;
   

--- a/src/lib/dom-module.html
+++ b/src/lib/dom-module.html
@@ -44,21 +44,21 @@
   // imports tree. (Note: this should only upgrade any imports that have been
   // loaded by this point. In addition the HTMLImports polyfill should be
   // changed to upgrade elements prior to running any scripts.)
-  var cePolyfill = window.CustomElements && !CustomElements.useNative;
+  var cePolyfill = window.CustomElements && !window.CustomElements.useNative;
   if (cePolyfill) {
-    var ready = CustomElements.ready;
-    CustomElements.ready = true;
+    var ready = window.CustomElements.ready;
+    window.CustomElements.ready = true;
   }
   document.registerElement('dom-module', DomModule);
   if (cePolyfill) {
-    CustomElements.ready = ready;
+    window.CustomElements.ready = ready;
   }
 
   function forceDocumentUpgrade() {
     if (cePolyfill) {
       var script = document._currentScript || document.currentScript;
       if (script) {
-        CustomElements.upgradeAll(script.ownerDocument);
+        window.CustomElements.upgradeAll(script.ownerDocument);
       }
     }
   }

--- a/src/lib/experimental/style-auditor.html
+++ b/src/lib/experimental/style-auditor.html
@@ -1,5 +1,5 @@
 <script>
-addEventListener('WebComponentsReady', function() {
+window.addEventListener('WebComponentsReady', function() {
 
   // given a list of elements, produce a report of rules that
   // match those elements.

--- a/src/lib/experimental/style-protector.html
+++ b/src/lib/experimental/style-protector.html
@@ -46,7 +46,7 @@
     SCOPE_ATTR: 'needs-scoping'
   };
 
-  addEventListener('DOMContentLoaded', styleProtector.scopeDocumentSheets());
+  window.addEventListener('DOMContentLoaded', styleProtector.scopeDocumentSheets());
 
 })();
 </script>

--- a/src/lib/imports-status.html
+++ b/src/lib/imports-status.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   if (window.HTMLImports) {
-    HTMLImports.whenReady(function() {
+    window.HTMLImports.whenReady(function() {
       Polymer.ImportStatus._importsLoaded();
     });
   }

--- a/src/lib/unresolved.html
+++ b/src/lib/unresolved.html
@@ -20,12 +20,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   if (window.WebComponents) {
-    addEventListener('WebComponentsReady', resolve);
+    window.addEventListener('WebComponentsReady', resolve);
   } else {
     if (document.readyState === 'interactive' || document.readyState === 'complete') {
       resolve();
     } else {
-      addEventListener('DOMContentLoaded', resolve);
+      window.addEventListener('DOMContentLoaded', resolve);
     }
   }
 

--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -451,12 +451,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
-    var needsUpgrade = window.CustomElements && !CustomElements.useNative;
+    var needsUpgrade = window.CustomElements && !window.CustomElements.useNative;
 
     function upgradeLightChildren(children) {
       if (needsUpgrade && children) {
         for (var i=0; i < children.length; i++) {
-          CustomElements.upgrade(children[i]);
+          window.CustomElements.upgrade(children[i]);
         }
       }
     }


### PR DESCRIPTION
Makes Polymer a little more friendly to Closure compilation.