### PR TITLE
Only one real listener per `listen` call

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -80,8 +80,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {string} methodName Name of handler method on `this` to call.
      */
     listen: function(node, eventName, methodName) {
-      this._listen(node, eventName,
-        this._createEventHandler(node, eventName, methodName));
+      var handler = this._recallEventHandler(this, eventName, node, methodName);
+      // reuse cache'd handler
+      if (!handler) {
+        handler = this._createEventHandler(node, eventName, methodName);
+      }
+      this._listen(node, eventName, handler);
     },
 
     _boundListenerKey: function(eventName, methodName) {
@@ -140,6 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      anymore.
      */
     unlisten: function(node, eventName, methodName) {
+      // leave handler in map for cache purposes
       var handler = this._recallEventHandler(this, eventName, node, methodName);
       if (handler) {
         this._unlisten(node, eventName, handler);

--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -85,7 +85,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!handler) {
         handler = this._createEventHandler(node, eventName, methodName);
       }
+      // don't call _listen if we are already listening
+      if (handler._listening) {
+        return;
+      }
       this._listen(node, eventName, handler);
+      handler._listening = true;
     },
 
     _boundListenerKey: function(eventName, methodName) {
@@ -129,6 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             methodName + '` not defined'));
         }
       };
+      handler._listening = false;
       this._recordEventHandler(host, eventName, node, methodName, handler);
       return handler;
     },
@@ -148,6 +154,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var handler = this._recallEventHandler(this, eventName, node, methodName);
       if (handler) {
         this._unlisten(node, eventName, handler);
+        handler._listening = false;
       }
     },
 

--- a/test/unit/events-elements.html
+++ b/test/unit/events-elements.html
@@ -93,3 +93,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </dom-module>
+
+<dom-module id="x-double">
+  <script>
+    Polymer({
+      is: 'x-double',
+      behaviors: [EventLoggerImpl],
+      setup: function() {
+        this.listen(this, 'foo', 'missing');
+        this.listen(this, 'foo', 'missing');
+      },
+      teardown: function() {
+        this.unlisten(this, 'foo', 'missing');
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -141,6 +141,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.deepEqual(el._removed[3], {target: 'div', event: 'bar'});
         });
       });
+
+      suite('Event Listener Cache', function() {
+        suiteSetup(function() {
+          el = document.createElement('x-double');
+          document.body.appendChild(el);
+          el.setup();
+        });
+
+        suiteTeardown(function() {
+          document.body.removeChild(el);
+        });
+
+        test('Event handler fires only once', function() {
+          el.fire('foo');
+          assert.equal(el._warned.length, 1, 'event should fire only once');
+        });
+
+        test('listen reuses handler cache', function() {
+          var expected = el._recallEventHandler(el, 'foo', el, 'missing');
+          el.listen(el, 'foo', 'missing');
+          var actual = el._recallEventHandler(el, 'foo', el, 'missing');
+          assert.equal(actual, expected, 'function was not cached');
+        });
+
+        test('unlisten keeps handler for caching', function() {
+          el.teardown();
+          var fn = el._recallEventHandler(el, 'foo', el, 'missing');
+          assert.ok(fn, 'should be cached');
+        });
+      });
     });
   </script>
 

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -153,6 +153,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           document.body.removeChild(el);
         });
 
+        test('listen marks event handler as listening', function() {
+          var handler = el._recallEventHandler(el, 'foo', el, 'missing');
+          assert.equal(handler._listening, true, 'handler should be marked');
+        });
+
         test('Event handler fires only once', function() {
           el.fire('foo');
           assert.equal(el._warned.length, 1, 'event should fire only once');
@@ -171,9 +176,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.ok(fn, 'should be cached');
         });
 
+        test('unlisten markes cached handler as not listening', function() {
+          var handler = el._recallEventHandler(el, 'foo', el, 'missing');
+          assert.equal(handler._listening, false, 'handler should not be listening');
+        });
+
         test('once unlistened, no handler fire', function() {
           el.fire('foo');
-          assert.equal(el._warned.length, 1, 'event should not be handled anymore')
+          assert.equal(el._warned.length, 1, 'event should not be handled anymore');
         });
       });
     });

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -170,6 +170,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var fn = el._recallEventHandler(el, 'foo', el, 'missing');
           assert.ok(fn, 'should be cached');
         });
+
+        test('once unlistened, no handler fire', function() {
+          el.fire('foo');
+          assert.equal(el._warned.length, 1, 'event should not be handled anymore')
+        });
       });
     });
   </script>


### PR DESCRIPTION
Actually use event listener cache correctly

Fixes #2534 Polymer Gestures creates a new bound handler for every `listen` call