### PR TITLE
#2579 Handle quoted string escaping when parsing annotations and methods

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -88,12 +88,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._parseElementAnnotations(node, list);
     },
 
-    _bindingRegex: /([^{[]*)({{|\[\[)([^}\]]*)(?:]]|}})/g,
+    _bindingRegex: (function() {
+        var dblQuotStr = '"(?:\\\\.|[^"\\\\])*"';
+        var quotStr = "'(?:\\\\.|[^'\\\\])*'";
+        var string = dblQuotStr + '|' + quotStr;
 
-    // TODO(kschaaf): We could modify this to allow an escape mechanism by
-    // looking for the escape sequence in each of the matches and converting
-    // the part back to a literal type, and then bailing if only literals
-    // were found
+        // binding: a sequence of (string or any char but quotes or braces)'
+        var binding = '(?:' + string + '|' + '[^}\\"\']]*' + ')*';
+
+        return new RegExp( '([^{[]*)({{|\\[\\[)(' + binding + ')(}}|\\]\\])', "g");
+    })(),
+
     _parseBindings: function(text) {
       var re = this._bindingRegex;
       var parts = [];

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -179,15 +179,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     },
 
+    _methodRegEx: (function() {
+        var dblQuotStr = '"(?:\\\\.|[^"\\\\])*"';
+        var quotStr = "'(?:\\\\.|[^'\\\\])*'";
+        var string = dblQuotStr + '|' + quotStr;
+
+        var methodName = '[^\\s]+';
+        var argumentList = '(' + '(?:' + string + '|' + '[^)\'"]*' + ')*' + ')';
+
+        return {
+            method: new RegExp('^\\s*(' + methodName + ')\\s*' + '\\(' + argumentList + '\\)\\s*$'),
+            argument: new RegExp('(' + string + '|' + '[^,\'"]*' + ')' + ',?\\s*')
+        };
+    })(),
+
     // method expressions are of the form: `name([arg1, arg2, .... argn])`
     _parseMethod: function(expression) {
       // tries to match valid javascript property names
-      var m = expression.match(/([^\s]+)\((.*)\)/);
+      var m = expression.match(this._methodRegEx.method);
       if (m) {
         var sig = { method: m[1], static: true };
         if (m[2].trim()) {
-          // replace escaped commas with comma entity, split on un-escaped commas
-          var args = m[2].replace(/\\,/g, '&comma;').split(',');
+          // "foo,bar,baz" is transformed into ["","foo","","bar","","baz",""]
+          var args = m[2].split(this._methodRegEx.argument);
+          // remove empty strings at even indices
+          for(var i=0;i<args.length;i++)
+            args.splice(i,1);
           return this._parseArgs(args, sig);
         } else {
           sig.args = Polymer.nar;

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -22,6 +22,8 @@
       computed-from-tricky-function='{{$computeTrickyFunctionFromLiterals( 3, "foo")}}'
       computed-from-tricky-literals="{{computeFromTrickyLiterals(3, 'tricky\,\'zot\'')}}"
       computed-from-tricky-literals2='{{computeFromTrickyLiterals(3,"tricky\,&#39;zot&#39;" )}}'
+      computed-from-tricky-literals3='{{computeFromTrickyLiterals(&#39;"\&#39;-&#39;, "\&#39;{{foo}}\&#39;\"")}}'
+      computed-from-tricky-literals4='{{computeFromTrickyLiterals(",,,",",,,")}}'
       computed-from-no-args="{{computeFromNoArgs( )}}"
       no-computed="{{foobared(noInlineComputed)}}"
       compoundAttr1$="{{cpnd1}}{{ cpnd2 }}{{cpnd3.prop}}{{ computeCompound(cpnd4, cpnd5, 'literal')}}"

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -174,6 +174,8 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedFromTrickyFunction, '3foo', 'Wrong result from tricky function with pure literal arg computation');
     assert.equal(el.$.boundChild.computedFromTrickyLiterals, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.boundChild.computedFromTrickyLiterals2, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
+    assert.equal(el.$.boundChild.computedFromTrickyLiterals3, '"\'-\'{{foo}}\'"', 'Wrong result from tricky literal arg computation');
+    assert.equal(el.$.boundChild.computedFromTrickyLiterals4, ',,,,,,', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.computedContent.textContent, '3tricky,\'zot\'', 'Wrong textContent from tricky literal arg computation');
   });
 


### PR DESCRIPTION
Allows expressions like this one without escaping
````
[[localize("Welcome back, (Mr {0})")]]
````
Fixes  #1784, #2295