### PR TITLE
Do not configure compound property/attribute binding if literal if em…

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -306,8 +306,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // Initialize attribute bindings with any literal parts
         var literal = this._literalFromParts(parts);
-        if (kind == 'attribute') {
-         node.setAttribute(name, literal);
+        if (literal && kind == 'attribute') {
+          node.setAttribute(name, literal);
         }
         // Clear attribute before removing, since IE won't allow removing
         // `value` attribute if it previously had a value (can't

--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -265,12 +265,11 @@ TODO(sjmiles): this module should produce either syntactic metadata
           var name = binding.name;
           storage[name] = literals;
           // Configure properties with their literal parts
-          if (binding.kind == 'property') {
-            var literal = literals.join('');
+          if (binding.literal && binding.kind == 'property') {
             if (node._configValue) {
-              node._configValue(name, literal);
+              node._configValue(name, binding.literal);
             } else {
-              node[name] = literal;
+              node[name] = binding.literal;
             }
           }
         }

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -703,7 +703,8 @@ suite('compound binding / string interpolation', function() {
 
   test('compound adjacent property bindings', function() {
     var el = document.createElement('x-basic');
-    assert.equal(el.$.boundProps.prop1, '');
+    // Adjacent compound binding with no literal do not override the default
+    assert.equal(el.$.boundProps.prop1, 'default');
     assert.isTrue(el.$.boundProps.prop1Changed.calledOnce);
     el.cpnd2 = 'cpnd2';
     assert.equal(el.$.boundProps.prop1, 'cpnd2');
@@ -736,7 +737,8 @@ suite('compound binding / string interpolation', function() {
 
   test('compound adjacent attribute bindings', function() {
     var el = document.createElement('x-basic');
-    assert.equal(el.$.boundChild.getAttribute('compoundAttr1'), '');
+    // Adjacent compound binding with no literal do not override the default
+    assert.equal(el.$.boundChild.getAttribute('compoundAttr1'), null);
     el.cpnd2 = 'cpnd2';
     assert.equal(el.$.boundChild.getAttribute('compoundAttr1'), 'cpnd2');
     el.cpnd1 = 'cpnd1';


### PR DESCRIPTION
…pty. Fixes #2583.