### PR TITLE
Add .gitattributes to solve line endings cross-OS (merge after other PRs)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
When checking out Polymer on a Linux machine, several files will be completely added due to non-CRLF endings. Therefore if you edit just 1 line, the whole file will be triggered as changed.

This change prevents the git diff from being cluttered, uniforming all line-endings across the project.
Fixes #2592 