### PR TITLE
Fixes #2078

### DIFF
--- a/polymer-micro.html
+++ b/polymer-micro.html
@@ -31,8 +31,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._prepAttributes();
       // shared behaviors
       this._prepBehaviors();
-      // inheritance
-      this._prepExtends();
       // factory
       this._prepConstructor();
     },

--- a/polymer-mini.html
+++ b/polymer-mini.html
@@ -28,9 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._prepAttributes();
       // shared behaviors
       this._prepBehaviors();
-      // inheritance
-      this._prepExtends();
-     // factory
+      // factory
       this._prepConstructor();
       // template
       this._prepTemplate();

--- a/polymer.html
+++ b/polymer.html
@@ -30,8 +30,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._prepIs();
       // attributes
       this._prepAttributes();
-      // inheritance
-      this._prepExtends();
       // factory
       this._prepConstructor();
       // template

--- a/src/lib/base.html
+++ b/src/lib/base.html
@@ -11,6 +11,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.Base = {
 
+    // Used for `isInstance` type checking; cannot use `instanceof` because
+    // there is no common Polymer.Base in the prototype chain between type
+    // extensions and normal custom elements
+    __isPolymerInstance__: true,
+
     // pluggable features
     // `this` context is a prototype, not an instance
     _addFeature: function(feature) {
@@ -117,6 +122,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   };
 
   Polymer.Base = Polymer.Base.chainObject(Polymer.Base, HTMLElement.prototype);
+
+  if (window.CustomElements) {
+    Polymer.instanceof = CustomElements.instanceof;
+  } else {
+    Polymer.instanceof = function(obj, ctor) {
+      return obj instanceof ctor;
+    };
+  }
+
+  Polymer.isInstance = function(obj) {
+    return Boolean(obj && obj.__isPolymerInstance__);
+  };
 
   // TODO(sjmiles): ad hoc telemetry
   Polymer.telemetry.instanceCount = 0;

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -177,7 +177,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var fragContent = (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) &&
           !node.__noContent && Polymer.dom(node).querySelector(CONTENT);
         var wrappedContent = fragContent &&
-          (Polymer.dom(fragContent).parentNode.nodeType !== 
+          (Polymer.dom(fragContent).parentNode.nodeType !==
           Node.DOCUMENT_FRAGMENT_NODE);
         var hasContent = fragContent || (node.localName === CONTENT);
         // There are 2 possible cases where a distribution may need to occur:
@@ -231,8 +231,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return parent && parent.shadyRoot && hasInsertionPoint(parent.shadyRoot);
       },
 
-      // NOTE: if `ensureComposedRemoval` is true then the node should be 
-      // removed from its composed parent. 
+      // NOTE: if `ensureComposedRemoval` is true then the node should be
+      // removed from its composed parent.
       _removeNodeFromHost: function(node, ensureComposedRemoval) {
         var hostNeedsDist;
         var root;
@@ -459,7 +459,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       importNode: function(externalNode, deep) {
         // for convenience use this node's ownerDoc if the node isn't a document
-        var doc = this.node instanceof HTMLDocument ? this.node : 
+        var doc = this.node instanceof Document ? this.node :
           this.node.ownerDocument;
         var n = nativeImportNode.call(doc, externalNode, false);
         if (deep) {
@@ -506,7 +506,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.domApi._distributeParent();
       },
       contains: function() {
-        return this.node.classList.contains.apply(this.node.classList, 
+        return this.node.classList.contains.apply(this.node.classList,
           arguments);
       }
     }
@@ -682,7 +682,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       DomApi.prototype.importNode = function(externalNode, deep) {
-        var doc = this.node instanceof HTMLDocument ? this.node : 
+        var doc = this.node instanceof Document ? this.node :
           this.node.ownerDocument;
         return doc.importNode(externalNode, deep);
       }
@@ -776,8 +776,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function getLightChildren(node) {
       var children = node._lightChildren;
-      // TODO(sorvell): it's more correct to use _composedChildren instead of 
-      // childNodes here but any trivial failure to use Polymer.dom 
+      // TODO(sorvell): it's more correct to use _composedChildren instead of
+      // childNodes here but any trivial failure to use Polymer.dom
       // will result in an error so we avoid using _composedChildren
       return children ? children : node.childNodes;
     }

--- a/src/lib/polymer-bootstrap.html
+++ b/src/lib/polymer-bootstrap.html
@@ -38,7 +38,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
 
     var desugar = function(prototype) {
-      prototype = Polymer.Base.chainObject(prototype, Polymer.Base);
+      // Note: need to chain user prorotype with the correct type-extended
+      // version of Polymer.Base; this is especially important when you can't
+      // prototype swizzle (e.g. IE10), since CustomElemets uses getPrototypeOf
+      var base = Polymer.Base;
+      if (prototype.extends) {
+        base = Polymer.Base._getExtendedPrototype(prototype.extends);
+      }
+      prototype = Polymer.Base.chainObject(prototype, base);
       prototype.registerCallback();
       return prototype.constructor;
     };

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -29,8 +29,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       forRulesInStyles: function(styles, callback) {
-        for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
-          this.forEachStyleRule(this.rulesForStyle(s), callback);
+        if (styles) {
+          for (var i=0, l=styles.length, s; (i<l) && (s=styles[i]); i++) {
+            this.forEachStyleRule(this.rulesForStyle(s), callback);
+          }
         }
       },
 

--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -72,7 +72,6 @@ elements to the template itself as the binding scope.
     },
 
     _registerFeatures: function() {
-      this._prepExtends();
       this._prepConstructor();
     },
 

--- a/src/micro/extends.html
+++ b/src/micro/extends.html
@@ -47,12 +47,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.Base._addFeature({
 
-    _prepExtends: function() {
-      if (this.extends) {
-        this.__proto__ = this._getExtendedPrototype(this.extends);
-      }
-    },
-
     _getExtendedPrototype: function(tag) {
       return this._getExtendedNativePrototype(tag);
     },

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -52,8 +52,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      _findStyleHost: function() {
+        var e = this, root;
+        while (root = Polymer.dom(e).getOwnerRoot()) {
+          if (root.host && root.host._computeStyleProperties) {
+            return root.host;
+          }
+          e = root.host;
+        }
+        return styleDefaults;
+      },
+
       _updateStyleProperties: function() {
-        var info, scope = this.domHost || styleDefaults;
+        var info, scope = this._findStyleHost();
         // install cache in host if it doesn't exist.
         if (!scope._styleCache) {
           scope._styleCache = new Polymer.StyleCache();
@@ -110,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _computeStyleProperties: function(scopeProps) {
         // get scope and make sure it has properties
-        var scope = this.domHost || styleDefaults;
+        var scope = this._findStyleHost();
         // force scope to compute properties if they don't exist or if forcing
         // and it doesn't need properties
         if (!scope._styleProperties) {

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _findStyleHost: function() {
         var e = this, root;
         while (root = Polymer.dom(e).getOwnerRoot()) {
-          if (root.host && root.host._computeStyleProperties) {
+          if (Polymer.isInstance(root.host)) {
             return root.host;
           }
           e = root.host;
@@ -174,8 +174,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       serializeValueToAttribute: function(value, attribute, node) {
         // override to ensure whenever classes are set, we need to shim them.
         node = node || this;
-        if (attribute === 'class') {
+        if (attribute === 'class' && !nativeShadow) {
           // host needed to scope styling.
+          // Under Shady DOM, domHost is safe to use here because we know it
+          // is a Polymer element
           var host = node === this ? (this.domHost || this.dataHost) : this;
           if (host) {
             value = host._scopeElementClass(node, value);
@@ -206,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * been made that affect the values of custom properties.
        *
        * @method updateStyles
-       * @param {Object=} properties Properties object which is mixed into 
+       * @param {Object=} properties Properties object which is mixed into
        * the element's `customStyle` property. This argument provides a shortcut
        * for setting `customStyle` and then calling `updateStyles`.
       */

--- a/test/runner.html
+++ b/test/runner.html
@@ -46,6 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/styling-cross-scope-apply.html',
       'unit/styling-cross-scope-var.html?dom=shadow',
       'unit/styling-cross-scope-apply.html?dom=shadow',
+      'unit/styling-cross-scope-unknown-host.html',
       'unit/custom-style.html',
       'unit/dynamic-import.html',
       'unit/dom-repeat.html',

--- a/test/unit/micro.html
+++ b/test/unit/micro.html
@@ -42,7 +42,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   });
 
-  suite('constructor', function() {
+  suite('type checking & constructor', function() {
+
+    test('Polymer.isInstance for non-instance', function() {
+      var el = document.createElement('div');
+      assert.isTrue(Polymer.instanceof(el, HTMLElement));
+      assert.isTrue(Polymer.instanceof(el, HTMLDivElement));
+      assert.isFalse(Polymer.isInstance(el));
+    });
+
+    test('document.createElement', function() {
+      var MyElement = Polymer({is: 'my-basic'});
+      var el = document.createElement('my-basic');
+      assert.isTrue(Polymer.instanceof(el, HTMLElement));
+      assert.isTrue(Polymer.instanceof(el, MyElement));
+      assert.isTrue(Polymer.isInstance(el));
+    });
 
     test('normal constructor', function() {
       var MyElement = Polymer({is: 'my-element'});
@@ -53,6 +68,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.instanceOf(el, MyElement, 'Instance of MyElement');
       }
       assert.instanceOf(el, HTMLElement, 'Instance of HTMLElement');
+      assert.isTrue(Polymer.instanceof(el, HTMLElement));
+      assert.isTrue(Polymer.instanceof(el, MyElement));
+      assert.isTrue(Polymer.isInstance(el));
     });
 
     test('type-extension constructor', function() {
@@ -62,8 +80,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (Object.__proto__) {
         // instanceof Constructor only supported where proto swizzling is possible
         assert.instanceOf(el, MyInput, 'Instance of MyInput');
+        assert.instanceOf(el, HTMLElement, 'Instance of HTMLInputElement');
       }
-      assert.instanceOf(el, HTMLElement, 'Instance of HTMLInputElement');
+      assert.isTrue(Polymer.instanceof(el, HTMLInputElement));
+      assert.isTrue(Polymer.instanceof(el, HTMLElement));
+      assert.isTrue(Polymer.instanceof(el, MyInput));
+      assert.isTrue(Polymer.isInstance(el));
     });
 
     test('custom constructor', function() {
@@ -81,6 +103,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.instanceOf(el, HTMLElement, 'Instance of HTMLElement');
       }
       assert.equal(el.title, 'my title', 'Argument passed to constructor');
+      assert.isTrue(Polymer.instanceof(el, HTMLElement));
+      assert.isTrue(Polymer.instanceof(el, MyElement2));
+      assert.isTrue(Polymer.isInstance(el));
     });
 
   });

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -531,7 +531,7 @@ suite('Polymer.dom', function() {
   test('Polymer.dom importNode shallow', function() {
     var a = document.createElement('div');
     a.innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    var b = Polymer.dom(document).importNode(Polymer.dom(a).firstElementChild);
+    var b = Polymer.dom(wrap(document)).importNode(Polymer.dom(a).firstElementChild);
     Polymer.dom(document.body).appendChild(b);
     assert.equal(Polymer.dom(b).childNodes.length, 0, 'shallow import has incorrect children');
     if (b.shadyRoot) {
@@ -542,7 +542,7 @@ suite('Polymer.dom', function() {
   test('Polymer.dom importNode deep', function() {
     var a = document.createElement('div');
     a.innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    var b = Polymer.dom(document).importNode(a, true);
+    var b = Polymer.dom(wrap(document)).importNode(a, true);
     Polymer.dom(document.body).appendChild(b);
     assert.equal(Polymer.dom(b.firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
     if (b.shadyRoot) {

--- a/test/unit/styling-cross-scope-unknown-host.html
+++ b/test/unit/styling-cross-scope-unknown-host.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <script>
+    Polymer = {dom: 'shadow'};
+  </script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+  <style is="custom-style">
+    unknown-host {
+      display: block;
+    }
+
+    :root {
+      --border: 2px solid steelblue;
+    }
+  </style>
+
+  <script>
+    HTMLImports.whenReady(function() {
+      // define unknown-host
+      var proto = Object.create(HTMLElement.prototype);
+      proto.createdCallback = function() {
+        this.root = this.createShadowRoot();
+      }
+      document.registerElement('unknown-host', {prototype: proto});
+    });
+  </script>
+  
+  <dom-module id="x-foo">
+    <style>
+      :host {
+        border: var(--border);
+        display: block;
+      }
+    </style>
+    <template>
+      x-foo
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'x-foo'
+      });
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-nest">
+    <style>
+      :host {
+        --border: 4px solid tomato;
+      }
+    </style>
+    <template>
+      <unknown-host id="unknown"></unknown-host>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'x-nest',
+
+        attached: function() {
+          this.$.unknown.root.appendChild(document.createElement('x-foo'));
+        }
+      });
+    });
+    </script>
+  </dom-module>
+
+  <script>
+  suite('scoped-styling-unknown-host', function() {
+
+    function assertComputed(element, value, pseudo) {
+      var computed = getComputedStyle(element, pseudo);
+      assert.equal(computed['border-top-width'], value, 'computed style incorrect');
+    }
+
+    function assertStylePropertyValue(properties, name, includeValue) {
+      assert.property(properties, name);
+      assert.include(properties[name], includeValue);
+    }
+
+    test('element in top level unknown host styled via property defaults', function() {
+      var host = document.createElement('unknown-host');
+      var foo = document.createElement('x-foo');
+      host.root.appendChild(foo);
+      document.body.appendChild(host);
+      CustomElements.takeRecords();
+      assertComputed(foo, '2px');
+    });
+
+    test('element in unknown host styled via containing polymer element', function() {
+      var n = document.createElement('x-nest');
+      document.body.appendChild(n);
+      CustomElements.takeRecords();
+      var foo = Polymer.dom(n.$.unknown.root).querySelector('x-foo');
+      assertComputed(foo, '4px');
+    });
+
+  });
+
+    
+  </script>
+  
+
+</body>
+


### PR DESCRIPTION
When computing custom style properties, make sure the styling scope is valid when the element is attached to a shadowRoot whose host is not a Polymer element.