### PR TITLE
Keep a sum-total count of native events to properly tally for `unlisten`

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -221,10 +221,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         gd = gobj[dep];
         if (!gd) {
-          gobj[dep] = gd = {};
+          gobj[dep] = gd = {_count: 0};
+        }
+        if (gd._count === 0) {
           node.addEventListener(dep, this.handleNative);
         }
         gd[name] = (gd[name] || 0) + 1;
+        gd._count = (gd._count || 0) + 1;
       }
       node.addEventListener(evType, handler);
       if (recognizer.touchAction) {
@@ -244,9 +247,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gd = gobj[dep];
           if (gd && gd[name]) {
             gd[name] = (gd[name] || 1) - 1;
-            if (gd[name] === 0) {
-              node.removeEventListener(dep, this.handleNative);
-            }
+            gd._count = (gd._count || 1) - 1;
+          }
+          if (gd._count === 0) {
+            node.removeEventListener(dep, this.handleNative);
           }
         }
       }

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -69,12 +69,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(obj.mousedown.downup, 2, 'mousedown downup');
           assert.equal(obj.mousedown.track, 1, 'mousedown track');
           assert.equal(obj.mousedown.tap, 1, 'mousedown tap');
+          assert.equal(obj.mousedown._count, 4, 'total mousedown')
           assert.equal(obj.touchstart.downup, 2, 'touchstart downup');
-          assert.equal(obj.touchmove.track, 1, 'touchmove track');
           assert.equal(obj.touchstart.tap, 1, 'touchstart tap');
+          assert.equal(obj.touchstart.track, 1, 'touchstart track');
+          assert.equal(obj.touchstart._count, 4, 'total touchstart')
+          assert.equal(obj.touchmove.track, 1, 'touchmove track');
+          assert.equal(obj.touchmove._count, 1, 'total touchmove');
           assert.equal(obj.touchend.downup, 2, 'touchend downup');
           assert.equal(obj.touchend.track, 1, 'touchend track');
           assert.equal(obj.touchend.tap, 1, 'touchend tap');
+          assert.equal(obj.touchend._count, 4, 'total touchend');
         });
 
         test('on-*', function() {
@@ -83,12 +88,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(obj.mousedown.downup, 2, 'mousedown downup');
           assert.equal(obj.mousedown.track, 1, 'mousedown track');
           assert.equal(obj.mousedown.tap, 1, 'mousedown tap');
+          assert.equal(obj.mousedown._count, 4, 'total mousedown')
           assert.equal(obj.touchstart.downup, 2, 'touchstart downup');
-          assert.equal(obj.touchmove.track, 1, 'touchmove track');
           assert.equal(obj.touchstart.tap, 1, 'touchstart tap');
+          assert.equal(obj.touchstart.track, 1, 'touchstart track');
+          assert.equal(obj.touchstart._count, 4, 'total touchstart')
+          assert.equal(obj.touchmove.track, 1, 'touchmove track');
+          assert.equal(obj.touchmove._count, 1, 'total touchmove');
           assert.equal(obj.touchend.downup, 2, 'touchend downup');
           assert.equal(obj.touchend.track, 1, 'touchend track');
           assert.equal(obj.touchend.tap, 1, 'touchend tap');
+          assert.equal(obj.touchend._count, 4, 'total touchend');;
         });
 
         test('dynamic', function() {
@@ -116,12 +126,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(obj.mousedown.downup, 0, 'mousedown downup');
           assert.equal(obj.mousedown.track, 0, 'mousedown track');
           assert.equal(obj.mousedown.tap, 0, 'mousedown tap');
+          assert.equal(obj.mousedown._count, 0, 'total mousedown');
           assert.equal(obj.touchstart.downup, 0, 'touchstart downup');
+          assert.equal(obj.touchstart._count, 0, 'total touchstart');
           assert.equal(obj.touchmove.track, 0, 'touchmove track');
+          assert.equal(obj.touchmove._count, 0, 'total touchmove')
           assert.equal(obj.touchstart.tap, 0, 'touchstart tap');
           assert.equal(obj.touchend.downup, 0, 'touchend downup');
           assert.equal(obj.touchend.track, 0, 'touchend track');
           assert.equal(obj.touchend.tap, 0, 'touchend tap');
+          assert.equal(obj.touchend._count, 0, 'total touchend');
         });
 
         test('on-*', function(){
@@ -134,12 +148,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(obj.mousedown.downup, 0, 'mousedown downup');
           assert.equal(obj.mousedown.track, 0, 'mousedown track');
           assert.equal(obj.mousedown.tap, 0, 'mousedown tap');
+          assert.equal(obj.mousedown._count, 0, 'total mousedown');
           assert.equal(obj.touchstart.downup, 0, 'touchstart downup');
+          assert.equal(obj.touchstart._count, 0, 'total touchstart');
           assert.equal(obj.touchmove.track, 0, 'touchmove track');
+          assert.equal(obj.touchmove._count, 0, 'total touchmove')
           assert.equal(obj.touchstart.tap, 0, 'touchstart tap');
           assert.equal(obj.touchend.downup, 0, 'touchend downup');
           assert.equal(obj.touchend.track, 0, 'touchend track');
           assert.equal(obj.touchend.tap, 0, 'touchend tap');
+          assert.equal(obj.touchend._count, 0, 'total touchend');
         });
 
         test('dynamic', function(){


### PR DESCRIPTION
Fixes #1988