### PR TITLE
Small performance tweak during object cloning

### DIFF
--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -45,11 +45,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // storage for configuration
     _setupConfigure: function(initialConfig) {
-      this._config = {};
+      // If we have more non-undefined properties, it is more efficient to clone whole object
+      // and then remove undesired properties
+      this._config = Object.create(initialConfig || {});
       // don't accept undefined values in intialConfig
       for (var i in initialConfig) {
-        if (initialConfig[i] !== undefined) {
-          this._config[i] = initialConfig[i];    
+        if (initialConfig[i] === undefined) {
+          delete this._config[i];
         }
       }
       this._handlers = [];


### PR DESCRIPTION
If most of properties are non-undefined, suggested improvement makes cloning twice as fast.
Performance test (results in 2x improvement in stable Firefox and Chromium):
```js
var w = {};
for (var i = 0; i < 10000; ++i) {
	w[i] = Math.random();
}

for (var i = 0; i < 1000; ++i) {
	w[i] = null;
}


var result1, result2;
var time1, time2, time3;
time1 = new Date;
result1 = {};
for (i in w) {
	if (w[i] !== null) {
		result1[i] = w[i];
	}
}
time2 = new Date;
result2 = Object.create(w);
for (i in result2) {
	if (result2[i] === null) {
		delete result2[i];
	}
}
time3 = new Date;
console.log(time2 - time1);
console.log(time3 - time2);
```

Even with half of elements being `null` it is still a bit faster.