### PR TITLE
Make model param of stamp method optional.

### DIFF
--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -373,7 +373,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * `stamp`.
      *
      * @method stamp
-     * @param {Object} model An object containing key/values to serve as the
+     * @param {Object=} model An object containing key/values to serve as the
      *   initial data configuration for the instance.  Note that properties
      *   from the host used in the template are automatically copied into
      *   the model.


### PR DESCRIPTION
Otherwise the compiler requires `this.stamp(null)` or `this.stamp({})`. Might as well make it optional?