### PR TITLE
Custom property parsing fixes

### DIFF
--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -154,10 +154,10 @@ Polymer.CssParse = (function() {
   var rx = {
     comments: /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim,
     port: /@import[^;]*;/gim,
-    customProp: /(?:^|[\s;])--[^;{]*?:[^{};]*?;/gim,
-    mixinProp: /(?:^|[\s;])--[^;{]*?:[^{;]*?{[^}]*?};?/gim,
-    mixinApply: /@apply[\s]*\([^)]*?\)[\s]*;/gim,
-    varApply: /[^;:]*?:[^;]*var[^;]*;/gim,
+    customProp: /(?:^|[\s;])--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
+    mixinProp: /(?:^|[\s;])--[^;{]*?:[^{;]*?{[^}]*?}(?:[;\n]|$)?/gim,
+    mixinApply: /@apply[\s]*\([^)]*?\)[\s]*(?:[;\n]|$)?/gim,
+    varApply: /[^;:]*?:[^;]*var[^;]*(?:[;\n]|$)?/gim,
     keyframesRule: /^@[^\s]*keyframes/,
   };
 

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -473,6 +473,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       toggle: function() {
         this.node.classList.toggle.apply(this.node.classList, arguments);
         this.domApi._distributeParent();
+      },
+      contains: function() {
+        return this.node.classList.contains.apply(this.node.classList, 
+          arguments);
       }
     }
 

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -343,8 +343,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       rx: {
-        VAR_ASSIGN: /(?:^|[;\n}]\s*)(--[^\:;]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n}])|$)/gim,
-        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)[;\n}]?/im, 
+        VAR_ASSIGN: /(?:^|[;\n}]\s*)(--[\w-]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n])|$)/gim,
+        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)/im, 
         // note, this supports:
         // var(--a)
         // var(--a, --b)

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -84,14 +84,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // but not production, so strip out {...}
         cssText = cssText.replace(this.rx.BRACKETED, '')
           .replace(this.rx.VAR_ASSIGN, '');
-        var parts = cssText.split(';');
-        for (var i=0, p; i<parts.length; i++) {
-          p = parts[i];
-          if (p.match(this.rx.MIXIN_MATCH) || p.match(this.rx.VAR_MATCH)) {
-            customCssText += p + ';\n';
-          }
+        // If any custom properties are used, then return the entire
+        // declaration. This avoids some specificity issues with splitting
+        // delcarations into separate styles.
+        if (cssText.match(this.rx.MIXIN_MATCH) || 
+          cssText.match(this.rx.VAR_MATCH)) {
+          return cssText;
         }
-        return customCssText;
       },
 
       collectPropertiesInCssText: function(cssText, props) {
@@ -344,8 +343,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       rx: {
-        VAR_ASSIGN: /(?:^|;\s*)(--[^\:;]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?=;)/gim,
-        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\);?/im, 
+        VAR_ASSIGN: /(?:^|[;\n}]\s*)(--[^\:;]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n}])|$)/gim,
+        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)[;\n}]?/im, 
         // note, this supports:
         // var(--a)
         // var(--a, --b)
@@ -355,7 +354,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         VAR_CAPTURE: /\([\s]*(--[^,\s)]*)(?:,[\s]*(--[^,\s)]*))?(?:\)|,)/gim,
         IS_VAR: /^--/,
         BRACKETED: /\{[^}]*\}/g,
