### PR TITLE
Fix for method parsing in computed binding

### DIFF
--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -185,7 +185,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // method expressions are of the form: `name([arg1, arg2, .... argn])`
     _parseMethod: function(expression) {
       // tries to match valid javascript property names
-      var m = expression.match(/([^\s]+)\((.*)\)/);
+      var m = expression.match(/([^\s]+?)\((.*)\)/);
       if (m) {
         var sig = { method: m[1], static: true };
         if (m[2].trim()) {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -37,6 +37,7 @@
       <span id="boundText">{{text}}</span>
       <span idtest id="{{boundId}}"></span>
       <s id="computedContent">{{computeFromTrickyLiterals(3, 'tricky\,\'zot\'')}}</s>
+      <s id="computedContent2">{{computeFromTrickyLiterals("(",3)}}</s>
       <input id="boundInput" value="{{text::input}}">
       <div id="compound1">{{cpnd1}}{{cpnd2}}{{cpnd3.prop}}{{computeCompound(cpnd4, cpnd5, 'literal')}}</div>
       <div id="compound2">

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -175,6 +175,7 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedFromTrickyLiterals, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.boundChild.computedFromTrickyLiterals2, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.computedContent.textContent, '3tricky,\'zot\'', 'Wrong textContent from tricky literal arg computation');
+    assert.equal(el.$.computedContent2.textContent, '(3', 'Wrong textContent from tricky literal arg computation');
   });
 
   test('computed annotation with no args', function() {


### PR DESCRIPTION
Quantifier should be greedy, otherwise it fails to parse correctly such construction:
```html
<span attr="[[computed('(', foo)]]">
```