### PR TITLE
Add note on arrayDelete with array vs. path

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -199,9 +199,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Removes an item from an array, if it exists.
+     * 
+     * If the array is specified by path, a change notification is 
+     * generated, so that observers, data bindings and computed
+     * properties watching that path can update. 
+     * 
+     * If the array is passed directly, **no change
+     * notification is generated**.
      *
      * @method arrayDelete
-     * @param {String|Array} path Path torray from which to remove the item
+     * @param {String|Array} path Path to array from which to remove the item
      *   (or the array itself).
      * @param {any} item Item to remove.
      * @return {Array} Array containing item removed.


### PR DESCRIPTION
Fixes #2427. Well, actually it just documents the limitation, it doesn't fix anything :).

@sorvell or @kevinpschaaf should review -- if this behavior is unintended, please correct me, but I don't think there's any way to reconstruct the path from the array.