-        HOST_PREFIX: '(?:^|[^.])',
+        HOST_PREFIX: '(?:^|[^.#[:])',
         HOST_SUFFIX: '($|[.:[\\s>+~])'
       },
 

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -343,7 +343,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       rx: {
-        VAR_ASSIGN: /(?:^|[;\n}]\s*)(--[\w-]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n])|$)/gim,
+        VAR_ASSIGN: /(?:^|[;\n]\s*)(--[\w-]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n])|$)/gim,
         MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)/im, 
         // note, this supports:
         // var(--a)

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -160,18 +160,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var self = this;
         selector = selector.replace(SIMPLE_SELECTOR_SEP, function(m, c, s) {
           if (!stop) {
-            var o = self._transformCompoundSelector(s, c, scope, hostScope);
-            stop = stop || o.stop;
-            hostContext = hostContext || o.hostContext;
-            c = o.combinator;
-            s = o.value;  
+            var info = self._transformCompoundSelector(s, c, scope, hostScope);
+            stop = stop || info.stop;
+            hostContext = hostContext || info.hostContext;
+            c = info.combinator;
+            s = info.value;  
           } else {
             s = s.replace(SCOPE_JUMP, ' ');
           }
           return c + s;
         });
         if (hostContext) {
-          selector = selector.replace(CONTEXT_MARKER_MATCH, 
+          selector = selector.replace(HOST_CONTEXT_PAREN, 
             function(m, pre, paren, post) {
               return pre + paren + ' ' + hostScope + post + 
                 COMPLEX_SELECTOR_SEP + ' ' + pre + hostScope + paren + post;
@@ -185,11 +185,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var jumpIndex = selector.search(SCOPE_JUMP);
         var hostContext = false;
         if (selector.indexOf(HOST_CONTEXT) >=0) {
-          // :host-context(...) -> ##...##
-          selector = selector.replace(HOST_CONTEXT_PAREN, function(m, host, paren) {
-            hostContext = true;
-            return CONTEXT_MARKER + paren + CONTEXT_MARKER;
-          });
+          hostContext = true;
         } else if (selector.indexOf(HOST) >=0) {
           // :host(...) -> scopeName...
           selector = selector.replace(HOST_PAREN, function(m, host, paren) {
@@ -259,9 +255,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // parsing which seems like overkill
     var HOST_PAREN = /(\:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
     var HOST_CONTEXT = ':host-context';
-    var HOST_CONTEXT_PAREN = /(\:host-context)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
-    var CONTEXT_MARKER = '##';
-    var CONTEXT_MARKER_MATCH = /(.*)##(.*)##(.*)/;
+    var HOST_CONTEXT_PAREN = /(.*)(?:\:host-context)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))(.*)/;
     var CONTENT = '::content';
     var SCOPE_JUMP = /\:\:content|\:\:shadow|\/deep\//;
     var CSS_CLASS_PREFIX = '.';

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
      * ::shadow, /deep/: processed simimlar to ::content
 
-     * :host-context(...): NOT SUPPORTED
+     * :host-context(...): scopeName..., ... scopeName
 
     */
     var api = {
@@ -156,13 +156,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _transformComplexSelector: function(selector, scope, hostScope) {
         var stop = false;
+        var hostContext = false;
         var self = this;
         selector = selector.replace(SIMPLE_SELECTOR_SEP, function(m, c, s) {
           if (!stop) {
             var o = self._transformCompoundSelector(s, c, scope, hostScope);
-            if (o.stop) {
-              stop = true;
-            }
+            stop = stop || o.stop;
+            hostContext = hostContext || o.hostContext;
             c = o.combinator;
             s = o.value;  
           } else {
@@ -170,14 +170,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           return c + s;
         });
+        if (hostContext) {
+          selector = selector.replace(CONTEXT_MARKER_MATCH, 
+            function(m, pre, paren, post) {
+              return pre + paren + ' ' + hostScope + post + 
+                COMPLEX_SELECTOR_SEP + ' ' + pre + hostScope + paren + post;
+             });
+        }
         return selector;
       },
 
       _transformCompoundSelector: function(selector, combinator, scope, hostScope) {
         // replace :host with host scoping class
         var jumpIndex = selector.search(SCOPE_JUMP);
-        if (selector.indexOf(HOST) >=0) {
-          // :host(...)
+        var hostContext = false;
+        if (selector.indexOf(HOST_CONTEXT) >=0) {
+          // :host-context(...) -> ##...##
+          selector = selector.replace(HOST_CONTEXT_PAREN, function(m, host, paren) {
+            hostContext = true;
+            return CONTEXT_MARKER + paren + CONTEXT_MARKER;
+          });
+        } else if (selector.indexOf(HOST) >=0) {
+          // :host(...) -> scopeName...
           selector = selector.replace(HOST_PAREN, function(m, host, paren) {
             return hostScope + paren;
           });
@@ -199,7 +213,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           selector = selector.replace(SCOPE_JUMP, ' ');
           stop = true;
         }
-        return {value: selector, combinator: combinator, stop: stop};
+        return {value: selector, combinator: combinator, stop: stop, 
+          hostContext: hostContext};
       },
 
       _transformSimpleSelector: function(selector, scope) {
@@ -243,6 +258,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // :host(:not([selected]), more general support requires
     // parsing which seems like overkill
     var HOST_PAREN = /(\:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
+    var HOST_CONTEXT = ':host-context';
+    var HOST_CONTEXT_PAREN = /(\:host-context)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
+    var CONTEXT_MARKER = '##';
+    var CONTEXT_MARKER_MATCH = /(.*)##(.*)##(.*)/;
     var CONTENT = '::content';
     var SCOPE_JUMP = /\:\:content|\:\:shadow|\/deep\//;
     var CSS_CLASS_PREFIX = '.';

--- a/test/smoke/host-context.html
+++ b/test/smoke/host-context.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+
+  <title>dom-if</title>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer.html">
+
+</head>
+<body>
+
+  <dom-module id="x-host">
+    <style>
+      :host {
+        display: block;
+      }
+
+      :host-context([dir="rtl"]):after {
+        content: 'rtl';
+      }
+    </style>
+    <template>
+      Hi!
+    </template>
+    <script>
+      Polymer({
+        is:'x-host',
+      });
+    </script>
+  </dom-module>
+  
+  <div  dir="rtl">
+    <x-host></x-host>
+  </div>
+  <br>
+  <x-host></x-host>
+  
+
+</body>
+</html>

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -191,7 +191,7 @@ suite('Polymer.dom', function() {
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), []);
   });
 
-  test('Polymer.dom.classListAdd/Remove/Toggle (reproject)', function() {
+  test('Polymer.dom.classListAdd/Remove/Toggle/Contains (reproject)', function() {
     var select = document.querySelector('x-select-class1');
     var child = Polymer.dom(select).firstElementChild;
     var c1 = Polymer.dom(select.root).querySelector('content');
@@ -203,31 +203,41 @@ suite('Polymer.dom', function() {
     var ip$ = [c1, c2, c3];
     assert.equal(Polymer.dom(child).getDestinationInsertionPoints().length, 0);
     Polymer.dom(child).classList.add('s1');
+    assert.isTrue(Polymer.dom(child).classList.contains('s1'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1]);
     Polymer.dom(child).classList.add('s2');
+    assert.isTrue(Polymer.dom(child).classList.contains('s2'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1, c2]);
     Polymer.dom(child).classList.add('s3');
+    assert.isTrue(Polymer.dom(child).classList.contains('s3'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1, c2, c3]);
     Polymer.dom(child).classList.toggle('s1');
+    assert.isFalse(Polymer.dom(child).classList.contains('s1'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), []);
     Polymer.dom(child).classList.toggle('s1');
+    assert.isTrue(Polymer.dom(child).classList.contains('s1'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1, c2, c3]);
     Polymer.dom(child).classList.remove('s2');
+    assert.isFalse(Polymer.dom(child).classList.contains('s2'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1]);
     Polymer.dom(child).classList.toggle('s2');
+    assert.isTrue(Polymer.dom(child).classList.contains('s2'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1, c2, c3]);
     Polymer.dom(child).classList.remove('s3');
+    assert.isFalse(Polymer.dom(child).classList.contains('s3'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), [c1, c2]);
     Polymer.dom(child).classList.remove('s2');
     Polymer.dom(child).classList.remove('s1');
+    assert.isFalse(Polymer.dom(child).classList.contains('s2'));
+    assert.isFalse(Polymer.dom(child).classList.contains('s1'));
     Polymer.dom.flush();
     assert.deepEqual(Polymer.dom(child).getDestinationInsertionPoints(), []);
   });

--- a/test/unit/styling-cross-scope-apply.html
+++ b/test/unit/styling-cross-scope-apply.html
@@ -19,6 +19,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <x-scope></x-scope>
 
+  <dom-module id="story-card">
+
+    <style>
+      :host {
+        display: block;
+      }
+      
+      #story-card .story-content {
+        font-family: 'Roboto', sans-serif;
+        font-size: 1.2em;
+        @apply(--story-content);
+      }
+    </style>
+
+    <template>
+      <div id="story-card">
+        <div class="story-content" id="content">Content</div>
+      </div>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'story-card'});
+    });
+    </script>
+  </dom-module>
+
   <dom-module id="x-child-scope">
     <style>
       :host {
@@ -46,6 +72,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       #mixin4 {
         @apply(--mixin4);
       }
+
+      #mixin6 {
+        @apply(--mixin6)
+      }
+
+      #mixin7 {@apply(--mixin7)}
     </style>
 
     <template>
@@ -53,6 +85,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div id="mixin2">mixin2</div>
       <div id="mixin3">mixin3</div>
       <div id="mixin4">mixin4</div>
+      <div id="mixin6">mixin6</div>
+      <div id="mixin7">mixin7</div>
     </template>
     <script>
     HTMLImports.whenReady(function() {
@@ -66,6 +100,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         display: block;
         padding: 8px;
+
+        --override-me: {
+          border: 11px solid black;
+        };
 
         --mixin1: {
           border: 1px solid black;
@@ -96,7 +134,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         --mixin5: {
           border: calc(var(--c1) + var(--c2)) solid orange;
         };
-      }
+
+        --mixin6: {
+          border: 16px solid orange;
+        }
+
+        --mixin7: {
+          border: 17px solid navy;
+        }}
 
       #mixin1 {
         @apply(--mixin1);
@@ -124,6 +169,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         padding: 10px;
       }
 
+      #card {
+        --story-content: {
+          border: 11px solid orange;
+        };
+      }
+
+      #override {
+        @apply(--override-me);
+        border: 19px solid steelblue;
+      }
+
     </style>
 
     <template>
@@ -134,6 +190,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div id="mixin5">mixin5</div>
       <hr>
       <x-child-scope id="child"></x-child-scope>
+      <story-card id="card"></story-card>
+      <div id="override">override</div>
     </template>
     <script>
     HTMLImports.whenReady(function() {
@@ -198,6 +256,19 @@ suite('scoped-styling-apply', function() {
 
   test('calc can be used in mixins', function() {
     assertComputed(styled.$.mixin5, '15px');
+  });
+
+  test('mixins work with selectors that contain element name', function() {
+    assertComputed(styled.$.card.$.content, '11px');
+  });
+
+  test('mixins with trailing new line or } apply', function() {
+    assertComputed(styled.$.child.$.mixin6, '16px');
+    assertComputed(styled.$.child.$.mixin7, '17px');
+  });
+
+  test('mixin values can be overridden by subsequent concrete properties', function() {
+    assertComputed(styled.$.override, '19px');
   });
 });
 

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -302,7 +302,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         --button-border: 16px solid tomato;
         --after: 17px solid brown;
-      }
+
+        --end-term: 19px solid blue}
+
+      :root{--ws-term: 18px solid orange}
 
       #me {
         border: var(--scope-var);
@@ -350,6 +353,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         --grand-child-scope-var: 9px solid orange;
       }
 
+      #overridesConcrete {
+        border: var(--scope-var);
+        border: 4px solid steelblue;
+      }
+
       #calc {
         border: solid red;
         border-width: calc(var(--a) + var(--b));
@@ -372,6 +380,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         content: 'after';
         border: var(--after);
       }
+
+      #wsTerm {
+        border: var(--ws-term)
+      }
+
+      #endTerm {border: var(--end-term)}
     </style>
 
     <template>
@@ -382,6 +396,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <x-overrides id="overrides1b"></x-overrides>
       <x-overrides2 id="overrides2"></x-overrides2>
       <x-overrides3 id="overrides3"></x-overrides3>
+      <div id="overridesConcrete">override concrete</div>
       <button id="button" is="x-button"></button>
       <div id="default1">default</div>
       <div id="default2">var default</div>
@@ -397,6 +412,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <x-has-if id="iffy"></x-has-if>
       <div id="after"></div>
       <x-dynamic id="dynamic"></x-dynamic>
+      <div id="wsTerm">new line var</div>
+      <div id="endTerm">end var</div>
     </template>
     <script>
     HTMLImports.whenReady(function() {
@@ -592,6 +609,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('elements using only variable defaults are styled properly', function() {
     assertComputed(styled.$.defaultElement1, '22px');
     assertComputed(styled.$.defaultElement2, '23px');
+  });
+
+  test('vars with trailing new line or } apply', function() {
+    assertComputed(styled.$.wsTerm, '18px');
+    assertComputed(styled.$.endTerm, '19px');
+  });
+
+  test('var values can be overridden by subsequent concrete properties', function() {
+    assertComputed(styled.$.overridesConcrete, '4px');
   });
   
 });

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -1,3 +1,19 @@
+<dom-module id="x-gchild">
+  <style>
+    :host-context(.wide) #target {
+      border: 10px solid orange;
+    }
+  </style>
+  <template>
+    <div id="target">x-gchild</div>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'x-gchild'
+  });
+</script>
+
 <dom-module id="x-child">
   <template>
     <div id="simple">simple</div>
