### PR TITLE
Add test for parsing multi-line css comments

### DIFF
--- a/test/unit/css-parse.html
+++ b/test/unit/css-parse.html
@@ -59,6 +59,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background: red;
     }
     /* comment */
+
+    /*
+      This is a multi-line comment
+    */
+
+    /*.aclassThatShouldBeIgnored {
+      someProperty: thatMustNotShowUp
+    }*/
   </style>
 <script>
 


### PR DESCRIPTION
Closes #2455 

Tests pass locally, but have to see what CI reports, else the issue requires additional information on how to reproduce the fault.