### PR TITLE
Eliminate the need to write `:host ::content` instead of just `::content`

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -30,9 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
      * :host(...) -> scopeName...
 
-     * ::content -> ' ' NOTE: requires use of scoping selector and selectors
-       cannot otherwise be scoped:
-       e.g. :host ::content > .bar -> x-foo > .bar
+     * ::content -> ' '
 
      * ::shadow, /deep/: processed similar to ::content
 
@@ -161,6 +159,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var stop = false;
         var hostContext = false;
         var self = this;
+        selector = selector.replace(/^(::content)/, ':host $1');
         selector = selector.replace(SIMPLE_SELECTOR_SEP, function(m, c, s) {
           if (!stop) {
             var info = self._transformCompoundSelector(s, c, scope, hostScope);

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -159,7 +159,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var stop = false;
         var hostContext = false;
         var self = this;
-        selector = selector.replace(/^(::content)/, ':host $1');
+        selector = selector.replace(CONTENT_START, HOST + ' $1');
         selector = selector.replace(SIMPLE_SELECTOR_SEP, function(m, c, s) {
           if (!stop) {
             var info = self._transformCompoundSelector(s, c, scope, hostScope);
@@ -255,7 +255,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // NOTE: this supports 1 nested () pair for things like
     // :host(:not([selected]), more general support requires
     // parsing which seems like overkill
-    var HOST_PAREN = /(\:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
+    var HOST_PAREN = /(:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
     var HOST_CONTEXT = ':host-context';
     var HOST_CONTEXT_PAREN = /(.*)(?::host-context)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))(.*)/;
     var CONTENT = '::content';
@@ -265,6 +265,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var CSS_ATTR_SUFFIX = ']';
     var PSEUDO_PREFIX = ':';
     var CLASS = 'class';
+    var CONTENT_START = new RegExp('^(' + CONTENT + ')');
 
     // exports
     return api;

--- a/test/unit/polymer-dom-elements.html
+++ b/test/unit/polymer-dom-elements.html
@@ -200,7 +200,7 @@
       box-sizing: border-box;
     }
 
-    :host ::content .add3 {
+    ::content .add3 {
       box-sizing: border-box;
       height: 20px;
       background: #333;
@@ -240,7 +240,7 @@
       padding: 4px;
     }
 
-    :host ::content .add2 {
+    ::content .add2 {
       box-sizing: border-box;
       height: 20px;
       background: gray;
@@ -281,7 +281,7 @@
       padding: 4px;
     }
 
-    :host ::content .add1 {
+    ::content .add1 {
       box-sizing: border-box;
       height: 20px;
       background: lightgray;


### PR DESCRIPTION
While keeping the same processing under the hood.
I've also removed workaround from tests and they don't fail, which is good.