### PR TITLE
"Unprevent" tap events

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -492,6 +492,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     save: function(e) {
       this.info.x = e.clientX;
       this.info.y = e.clientY;
+      this.info.prevent = false;
     },
 
     mousedown: function(e) {


### PR DESCRIPTION
After touchmove, the next tap stays prevented. Set info.prevent to false when "saving" a new tap event so any calls to Gestures.prevent('tap') only prevent the "current" tap.