### PR TITLE
Correct custom property regexp's to catch new lines.

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -344,15 +344,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       rx: {
-        VAR_ASSIGN: /(?:^|[;\n]\s*)(--[\w-]*?):\s*?(?:([^;{]*?)|{([^}]*)})(?:(?=[;\n])|$)/gim,
-        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)/im, 
+        VAR_ASSIGN: /(?:^|[;\n]\s*)(--[\w-]*?):\s*(?:([^;{]*)|{([^}]*)})(?:(?=[;\n])|$)/gi,
+        MIXIN_MATCH: /(?:^|\W+)@apply[\s]*\(([^)]*)\)/i, 
         // note, this supports:
         // var(--a)
         // var(--a, --b)
         // var(--a, fallback-literal)
         // var(--a, fallback-literal(with-one-nested-parens))
-        VAR_MATCH: /(^|\W+)var\([\s]*([^,)]*)[\s]*,?[\s]*((?:[^,)]*)|(?:[^;]*\([^;)]*\)))[\s]*?\)/gim,
-        VAR_CAPTURE: /\([\s]*(--[^,\s)]*)(?:,[\s]*(--[^,\s)]*))?(?:\)|,)/gim,
+        VAR_MATCH: /(^|\W+)var\([\s]*([^,)]*)[\s]*,?[\s]*((?:[^,)]*)|(?:[^;]*\([^;)]*\)))[\s]*?\)/gi,
+        VAR_CAPTURE: /\([\s]*(--[^,\s)]*)(?:,[\s]*(--[^,\s)]*))?(?:\)|,)/gi,
         IS_VAR: /^--/,
         BRACKETED: /\{[^}]*\}/g,
         HOST_PREFIX: '(?:^|[^.#[:])',

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -91,7 +91,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #gc4 {
-        --grand-child-scope-var: var(--gc4-scope);
+        --grand-child-scope-var: 
+        var(--gc4-scope);
       }
     </style>
 


### PR DESCRIPTION
Fixes #1974: correct custom property regexp's so that `--foo: \n var(--bar);` is supported.