### PR TITLE
Fix a rare, racey IE11 bug

### DIFF
--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -64,7 +64,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (var i=0, c; i < i$.length; i++) {
           c = i$[i];
           saveLightChildrenIfNeeded(c);
-          saveLightChildrenIfNeeded(c.parentNode);
+          // Also check for _lightParent because of an IE 11 bug, where
+          // a child of a document fragment doesn't always know about its
+          // parent, even when the parent knows about the child.
+          // More info: https://github.com/Polymer/polymer/pull/2321
+          saveLightChildrenIfNeeded(c.parentNode || c._lightParent);
         }
         this.shadyRoot.host = this;
       },


### PR DESCRIPTION
In very rare cases that I can only sometimes reproduce, and only sometimes on IE11 running within certain VMs, `c` (which is a <content> node) has no parent at this point in the code.

Charitably, perhaps this setup is exercising certain unusual event timings, causing a legal but unusual order of operations.

Bisect indicates that this "bug" was introduced at https://github.com/Polymer/polymer/commit/21500fb53f4dc186ffd1099d5492c711e097c8a4 