### PR TITLE
Reset handlers queue after finished replaying events

### DIFF
--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -49,7 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // don't accept undefined values in intialConfig
       for (var i in initialConfig) {
         if (initialConfig[i] !== undefined) {
-          this._config[i] = initialConfig[i];    
+          this._config[i] = initialConfig[i];
         }
       }
       this._handlers = [];
@@ -190,6 +190,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       for (var i=0, l=h$.length, h; (i<l) && (h=h$[i]); i++) {
         h[0].call(this, h[1], h[2]);
       }
+      // reset handlers array
+      //
+      // If an element holds a reference to a CustomEvent with a detail
+      // property, Chrome will leak memory across page refreshes
+      // https://crbug.com/529941
+      this._handlers = [];
     }
 
   });


### PR DESCRIPTION
Holding on to an array of CustomEvents can leak memory across page refreshes in
Chrome: https://crbug.com/529941

Fixes #2452