### PR TITLE
Use single-property observer to deal better with if=undefined. Fixes #1742

### DIFF
--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -44,7 +44,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       'if': {
         type: Boolean,
-        value: false
+        value: false,
+        observer: '_queueRender'
       },
 
       /**
@@ -56,17 +57,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       restamp: {
         type: Boolean,
-        value: false
+        value: false,
+        observer: '_queueRender'
       }
 
     },
 
     behaviors: [
       Polymer.Templatizer
-    ],
-
-    observers: [
-      '_queueRender(if, restamp)'
     ],
 
     _queueRender: function() {

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -48,6 +48,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </div>
 
+  <div id="structuredContainer">
+    <template is="dom-bind" id="structuredDomBind">
+      <template is="dom-if" id="structuredDomIf" if="{{item.show}}">
+        <div class="showing"></div>
+      </template>
+    </template>
+  </div>
+
   <script>
 
     suite('nested pre-configured dom-if', function() {
@@ -413,6 +421,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(stamped2[1].prop, 'bar');
         assert.equal(stamped2[2].prop, 'bar');
       });
+    });
+
+    suite('structured data controlling if', function() {
+
+      test('item changed with no if field', function() {
+        var showing;
+        showing = structuredContainer.querySelector('.showing');
+        assert.notOk(showing);
+        structuredDomBind.item = {show: true};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.ok(showing);
+        assert.equal(getComputedStyle(showing).display, 'block');
+        structuredDomBind.item = {};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.ok(showing);
+        assert.equal(getComputedStyle(showing).display, 'none');
+        structuredDomBind.item = {show: true};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.ok(showing);
+        assert.equal(getComputedStyle(showing).display, 'block');
+      });
+
+      test('item changed with no if field (restamp)', function() {
+        var showing;
+        structuredDomIf.restamp = true;
+        structuredDomIf.if = false;
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.notOk(showing);
+        structuredDomBind.item = {show: true};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.ok(showing);
+        structuredDomBind.item = {};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.notOk(showing);
+        structuredDomBind.item = {show: true};
+        structuredDomIf.render();
+        showing = structuredContainer.querySelector('.showing');
+        assert.ok(showing);
+      });
+
     });
 
   </script>


### PR DESCRIPTION
This takes advantage of the fact that single property observers are called for each change (including undefined), whereas multi-property observers wait for all properties to be defined.  Since the side-effect of the observe is to queue an async render, there is no real benefit from this being a multi-property observer.  #1946 is open to track a more general fix for this issue.