### PR TITLE
Remove forceUpgraded check in dom-module.import

### DIFF
--- a/src/lib/dom-module.html
+++ b/src/lib/dom-module.html
@@ -10,7 +10,7 @@
 
   /**
    * The `dom-module` element registers the dom it contains to the name given
-   * by the module's id attribute. It provides a unified database of dom 
+   * by the module's id attribute. It provides a unified database of dom
    * accessible via any dom-module element. Use the `import(id, selector)`
    * method to locate dom within this database. For example,
    *
@@ -39,13 +39,13 @@
 
     /**
      * Registers the dom-module at a given id. This method should only be called
-     * when a dom-module is imperatively created. For 
+     * when a dom-module is imperatively created. For
      * example, `document.createElement('dom-module').register('foo')`.
      * @method register
      * @param {String} id The id at which to register the dom-module.
      */
     register: function(id) {
-      var id = id || this.id || 
+      var id = id || this.id ||
         this.getAttribute('name') || this.getAttribute('is');
       if (id) {
         this.id = id;
@@ -58,7 +58,7 @@
     },
 
     /**
-     * Retrieves the dom specified by `selector` in the module specified by 
+     * Retrieves the dom specified by `selector` in the module specified by
      * `id`. For example, this.import('foo', 'img');
      * @method register
      * @param {String} id
@@ -99,8 +99,7 @@
     if (cePolyfill) {
       var script = document._currentScript || document.currentScript;
       var doc = script && script.ownerDocument;
-      if (doc && !doc.__customElementsForceUpgraded) {
-        doc.__customElementsForceUpgraded = true;
+      if (doc) {
         CustomElements.upgradeAll(doc);
       }
     }

--- a/test/runner.html
+++ b/test/runner.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/unresolved.html',
       'unit/attributes.html',
       'unit/dom-module.html',
+      'unit/dom-module-inline.html',
       'unit/async.html',
       'unit/behaviors.html',
       'unit/template.html',

--- a/test/unit/dom-module-inline.html
+++ b/test/unit/dom-module-inline.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+
+  <div id="temp"></div>
+  <script>
+
+    var module;
+
+    suite('dom-module inline', function() {
+      var temp = document.getElementById('temp');
+
+      test('dom-module will work when inlined', function() {
+        // simulate an inline dom-module
+        // use a new script object to make document.currentScript work correctly
+        var e = document.createElement('script');
+        e.textContent = 'temp.innerHTML = \'<dom-module id="foo"></dom-module>\'; module = Polymer.DomModule.import("foo");';
+        document.body.appendChild(e);
+        assert.ok(module, 'found module');
+      });
+    });
+
+  </script>
+
+</body>
+</html>
+


### PR DESCRIPTION
Multiple elements depend on dom-module.import and may register before dom-module
is registered.

With the forceUpgraded check, only the first module to call .import will be
upgraded, typically custom-style.

This will break the subsiquent elements, such as dom-template.

Fixes Polymer/vulcanize#234