### PR TITLE
Add `deepActiveElement` getter to the DomApi.

### DIFF
--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // we don't distribute before initial distribution
         if (host.shadyRoot && host.shadyRoot._distributionClean) {
           host.shadyRoot._distributionClean = false;
-          Polymer.dom.addDebouncer(host.debounce('_distribute', 
+          Polymer.dom.addDebouncer(host.debounce('_distribute',
             host._distributeContent));
         }
       },
@@ -741,13 +741,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       DomApi.prototype.getDestinationInsertionPoints = function() {
-        var n$ = this.node.getDestinationInsertionPoints && 
+        var n$ = this.node.getDestinationInsertionPoints &&
           this.node.getDestinationInsertionPoints();
         return n$ ? Array.prototype.slice.call(n$) : [];
       };
 
       DomApi.prototype.getDistributedNodes = function() {
-        var n$ = this.node.getDistributedNodes && 
+        var n$ = this.node.getDistributedNodes &&
           this.node.getDistributedNodes();
         return n$ ? Array.prototype.slice.call(n$) : [];
       };
@@ -828,7 +828,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // add flush api...
     Polymer.Base.extend(Polymer.dom, {
-      
+
       _flushGuard: 0,
       _FLUSH_MAX: 100,
       _needsTakeRecords: !Polymer.Settings.useNativeCustomElements,
@@ -860,9 +860,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      // TODO(sorvell): There is currently not a good way 
+      // TODO(sorvell): There is currently not a good way
       // to process all custom elements mutations under SD polyfill because
-      // these mutations may be inside shadowRoots. 
+      // these mutations may be inside shadowRoots.
       _flushPolyfills: function() {
         if (this._needsTakeRecords) {
           CustomElements.takeRecords();
@@ -872,12 +872,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       addDebouncer: function(debouncer) {
         this._debouncers.push(debouncer);
         // ensure the list of active debouncers is cleared when done.
-        this._finishDebouncer = Polymer.Debounce(this._finishDebouncer, 
+        this._finishDebouncer = Polymer.Debounce(this._finishDebouncer,
           this._finishFlush);
       },
 
       _finishFlush: function() {
         Polymer.dom._debouncers = [];
+      },
+
+      get deepActiveElement() {
+        var node = document.activeElement;
+        if (Polymer.Settings.useNativeShadow) {
+          while (node.shadowRoot && node.shadowRoot.activeElement) {
+            node = node.shadowRoot.activeElement;
+          }
+        }
+        return node;
       }
 
     });

--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -887,7 +887,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             node = node.shadowRoot.activeElement;
           }
         }
-        return node;
+        return Polymer.dom(node).node;
       }
 
     });

--- a/test/unit/polymer-dom-elements.html
+++ b/test/unit/polymer-dom-elements.html
@@ -55,7 +55,7 @@
   Polymer({
     is: 'x-test-no-distribute'
   });
-</script> 
+</script>
 
 <dom-module id="x-distribute">
   <template>
@@ -327,5 +327,16 @@
       }
     }
   });
+  </script>
+</dom-module>
+
+<dom-module id="x-focusable">
+  <template>
+    <div tabindex="1">x-focusable</div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-focusable'
+    });
   </script>
 </dom-module>

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -623,7 +623,25 @@ suite('Polymer.dom', function() {
     } else {
       testHeight();
     }
-    
+
+  });
+
+  test('deepActiveElement search', function() {
+    var a = document.createElement('x-trivial');
+    var b = document.createElement('x-trivial');
+    Polymer.dom(b).setAttribute('tabindex', 1);
+    Polymer.dom(a).appendChild(b);
+    Polymer.dom(document.body).appendChild(a);
+    b.focus();
+    assert.equal(Polymer.dom.deepActiveElement, b);
+  });
+
+  test('deepActiveElement complex search', function() {
+    var a = document.createElement('x-focusable');
+    var b = Polymer.dom(a.root).querySelector('[tabindex="1"]');
+    Polymer.dom(document.body).appendChild(a);
+    b.focus();
+    assert.equal(Polymer.dom.deepActiveElement, b);
   });
 
 });

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -636,14 +636,22 @@ suite('Polymer.dom', function() {
     assert.equal(Polymer.dom.deepActiveElement, b);
   });
 
-  test('deepActiveElement complex search', function() {
+  test('deepActiveElement complex search', function(done) {
     var a = document.createElement('x-focusable');
     var b = Polymer.dom(a.root).querySelector('[tabindex="1"]');
     Polymer.dom(document.body).appendChild(a);
-    b.focus();
-    assert.equal(Polymer.dom.deepActiveElement, b);
+    Polymer.dom.flush();
+    function testDeepActiveElement() {
+      b.focus();
+      assert.equal(Polymer.dom.deepActiveElement, b);
+      done();
+    }
+    if (Polymer.Settings.useShadow && !Polymer.Settings.useNativeShadow) {
+      setTimeout(testDeepActiveElement);
+    } else {
+      testDeepActiveElement();
+    }
   });
-
 });
 
 suite('Polymer.dom accessors', function() {


### PR DESCRIPTION
>> According to the current spec,
http://w3c.github.io/webcomponents/spec/shadow/#active-element
Document.activeElement returns "adjusted" element, i.e.
when the real focused element is within a shadow tree, it returns
the top-most shadow host in the Document treescope.  

(https://github.com/w3c/webcomponents/issues/104)