### PR TITLE
Fixes #2077

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -147,12 +147,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // `annote` is supplied as it is the annote.parent of added annotations
     _parseChildNodesAnnotations: function(root, annote, list, callback) {
       if (root.firstChild) {
-        for (var i=0, node=root.firstChild; node; node=node.nextSibling, i++){
+        for (var i=0, node=root.firstChild; node; node=node.nextSibling, i++) {
           if (node.localName === 'template' &&
             !node.hasAttribute('preserve-content')) {
             this._parseTemplate(node, i, list, annote);
           }
-          //
+          // collapse adjacent textNodes: fixes an IE issue that can cause 
+          // text nodes to be inexplicably split =(
+          // note that root.normalize() should work but does not so we do this
+          // manually.
+          if (node.nodeType === Node.TEXT_NODE) {
+            var n = node.nextSibling;
+            while (n && (n.nodeType === Node.TEXT_NODE)) {
+              node.textContent += n.textContent;
+              root.removeChild(n);
+              n = n.nextSibling;
+            }
+          }
           var childAnnotation = this._parseNodeAnnotations(node, list, callback);
           if (childAnnotation) {
             childAnnotation.parent = annote;

--- a/test/smoke/ie-annotations.html
+++ b/test/smoke/ie-annotations.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+
+  <title>annotations</title>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer.html">
+
+</head>
+<body>
+
+  <dom-module id="my-component">
+    <template>
+      <p>&copy;</p>
+      <p>{{myText}}</p>
+    </template>
+  </dom-module>
+
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({
+      is: "my-component",
+      properties: {
+        myText: {
+          type: String,
+          value: 'Sample'
+        }
+      },
+    });
+  });
+  </script>
+    
+  <h1>Bind correctly?</h1>
+  
+  <my-component></my-component>
+  
+
+</body>
+</html>

--- a/test/smoke/ie-split-text.html
+++ b/test/smoke/ie-split-text.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+
+  <title>annotations</title>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../src/polymer-lib.html">
+
+</head>
+<body>
+
+  <p>&copy;</p>
+  <p id="binding">{{binding}}</p>
+  <h4>textNodes above</h4>
+  <script>
+    var c$ = binding.childNodes;
+    for (var i=0; i < c$.length; i++) {
+      var d = document.createElement('div');
+      d.innerHTML = c$[i].textContent;
+      document.body.appendChild(d);
+    }
+  </script>
+  
+</body>
+</html>

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -390,3 +390,22 @@
     shouldNotChangeChanged: function() { }
   });
 </script>
+
+<dom-module id="x-entity-and-binding">
+    <template>
+      <p>&copy;</p>
+      <p id="binding">{{myText}}</p>
+    </template>
+  </dom-module>
+
+  <script>
+    Polymer({
+      is: "x-entity-and-binding",
+      properties: {
+        myText: {
+          type: String,
+          value: 'binding'
+        }
+      }
+    });
+  </script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -681,6 +681,19 @@ suite('warnings', function() {
 
 </script>
 
+<script>
+  suite('binding corner cases', function() {
+    
+    // IE can create adjacent text nodes that split bindings; this test
+    // ensures the code that addresses this is functional
+    test('text binding after entity', function() {
+      var el = document.createElement('x-entity-and-binding');
+      assert.equal(el.$.binding.textContent, 'binding');
+    });
+    
+  });
+</script>
+
 
 
 </body>


### PR DESCRIPTION
Workaround IE text node splitting issue that can make text bindings fail. The behavior is such that node.normalize() fails and so we address adjacent text nodes manually.