### PR TITLE
Simplified default value decaration

### DIFF
--- a/polymer.html
+++ b/polymer.html
@@ -42,6 +42,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._prepEffects();
       // shared behaviors
       this._prepBehaviors();
+      // convert simplified default value for properties into expanded form
+      this._prepSimplifiedProperties();
       // fast access to property info
       this._prepPropertyInfo();
       // accessors part 2
@@ -85,7 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // acquire instance behaviors
       this._marshalBehaviors();
       /*
-      TODO(sorvell): It's *slightly() more efficient to marshal attributes prior 
+      TODO(sorvell): It's *slightly() more efficient to marshal attributes prior
       to installing hostAttributes, but then hostAttributes must be separately
       funneled to configure, which is cumbersome.
       Since this delta seems hard to measure we will not bother atm.

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -208,6 +208,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // property, Chrome will leak memory across page refreshes
       // https://crbug.com/529941
       this._handlers = [];
+    },
+
+    _prepSimplifiedProperties: function() {
+      var property, type, value;
+      for (property in this.properties) {
+        value = this.properties[property];
+        type = (function() {
+          switch (typeof value) {
+            case 'boolean':
+              return Boolean;
+            case 'number':
+              return Number;
+            case 'string':
+              return String;
+            default:
+              if (value instanceof Date) {
+                return Date;
+              } else if (value instanceof Array) {
+                return Array;
+              }
+          }
+        })();
+        if (type) {
+          this.properties[property] = {
+            type: type,
+            value: value
+          }
+        }
+      }
     }
 
   });

--- a/test/unit/configure-elements.html
+++ b/test/unit/configure-elements.html
@@ -18,6 +18,7 @@
 <dom-module id="x-configure-value">
   <template>
     <span id="content">{{content}}</span>
+    <span id="simplified_content">{{simplified}}</span>
   </template>
   <script>
     Polymer({
@@ -45,7 +46,13 @@
         },
         stomp: {
           value: 5
-        }
+        },
+        simplified: "default",
+        simplifiedBoolean: false
+      },
+      ready: function () {
+        this.simplifiedAtReady = this.simplified;
+        this.simplifiedBooleanAtReady = this.simplifiedBoolean;
       }
 
     });

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -22,9 +22,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <x-configure-value content="attr" object='{"foo": "obj-attr"}'></x-configure-value>
 
-  <x-configure-host></x-configure-host>  
+  <x-configure-value simplified="attr" simplified-boolean></x-configure-value>
 
-  <x-configure-host content="attr"></x-configure-host>  
+  <x-configure-host></x-configure-host>
+
+  <x-configure-host content="attr"></x-configure-host>
 
 <script>
 
@@ -49,11 +51,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assert.equal(e.$.content.textContent, value, 'Bound value not propagated to dom');
   }
 
+  function testSimplifiedDefault(e, value) {
+    assert.equal(e.simplified, value, 'Simplified default value declaration failed');
+    assert.equal(e.properties.simplified.type, String, 'Type for simplified default value was not inferred');
+    assert.equal(e.$.simplified_content.textContent, value, 'Bound value not propagated to dom with simplified declaration');
+  }
+
   suite('configure', function() {
 
     test('value set in properties initializes correctly', function() {
       var e = document.querySelector('x-configure-value');
-      testConfigure(e, 'default', 'obj-default');      
+      testConfigure(e, 'default', 'obj-default');
+    });
+
+    test('simplified default value set in properties initializes correctly', function() {
+      var e = document.querySelector('x-configure-value');
+      testSimplifiedDefault(e, 'default');
+    });
+
+    test('simplified default value with attribute initializes correctly', function() {
+      var e = document.querySelector('x-configure-value[simplified]');
+      assert.equal(e.simplifiedAtReady, 'attr', 'Simplified default value declaration with element attribute failed');
+      assert.equal(e.simplifiedBooleanAtReady, true, 'Simplified default boolean value declaration with element attribute failed');
     });
 
     test('attribute overrides value set in properties', function() {


### PR DESCRIPTION
I was not able to wait and implemented #2176 myself.
It allows turn:
```javascript
...
  properties: {
    prop : {
      type : String,
      value : "Default value"
    }
  }
...
```
into
```javascript
...
  properties: {
    prop : "Default value"
  }
...
```
which radically improves readability of this common use case without sacrificing performance.

It works with strings, numbers, boolean values, date objects and arrays (everything supported by Polymer), generic objects are ignored because it will cause random errors otherwise.

I wasn't able to run WCT in any way I've tried, so tests were not actually tested by myself.