### PR TITLE
Fix for loosing prototype's property value during getter/setter initialization

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -157,10 +157,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // create accessors that implement effects
 
     _createAccessors: function(model, property, effects) {
+      var prototype_value = model[property];
       var defun = {
         get: function() {
           // TODO(sjmiles): elide delegation for performance, good ROI?
-          return this.__data__[property];
+          return (property in this.__data__) ? this.__data__[property] : prototype_value;
         }
       };
       var setter = function(value) {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -110,6 +110,7 @@
           computed: 'foobared(noComputed)'
         }
       },
+      notInProperties: 'foo',
       observers: [
         'multipleDepChangeHandler(dep1, dep2, dep3)',
         'customEventObjectValueChanged(customEventObject.value)',

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -262,6 +262,10 @@ suite('single-element binding effects', function() {
     assert.equal(el.observerCounts.customEventObjectValueChanged, 1, 'custom bound path observer not called');
   });
 
+  test('accessing property from prototype (not in properties)', function() {
+    assert.equal(el.notInProperties, 'foo', 'property from constructor was overridden, likely replaced with accessor');
+  });
+
 });
 
 </script>
@@ -684,14 +688,14 @@ suite('warnings', function() {
 
 <script>
   suite('binding corner cases', function() {
-    
+
     // IE can create adjacent text nodes that split bindings; this test
     // ensures the code that addresses this is functional
     test('text binding after entity', function() {
       var el = document.createElement('x-entity-and-binding');
       assert.equal(el.$.binding.textContent, 'binding');
     });
-    
+
   });
 </script>
 


### PR DESCRIPTION
Basically prototype's value was overridden with accessor.
Check added - if instance value doesn't exist - use value from prototype, just like it work during regular prototype inheritance.
Fixes #2257 (partially)