### PR TITLE
#2520 Support es6 class extends

### DIFF
--- a/src/lib/polymer-bootstrap.html
+++ b/src/lib/polymer-bootstrap.html
@@ -23,6 +23,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // if input is a `class` (aka a function with a prototype), use the prototype
       // remember that the `constructor` will never be called
       if (typeof prototype === 'function') {
+        // flatten the prototype if it has super class
+        flatten(prototype);
         prototype = prototype.prototype;
       }
       // if there is no prototype, use a default empty object
@@ -45,6 +47,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.telemetry._registrate(prototype);
       document.registerElement(prototype.is, options);
       return factory;
+    };
+
+    var flatten = function(child) {
+      var childProto = child.prototype,
+          parentProto = Object.getPrototypeOf(childProto),
+          parent = parentProto.constructor;
+
+      if (parent !== Object) flatten(parent);
+      if (parent === Object) return;
+
+      Object.getOwnPropertyNames(parentProto)
+        .forEach(function(key) {
+          if (key === 'constructor') return;
+          if (childProto.hasOwnProperty(key)) return; //Overriden.
+          childProto[key] = parentProto[key];
+        });
     };
 
     var desugar = function(prototype) {

--- a/test/runner.html
+++ b/test/runner.html
@@ -63,7 +63,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dom-repeat.html',
       'unit/dom-if.html',
       'unit/dom-bind.html',
-      'unit/script-after-import-in-head.html'
+      'unit/script-after-import-in-head.html',
+      'unit/es6.html'
     ]);
   </script>
 </body>

--- a/test/unit/es6-class-extends.es6
+++ b/test/unit/es6-class-extends.es6
@@ -1,0 +1,24 @@
+"use strict";
+
+class XBaseClass {
+  sayFoo() {
+    this.saying = "foo";
+  }
+}
+
+class XExtendedClass extends XBaseClass {
+  beforeRegister() {
+    this.is = "x-extended-class";
+    this.properties = {
+      saying: {
+        type: String,
+        value: "hello"
+      }
+    };
+  }
+
+  ready(){
+    this.sayFoo();
+  }
+}
+

--- a/test/unit/es6-class-extends.html
+++ b/test/unit/es6-class-extends.html
@@ -1,0 +1,36 @@
+<script>
+  "use strict";
+
+  class XBaseClass {
+    sayFoo() {
+      this.saying = "foo";
+    }
+  }
+
+  class XExtendedClass extends XBaseClass {
+    beforeRegister() {
+      this.is = "x-extended-class";
+      this.properties = {
+        saying: {
+          type: String,
+          value: "hello"
+        }
+      };
+    }
+
+    ready(){
+      this.sayFoo();
+    }
+  }
+</script>
+
+<dom-module id="x-extended-class">
+  <template>
+    x-extended-class
+    <content></content>
+  </template>
+  <script>
+    Polymer(XExtendedClass);
+  </script>
+</dom-module>
+

--- a/test/unit/es6-class-extends.html
+++ b/test/unit/es6-class-extends.html
@@ -1,34 +1,9 @@
-<script>
-  "use strict";
-
-  class XBaseClass {
-    sayFoo() {
-      this.saying = "foo";
-    }
-  }
-
-  class XExtendedClass extends XBaseClass {
-    beforeRegister() {
-      this.is = "x-extended-class";
-      this.properties = {
-        saying: {
-          type: String,
-          value: "hello"
-        }
-      };
-    }
-
-    ready(){
-      this.sayFoo();
-    }
-  }
-</script>
-
 <dom-module id="x-extended-class">
   <template>
     x-extended-class
     <content></content>
   </template>
+  <script src="es6-class-extends.js"></script>
   <script>
     Polymer(XExtendedClass);
   </script>

--- a/test/unit/es6-class-extends.js
+++ b/test/unit/es6-class-extends.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var XBaseClass = (function () {
+  function XBaseClass() {
+    _classCallCheck(this, XBaseClass);
+  }
+
+  _createClass(XBaseClass, [{
+    key: "sayFoo",
+    value: function sayFoo() {
+      this.saying = "foo";
+    }
+  }]);
+
+  return XBaseClass;
+})();
+
+var XExtendedClass = (function (_XBaseClass) {
+  _inherits(XExtendedClass, _XBaseClass);
+
+  function XExtendedClass() {
+    _classCallCheck(this, XExtendedClass);
+
+    _get(Object.getPrototypeOf(XExtendedClass.prototype), "constructor", this).apply(this, arguments);
+  }
+
+  _createClass(XExtendedClass, [{
+    key: "beforeRegister",
+    value: function beforeRegister() {
+      this.is = "x-extended-class";
+      this.properties = {
+        saying: {
+          type: String,
+          value: "hello"
+        }
+      };
+    }
+  }, {
+    key: "ready",
+    value: function ready() {
+      this.sayFoo();
+    }
+  }]);
+
+  return XExtendedClass;
+})(XBaseClass);
+

--- a/test/unit/es6.html
+++ b/test/unit/es6.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+  <link rel="import" href="es6-class-extends.html">
+</head>
+
+<body>
+
+  <h4>x-extended-class</h4>
+  <x-extended-class id="extended"></x-extended-class>
+
+  <script>
+    suite('es6 feature', function() {
+
+      test('class extends base class', function() {
+        var el = extended;
+        assert.equal("foo", el.saying);
+      });
+    });
+  </script>
+
+</body>
+
+</html>
+


### PR DESCRIPTION
Ref. https://github.com/Polymer/polymer/issues/2520

To support class extends, the prototype inheritances must be flattened to single prototype.
Sample: http://jsbin.com/wetiwi/edit?html,console

Please review my PR! Thanks.