@@ -6,6 +22,8 @@
     <div id="media">media</div>
     <div id="shadow" class="shadowTarget">shadowTarget</div>
     <div id="deep" class="deepTarget">deepTarget</div>
+    <x-gchild id="gchild1"></x-gchild>
+    <x-gchild id="gchild2" class="wide"></x-gchild>
   </template>
 </dom-module>
 <script>

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -64,6 +64,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
   });
 
+  test(':host-context(...)', function() {
+    assertComputed(styled.$.child.$.gchild1.$.target, '0px');
+    assertComputed(styled.$.child.$.gchild2.$.target, '10px');
+    assertComputed(styledWide.$.child.$.gchild1.$.target, '10px');
+    assertComputed(styledWide.$.child.$.gchild2.$.target, '10px');
+  });
+
   test('scoped selectors, simple and complex', function() {
     assertComputed(styled.$.simple, '3px');
     assertComputed(styled.$.complex1, '4px');
@@ -192,7 +199,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('styles shimmed in registration order', function() {
         var s$ = document.head.querySelectorAll('style[scope]');
-        var expected = ['x-child2', 'x-styled', 'x-button', 'x-dynamic-scope'];
+        var expected = ['x-gchild', 'x-child2', 'x-styled', 'x-button', 'x-dynamic-scope'];
         var actual = [];
         for (var i=0; i<s$.length; i++) {
           actual.push(s$[i].getAttribute('scope'));


### PR DESCRIPTION
Fixes #1938: make host selector not tripped up by id, attr, or pseud properties
Fixes #1874, #1761: maintain static declarations within declarations that contain custom properties
Fixes #1927: make custom property parser able to see property endings of ; or \n or end token.