### PR TITLE
Fixes #2334: when composing nodes in shady dom, check if a node is wh…

### DIFF
--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -238,8 +238,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _tryRemoveUndistributedNode: function(node) {
         if (this.node.shadyRoot) {
-          if (node._composedParent) {
-            nativeRemoveChild.call(node._composedParent, node);
+          var parent = getComposedParent(node);
+          if (parent) {
+            nativeRemoveChild.call(parent, node);
           }
           return true;
         }
@@ -289,7 +290,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._updateInsertionPoints(root.host);
           this._lazyDistribute(root.host);
         } else if (ensureComposedRemoval) {
-          removeFromComposedParent(node._composedParent, node);
+          removeFromComposedParent(getComposedParent(node), node);
         }
       },
 
@@ -572,8 +573,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         parentNode: {
           get: function() {
             return this.node._lightParent ||
-              (this.node.__patched ? this.node._composedParent :
-              this.node.parentNode);
+              getComposedParent(this.node);
           },
           configurable: true
         },
@@ -909,7 +909,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         addNodeToComposedChildren(node, parent, children, i);
       }
+    }
 
+    function getComposedParent(node) {
+      return node.__patched ? node._composedParent : node.parentNode;
     }
 
     function addNodeToComposedChildren(node, parent, children, i) {
@@ -956,6 +959,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return {
       getLightChildren: getLightChildren,
+      getComposedParent: getComposedParent,
       getComposedChildren: getComposedChildren,
       removeFromComposedParent: removeFromComposedParent,
       saveLightChildrenIfNeeded: saveLightChildrenIfNeeded,

--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -300,7 +300,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // process removals
         for (var i=0, d=0, s; (i<splices.length) && (s=splices[i]); i++) {
           for (var j=0, n; (j < s.removed.length) && (n=s.removed[j]); j++) {
-            remove(n);
+            // check if the node is still where we expect it is before trying
+            // to remove it; this can happen if Polymer.dom moves a node and 
+            // then schedules its previous host for distribution resulting in
+            // the node being removed here.
+            if (getComposedParent(n) === container) {
+              remove(n);
+            }
             composed.splice(s.index + d, 1);
           }
           d -= s.addedCount;

--- a/src/mini/shady.html
+++ b/src/mini/shady.html
@@ -320,6 +320,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             composed.splice(j, 0, n);
           }
         }
+        // ensure composed parent is set
+        ensureComposedParent(container, children);
       },
 
       _matchesContentSelect: function(node, contentElement) {
@@ -364,6 +366,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var matchesSelector = Polymer.DomApi.matchesSelector;
     var hasInsertionPoint = Polymer.DomApi.hasInsertionPoint;
     var getComposedChildren = Polymer.DomApi.getComposedChildren;
+    var getComposedParent = Polymer.DomApi.getComposedParent;
     var removeFromComposedParent = Polymer.DomApi.removeFromComposedParent;
 
     function distributeNodeInto(child, insertionPoint) {
@@ -434,8 +437,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
-    function getComposedParent(node) {
-      return node.__patched ? node._composedParent : node.parentNode;
+    function ensureComposedParent(parent, children) {
+      for (var i=0, n; i < children.length; i++) {
+        children[i]._composedParent = parent;
+      }
     }
 
     // returns the host that's the top of this host's distribution tree

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -29,6 +29,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-dist-simple">
+  <template>
+    <content id="content"></content>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-dist-simple'});
+  });
+  </script>
+</dom-module>
+
 <dom-module id="x-dist-inside-deep-tree">
   <template>
     x-dist-inside-deep-tree
@@ -1140,6 +1151,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('moving children between distributing host with deep insertion and fragment (parsed child)', function() {
       var div = document.createElement('div');
       div.innerHTML = '<x-dist-inside-deep-tree><div></div></x-dist-inside-deep-tree>';
+      var h1 = div.firstChild;
+      var h2 = document.createDocumentFragment();;
+      document.body.appendChild(h1);
+      Polymer.dom.flush();
+      var d = Polymer.dom(h1).firstElementChild;
+      assert.equal(d.localName, 'div');
+      assert.equal(Polymer.dom(h1).childNodes.length, 1);
+      assert.equal(Polymer.dom(h1).firstElementChild, d);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes(), [d]);
+      assert.equal(Polymer.dom(h2).childNodes.length, 0);
+      Polymer.dom(h2).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h2).childNodes.length, 1);
+      assert.equal(Polymer.dom(h2).firstElementChild, d);
+      assert.equal(Polymer.dom(h1).childNodes.length, 0);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes().length, 0);
+      Polymer.dom(h1).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h1).childNodes.length, 1);
+      assert.equal(Polymer.dom(h1).firstElementChild, d);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes(), [d]);
+      assert.equal(Polymer.dom(h2).childNodes.length, 0);
+      Polymer.dom(h2).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h2).childNodes.length, 1);
+      assert.equal(Polymer.dom(h2).firstElementChild, d);
+      assert.equal(Polymer.dom(h1).childNodes.length, 0);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes().length, 0);
+      document.body.removeChild(h1);
+    });
+
+    test('moving children between distributing host with shallow insertion and fragment', function() {
+      var h1 = document.createElement('x-dist-simple');
+      var h2 = document.createDocumentFragment();;
+      document.body.appendChild(h1);
+      Polymer.dom.flush();
+      var d = document.createElement('div');
+      Polymer.dom(h1).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h1).childNodes.length, 1);
+      assert.equal(Polymer.dom(h1).firstElementChild, d);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes(), [d]);
+      assert.equal(Polymer.dom(h2).childNodes.length, 0);
+      Polymer.dom(h2).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h2).childNodes.length, 1);
+      assert.equal(Polymer.dom(h2).firstElementChild, d);
+      assert.equal(Polymer.dom(h1).childNodes.length, 0);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes().length, 0);
+      Polymer.dom(h1).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h1).childNodes.length, 1);
+      assert.equal(Polymer.dom(h1).firstElementChild, d);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes(), [d]);
+      assert.equal(Polymer.dom(h2).childNodes.length, 0);
+      Polymer.dom(h2).appendChild(d);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(h2).childNodes.length, 1);
+      assert.equal(Polymer.dom(h2).firstElementChild, d);
+      assert.equal(Polymer.dom(h1).childNodes.length, 0);
+      assert.deepEqual(Polymer.dom(h1.$.content).getDistributedNodes().length, 0);
+      document.body.removeChild(h1);
+    });
+
+    test('moving children between distributing host with shallow insertion and fragment (parsed child)', function() {
+      var div = document.createElement('div');
+      div.innerHTML = '<x-dist-simple><div></div></x-dist-simple>';
       var h1 = div.firstChild;
       var h2 = document.createDocumentFragment();;
       document.body.appendChild(h1);


### PR DESCRIPTION
…ere we expect it to be before removing it from its distributed position. We do this because the node may have been moved by Polymer.dom in a way that triggered distribution of its previous location. The node is already where it needs to be so removing it from its parent when it's no longer distributed is destructive.