### PR TITLE
Fix dom bind example in jsdoc

### DIFF
--- a/PRIMER.md
+++ b/PRIMER.md
@@ -2253,7 +2253,7 @@ In order to use Polymer bindings without defining a new custom element, you may 
   <meta charset="utf-8">
   <script src="components/webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="components/polymer/polymer.html">
-  <link rel="import" href="components/core-ajax/core-ajax.html">
+  <link rel="import" href="components/iron-ajax/iron-ajax.html">
 
 </head>
 <body>
@@ -2262,7 +2262,7 @@ In order to use Polymer bindings without defining a new custom element, you may 
   <!-- allow use of Polymer bindings main document -->
   <template is="dom-bind">
 
-    <core-ajax url="http://..." lastresponse="{{data}}"></core-ajax>
+    <iron-ajax url="http://..." lastresponse="{{data}}" auto></iron-ajax>
 
     <template is="dom-repeat" items="{{data}}">
         <div><span>{{item.first}}</span> <span>{{item.last}}</span></div>

--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -27,14 +27,14 @@ elements to the template itself as the binding scope.
   <meta charset="utf-8">
   <script src="components/webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="components/polymer/polymer.html">
-  <link rel="import" href="components/core-ajax/core-ajax.html">
+  <link rel="import" href="components/iron-ajax/iron-ajax.html">
 
 </head>
 <body>
 
   <template is="dom-bind">
 
-    <core-ajax url="http://..." lastresponse="{{data}}"></core-ajax>
+    <iron-ajax url="http://..." lastresponse="{{data}}" auto></iron-ajax>
 
     <template is="dom-repeat" items="{{data}}">
         <div><span>{{item.first}}</span> <span>{{item.last}}</span></div>
@@ -135,7 +135,7 @@ elements to the template itself as the binding scope.
     },
 
     /**
-     * Forces the element to render its content. This is typically only 
+     * Forces the element to render its content. This is typically only
      * necessary to call if HTMLImports with the async attribute are used.
      */
     render: function() {


### PR DESCRIPTION
Rename `core-ajax` to `iron-ajax`, and add `auto` attribute as in https://github.com/Polymer/docs/pull/1276