### PR TITLE
Remove unused callback parameter.

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -145,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // add annotations gleaned from children of `root` to `list`, `root`'s
     // `annote` is supplied as it is the annote.parent of added annotations
-    _parseChildNodesAnnotations: function(root, annote, list, callback) {
+    _parseChildNodesAnnotations: function(root, annote, list) {
       if (root.firstChild) {
         for (var i=0, node=root.firstChild; node; node=node.nextSibling, i++) {
           if (node.localName === 'template' &&
@@ -164,7 +164,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               n = n.nextSibling;
             }
           }
-          var childAnnotation = this._parseNodeAnnotations(node, list, callback);
+          var childAnnotation = this._parseNodeAnnotations(node, list);
           if (childAnnotation) {
             childAnnotation.parent = annote;
             childAnnotation.index = i;


### PR DESCRIPTION
The `callback` parameter of both `_parseNodeAnnotations` and `_parseChildNodesAnnotations` was not being used at all.

I did grep for it on Polymer/polymer and all official elements packages and couldn't find any reference to it.