### PR TITLE
Fixes #2081

### DIFF
--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -688,12 +688,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       DomApi.prototype.getDestinationInsertionPoints = function() {
-        var n$ = this.node.getDestinationInsertionPoints();
+        var n$ = this.node.getDestinationInsertionPoints && 
+          this.node.getDestinationInsertionPoints();
         return n$ ? Array.prototype.slice.call(n$) : [];
       };
 
       DomApi.prototype.getDistributedNodes = function() {
-        var n$ = this.node.getDistributedNodes();
+        var n$ = this.node.getDistributedNodes && 
+          this.node.getDistributedNodes();
         return n$ ? Array.prototype.slice.call(n$) : [];
       };
 

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -116,8 +116,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Array<Node>} List of distributed nodes for the `<content>`.
      */
     getContentChildNodes: function(slctr) {
-      return Polymer.dom(Polymer.dom(this.root).querySelector(
-          slctr || 'content')).getDistributedNodes();
+      var content = Polymer.dom(this.root).querySelector(slctr || 'content');
+      return content ? Polymer.dom(content).getDistributedNodes() : [];
     },
 
     /**

--- a/test/runner.html
+++ b/test/runner.html
@@ -37,6 +37,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/gestures.html',
       'unit/utils.html',
       'unit/utils-content.html',
+      'unit/utils.html?dom=shadow',
+      'unit/utils-content.html?dom=shadow',
       'unit/resolveurl.html',
       'unit/css-parse.html',
       'unit/styling-scoped.html',

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -810,4 +810,14 @@ suite('Polymer.dom non-distributed elements', function() {
     Polymer.dom(c1).appendChild(test);
     assert.notOk(Polymer.dom(test).getOwnerRoot(), 'getOwnerRoot incorrect for child moved from a root to no root');
   });
+
+  test('getDistributedNodes on non-content element', function() {
+    assert.equal(Polymer.dom(document.createElement('div')).getDistributedNodes().length, 0);
+        assert.equal(Polymer.dom().getDistributedNodes().length, 0);
+  });
+
+  test('getDestinationInsertionPoints on non-distributable element', function() {
+    assert.equal(Polymer.dom(document.createElement('div')).getDestinationInsertionPoints().length, 0);
+    assert.equal(Polymer.dom(document).getDestinationInsertionPoints().length, 0);
+  });
 });

--- a/test/unit/utils-content.html
+++ b/test/unit/utils-content.html
@@ -78,6 +78,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         nodes = elt3.getContentChildren('[select=span]');
         assert.equal(nodes.length, 4, 'should have 4 spans');
       });
+
+      test('getContentChildNodes with non-existent selector', function() {
+        var nodes = elt3.getContentChildNodes('[dne]');
+        assert.equal(nodes.length, 0, 'should find 0 nodes');
+      });
+
+      test('getContentChildren with non-existent selector', function() {
+        var nodes = elt3.getContentChildren('[dne]');
+        assert.equal(nodes.length, 0, 'should find 0 nodes');
+      });
       
     });
   


### PR DESCRIPTION
* make `Polymer.dom(element).getDistributedNodes` and `Polymer.dom(element).getDestinationInsertionPoints()` always return at least an empty array (was generating exception under Shadow DOM); 

* make `element.getContentChildNodes` and `element.getContentChildren` always return at least an empty array when a selector is passed that does not find a `<content>`  (was generating exception under Shadow DOM)