### PR TITLE
pass event registered node to handler

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -119,7 +119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var host = this;
       var handler = function(e) {
         if (host[methodName]) {
-          host[methodName](e, e.detail);
+          host[methodName](e, e.detail, node);
         } else {
           host._warn(host._logf('_createEventHandler', 'listener method `' +
             methodName + '` not defined'));


### PR DESCRIPTION
This let's you write event handlers with a reliable reference to the node the event was registered to.

```javascript
this.listen(polymerElement, 'tap', 'tapHandler');

tapHandler: function(e, detail, node) {
  console.log(node) // polymerElement
}
```
Has been tested with adding event handlers via 
```javascript
on-eventName="eventHandler"
this.listen(element, eventType, eventHandler),
listeners : {'myId.tap': 'eventHandler'}
```