### PR TITLE
Add expose method to be able to delegate Polymer object functions.

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -150,7 +150,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *   payload.
      * @param {Object=} options Object specifying options.  These may include:
      *  `bubbles` (boolean, defaults to `true`),
-     *  `cancelable` (boolean, defaults to false), and 
+     *  `cancelable` (boolean, defaults to false), and
      *  `node` on which to fire the event (HTMLElement, defaults to `this`).
      * @return {CustomEvent} The new event that was fired.
      */
@@ -199,11 +199,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Removes an item from an array, if it exists.
-     * 
-     * If the array is specified by path, a change notification is 
+     *
+     * If the array is specified by path, a change notification is
      * generated, so that observers, data bindings and computed
-     * properties watching that path can update. 
-     * 
+     * properties watching that path can update.
+     *
      * If the array is passed directly, **no change
      * notification is generated**.
      *
@@ -306,6 +306,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       return elt;
+    },
+
+    /**
+     * Enables exposure of a function in a Polymer object while maintaining
+     * the reference of the object in this, but also passing the original
+     * calling element as first argument.
+     * This can solve the problem of losing either one of the this references.
+     *
+     * The exposing function must have N + 1 arguments, which is turned in a
+     * function with N arguments.
+     *
+     * @method expose
+     * @param {Function} func The function to expose to, has N + 1 arguments.
+     * @return {Function} The function that can be exposed, has N arguments.
+     */
+    expose: function(func) {
+      var that = this;
+      return function() {
+        // Proxy the array in order to prevent memory leaks. For more information see
+        // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+        var args = new Array(arguments.length + 1);
+        args[0] = this;
+        for(var i = 0; i < arguments.length; ++i) {
+            args[i + 1] = arguments[i];
+        }
+        return func.apply(that, args);
+      }
     }
 
   });

--- a/test/unit/utils.html
+++ b/test/unit/utils.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
 <script>
-  
+
   HTMLImports.whenReady(function() {
     Polymer({is: 'my-element'});
   });
@@ -98,6 +98,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
   });
+
+  suite('expose', function() {
+
+    test('correctly delegates this', function() {
+      var externalAPI = {
+        init: function(config) {
+          this.callMe = config.callMe;
+        }
+      };
+
+      externalAPI.init({
+        callMe: window.el1.expose(function(element) {
+          return {
+            thisValue: this,
+            elementValue: element
+          };
+        })
+      });
+
+      assert.equal(externalAPI.callMe().thisValue, window.el1);
+      assert.equal(externalAPI.callMe().elementValue, externalAPI);
+    });
+  })
 
 </script>
 </body>


### PR DESCRIPTION
When passing callbacks to external APIs, it is common to fetch
the `this` reference from the callback. This `this` references the
element that invoked the callback.

However, in order to be able to use Polymer functions, the `this`
that originally referenced the Polymer object, is lost.

Therefore in order to maintain both references, expose links `this`
to the Polymer object and the first argument references the element
that called the callback.

I personally came accross this problem while working on a `fullCalendar` Polymer element. The conflicting callback was `drop`. [In their docs](http://fullcalendar.io/docs/dropping/drop/) it is stated:
`this holds the DOM element that has been dropped.`

I do need the element, because it contains some data/properties I need process. Therefore I would lose my this reference to my Polymer element, making me unable to use any of all the functions defined by Polymer (or my custom functions/properties).