### PR TITLE
Adds incremental rendering to dom-repeat. Fixes #2537.

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -194,7 +194,7 @@ Then the `observe` property should be configured as follows:
        * Defines an initial count of template instances to render after setting
        * the `items` array, before the next paint, and puts the `dom-repeat`
        * into "chunking mode".  The remaining items will be created and rendered
-       * incrementally at each animation frame therof until all instnaces have
+       * incrementally at each animation frame therof until all instances have
        * been rendered.
        */
       initialCount: {

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -491,7 +491,7 @@ Then the `observe` property should be configured as follows:
       }
       // Remove any extra instances from previous state
       for (var j=this._instances.length-1; j>=i; j--) {
-        this._removeInstance(j);
+        this._detachAndRemoveInstance(j);
       }
     },
 
@@ -544,7 +544,7 @@ Then the `observe` property should be configured as follows:
           var idx = removedIdxs[i];
           // Removed idx may be undefined if item was previously filtered out
           if (idx !== undefined) {
-            this._removeInstance(idx);
+            this._detachAndRemoveInstance(idx);
           }
         }
       }
@@ -606,7 +606,7 @@ Then the `observe` property should be configured as follows:
       splices.forEach(function(s) {
         // Detach & pool removed instances
         for (var i=0; i<s.removed.length; i++) {
-          this._removeInstance(s.index);
+          this._detachAndRemoveInstance(s.index);
         }
         for (var i=0; i<s.addedKeys.length; i++) {
           this._insertPlaceholder(s.index+i, s.addedKeys[i]);
@@ -632,7 +632,7 @@ Then the `observe` property should be configured as follows:
       }
     },
 
-    _removeInstance: function(idx) {
+    _detachAndRemoveInstance: function(idx) {
       var inst = this._detachInstance(idx);
       if (inst) {
         this._pool.push(inst);

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -241,18 +241,6 @@ Then the `observe` property should be configured as follows:
         value: 20
       },
 
-      /**
-       * Maximum number of removed instances to pool for reuse when rows are
-       * added in a future turn.  By default, pooling is enabled.
-       *
-       * Set to 0 to disable pooling, which will allow all removed instances to
-       * be garbage collected.
-       */
-      poolSize: {
-        type: Number,
-        value: 1000
-      },
-
       _targetFrameTime: {
         computed: '_computeFrameTime(targetFramerate)'
       }
@@ -338,10 +326,10 @@ Then the `observe` property should be configured as follows:
       return Math.ceil(1000/rate);
     },
 
-    _initializeChunkCount: function(initialCount, chunkCount) {
-      if (initialCount) {
-        this.limit = initialCount;
-        this._chunkCount = parseInt(chunkCount, 10) || initialCount;
+    _initializeChunkCount: function() {
+      if (this.initialCount) {
+        this.limit = this.initialCount;
+        this._chunkCount = parseInt(this.chunkCount, 10) || this.initialCount;
       }
     },
 
@@ -386,6 +374,9 @@ Then the `observe` property should be configured as follows:
         } else {
           this._error(this._logf('dom-repeat', 'expected array for `items`,' +
             ' found', this.items));
+        }
+        if (this._instances.length && this.initialCount) {
+          this._initializeChunkCount();
         }
         this._keySplices = [];
         this._indexSplices = [];
@@ -472,8 +463,12 @@ Then the `observe` property should be configured as follows:
         }
       }
       // Reset the pool
-      // TODO(kschaaf): Allow pool to be reused across turns & between nested
-      // peer repeats (requires updating parentProps when reusing from pool)
+      // TODO(kschaaf): Reuse pool across turns and nested templates
+      // Requires updating parentProps and dealing with the fact that path
+      // notifications won't reach instances sitting in the pool, which
+      // could result in out-of-sync instances since simply re-setting
+      // `item` may not be sufficient if the pooled instance happens to be
+      // the same item.
       this._pool.length = 0;
       // Notify users
       this.fire('dom-change');
@@ -518,10 +513,8 @@ Then the `observe` property should be configured as follows:
         var key = keys[i];
         var inst = this._instances[i];
         if (inst) {
-          if (inst.isPlaceholder) {
-            inst.__key__ = key;
-          } else {
-            inst.__setProperty('__key__', key, true);
+          inst.__key__ = key;
+          if (!inst.isPlaceholder && i < this.limit) {
             inst.__setProperty(this.as, c.getItem(key), true);
           }
         } else {
@@ -661,12 +654,21 @@ Then the `observe` property should be configured as follows:
           var el = inst._children[i];
           Polymer.dom(inst.root).appendChild(el);
         }
-        this._pool.push(inst);
+        if (!keepInstance) {
+          this._pool.push(inst);
+        }
       }
       if (!keepInstance) {
         this._instances.splice(idx, 1);
       }
       return inst;
+    },
+
+    _detachAllRows: function() {
+      for (var i=0; i<this._instances.length; i++) {
+        this._detachRow(i, true);
+      }
+      this._instances.length = 0;
     },
 
     _insertRow: function(idx, key, replace, makePlaceholder) {
@@ -678,6 +680,8 @@ Then the `observe` property should be configured as follows:
         };
       } else {
         if (inst = this._pool.pop()) {
+          // TODO(kschaaf): If the pool is shared across turns, parentProps
+          // need to be re-set to reused instances in addition to item/key
           inst.__setProperty(this.as, this.collection.getItem(key), true);
           inst.__setProperty('__key__', key, true);
         } else {
@@ -749,18 +753,24 @@ Then the `observe` property should be configured as follows:
     // Called as side-effect of a host property change, responsible for
     // notifying parent path change on each inst
     _forwardParentProp: function(prop, value) {
-      this._instances.forEach(function(inst) {
-        inst.__setProperty(prop, value, true);
-      }, this);
+      for (var i=0, i$=this._instances, il=i$.length; i<il; i++) {
+        var inst = i$[i];
+        if (!inst.isPlaceholder) {
+          inst.__setProperty(prop, value, true);
+        }
+      }
     },
 
     // Implements extension point from Templatizer
     // Called as side-effect of a host path change, responsible for
     // notifying parent path change on each inst
     _forwardParentPath: function(path, value) {
-      this._instances.forEach(function(inst) {
-        inst._notifyPath(path, value, true);
-      }, this);
+      for (var i=0, i$=this._instances, il=i$.length; i<il; i++) {
+        var inst = i$[i];
+        if (!inst.isPlaceholder) {
+          inst._notifyPath(path, value, true);
+        }
+      }
     },
 
     // Called as a side effect of a host items.<key>.<path> path change,
@@ -771,7 +781,7 @@ Then the `observe` property should be configured as follows:
         var key = path.substring(0, dot < 0 ? path.length : dot);
         var idx = this._keyToInstIdx[key];
         var inst = this._instances[idx];
-        if (inst) {
+        if (inst && !inst.isPlaceholder) {
           if (dot >= 0) {
             path = this.as + '.' + path.substring(dot+1);
             inst._notifyPath(path, value, true);

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -315,9 +315,8 @@ Then the `observe` property should be configured as follows:
       // Simple auto chunkSize throttling algorithm based on feedback loop:
       // measure actual time between frames and scale chunk count by ratio
       // of target/actual frame time
-      var lastChunkTime = this._lastChunkTime;
       var currChunkTime = performance.now();
-      var ratio = this._targetFrameTime / (currChunkTime - lastChunkTime);
+      var ratio = this._targetFrameTime / (currChunkTime - this._lastChunkTime);
       this._chunkCount = Math.round(this._chunkCount * ratio) || 1;
       this._limit += this._chunkCount;
       this._lastChunkTime = currChunkTime;
@@ -668,7 +667,7 @@ Then the `observe` property should be configured as follows:
       } else {
         inst = this._stampInstance(idx, key);
       }
-      var beforeRow = this._instances[idx + 1 ];
+      var beforeRow = this._instances[idx + 1];
       var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;
       var parentNode = Polymer.dom(this).parentNode;
       Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -195,8 +195,7 @@ Then the `observe` property should be configured as follows:
        * the `items` array, before the next paint, and puts the `dom-repeat`
        * into "chunking mode".  The remaining items will be created and rendered
        * incrementally at each animation frame therof until all instnaces have
-       * been rendered.  The number of instances created each animation frame
-       * can be controlled via the `chunkCount` property.
+       * been rendered.
        */
       initialCount: {
         type: Number,

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -394,7 +394,7 @@ Then the `observe` property should be configured as follows:
       var c = this.collection;
       // Choose rendering path: full vs. incremental using splices
       if (this._needFullRefresh) {
-        // Full refresh when items, sort, filter change or render() called
+        // Full refresh when items, sort, or filter change, or when render() called
         this._applyFullRefresh();
         this._needFullRefresh = false;
       } else if (this._keySplices.length) {
@@ -652,8 +652,7 @@ Then the `observe` property should be configured as follows:
       };
       model[this.as] = this.collection.getItem(key);
       model[this.indexAs] = idx;
-      var inst = this.stamp(model);
-      return inst;
+      return this.stamp(model);
     },
 
     _upgradePlaceholder: function(idx, key) {

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -188,7 +188,75 @@ Then the `observe` property should be configured as follows:
        * This is useful in rate-limiting shuffing of the view when
        * item changes may be frequent.
        */
-      delay: Number
+      delay: Number,
+
+      /**
+       * When `limit` is defined, the number of actually rendered template
+       * instances will be limited to this count.
+       *
+       * Note that if `initialCount` is used, the `limit` property will be
+       * automatically controlled and should not be set by the user.
+       */
+      limit: {
+        value: Infinity,
+        type: Number,
+        observer: '_limitChanged'
+      },
+
+      /**
+       * Defines an initial count of template instances to render after setting
+       * the `items` array, before the next paint, and puts the `dom-repeat`
+       * into "chunking mode".  The remaining items will be created and rendered
+       * incrementally at each animation frame therof until all instnaces have
+       * been rendered.  The number of instances created each animation frame
+       * can be controlled via the `chunkCount` property.
+       */
+      initialCount: {
+        type: Number,
+        value: 0
+      },
+
+      /**
+       * When `initialCount` is used, defines the number of instances to be
+       * created at each animation frame after rendering the `initialCount`.
+       * When left to the default `'auto'` value, the chunk count will be
+       * throttled automatically using a best effort scheme to maintain the
+       * value of the `targetFramerate` property.
+       */
+      chunkCount: {
+        type: Number,
+        value: 'auto'
+      },
+
+      /**
+       * When `initialCount` is used and `chunkCount` is set to `'auto'`, this
+       * property defines a frame rate to target by throttling the number of
+       * instances rendered each frame to not exceed the budget for the target
+       * frame rate.  Setting this to a higher number will allow lower latency
+       * and higher throughput for things like event handlers, but will result
+       * in a longer time for the remaining items to complete rendering.
+       */
+      targetFramerate: {
+        type: Number,
+        value: 20
+      },
+
+      /**
+       * Maximum number of removed instances to pool for reuse when rows are
+       * added in a future turn.  By default, pooling is enabled.
+       *
+       * Set to 0 to disable pooling, which will allow all removed instances to
+       * be garbage collected.
+       */
+      poolSize: {
+        type: Number,
+        value: 1000
+      },
+
+      _targetFrameTime: {
+        computed: '_computeFrameTime(targetFramerate)'
+      }
+
     },
 
     behaviors: [
@@ -196,23 +264,32 @@ Then the `observe` property should be configured as follows:
     ],
 
     observers: [
-      '_itemsChanged(items.*)'
+      '_itemsChanged(items.*)',
+      '_initializeChunkCount(initialCount, chunkCount)'
     ],
 
     created: function() {
       this._instances = [];
+      this._pool = [];
+      this._boundRenderChunk = this._renderChunk.bind(this);
     },
 
     detached: function() {
       for (var i=0; i<this._instances.length; i++) {
-        this._detachRow(i);
+        var inst = this._instances[i];
+        if (!inst.isPlaceholder) {
+          this._detachRow(i, true);
+        }
       }
     },
 
     attached: function() {
       var parentNode = Polymer.dom(this).parentNode;
       for (var i=0; i<this._instances.length; i++) {
-        Polymer.dom(parentNode).insertBefore(this._instances[i].root, this);
+        var inst = this._instances[i];
+        if (!inst.isPlaceholder) {
+          Polymer.dom(parentNode).insertBefore(inst.root, this);
+        }
       }
     },
 
@@ -231,9 +308,8 @@ Then the `observe` property should be configured as follows:
       }
     },
 
-    _sortChanged: function() {
+    _sortChanged: function(sort) {
       var dataHost = this._getRootDataHost();
-      var sort = this.sort;
       this._sortFn = sort && (typeof sort == 'function' ? sort :
         function() { return dataHost[sort].apply(dataHost, arguments); });
       this._needFullRefresh = true;
@@ -242,15 +318,58 @@ Then the `observe` property should be configured as follows:
       }
     },
 
-    _filterChanged: function() {
+    _filterChanged: function(filter) {
       var dataHost = this._getRootDataHost();
-      var filter = this.filter;
       this._filterFn = filter && (typeof filter == 'function' ? filter :
         function() { return dataHost[filter].apply(dataHost, arguments); });
       this._needFullRefresh = true;
       if (this.items) {
         this._debounceTemplate(this._render);
       }
+    },
+
+    _limitChanged: function(limit) {
+      if (this.items) {
+        this._debounceTemplate(this._render);
+      }
+    },
+
+    _computeFrameTime: function(rate) {
+      return Math.ceil(1000/rate);
+    },
+
+    _initializeChunkCount: function(initialCount, chunkCount) {
+      if (initialCount) {
+        this.limit = initialCount;
+        this._chunkCount = parseInt(chunkCount, 10) || initialCount;
+      }
+    },
+
+    _tryRenderChunk: function() {
+      if (this.limit >= 0 && this._chunkCount &&
+          Math.min(this.limit, this._instances.length) < this.items.length) {
+        this.debounce('renderChunk', this._requestRenderChunk);
+      }
+    },
+
+    _requestRenderChunk: function() {
+      requestAnimationFrame(this._boundRenderChunk);
+    },
+
+    _renderChunk: function() {
+      if (this.chunkCount == 'auto') {
+        // Simple auto chunkSize throttling algorithm based on feedback loop:
+        // measure actual time between frames and scale chunk count by ratio
+        // of target/actual frame time
+        var prevChunkTime = this._currChunkTime;
+        this._currChunkTime = performance.now();
+        var chunkTime = this._currChunkTime - prevChunkTime;
+        if (chunkTime) {
+          var ratio = this._targetFrameTime / chunkTime;
+          this._chunkCount = Math.round(this._chunkCount * ratio) || 1;
+        }
+      }
+      this.limit += this._chunkCount;
     },
 
     _observeChanged: function() {
@@ -324,7 +443,7 @@ Then the `observe` property should be configured as follows:
       if (this._needFullRefresh) {
         this._applyFullRefresh();
         this._needFullRefresh = false;
-      } else {
+      } else if (this._keySplices.length) {
         if (this._sortFn) {
           this._applySplicesUserSort(this._keySplices);
         } else {
@@ -338,14 +457,28 @@ Then the `observe` property should be configured as follows:
       }
       this._keySplices = [];
       this._indexSplices = [];
-      // Update final _keyToInstIdx and instance indices
+      // Update final _keyToInstIdx, instance indices, and replace placeholders
       var keyToIdx = this._keyToInstIdx = {};
-      for (var i=0; i<this._instances.length; i++) {
+      for (var i=this._instances.length-1; i>=0; i--) {
         var inst = this._instances[i];
+        if (inst.isPlaceholder && i<this.limit) {
+          inst = this._insertRow(i, inst.__key__, true);
+        } else if (!inst.isPlaceholder && i>=this.limit) {
+          inst = this._insertRow(i, inst.__key__, true, true);
+        }
         keyToIdx[inst.__key__] = i;
-        inst.__setProperty(this.indexAs, i, true);
+        if (!inst.isPlaceholder) {
+          inst.__setProperty(this.indexAs, i, true);
+        }
       }
+      // Reset the pool
+      // TODO(kschaaf): Allow pool to be reused across turns & between nested
+      // peer repeats (requires updating parentProps when reusing from pool)
+      this._pool.length = 0;
+      // Notify users
       this.fire('dom-change');
+      // Check to see if we need to render more items
+      this._tryRenderChunk();
     },
 
     // Render method 1: full refesh
@@ -385,17 +518,20 @@ Then the `observe` property should be configured as follows:
         var key = keys[i];
         var inst = this._instances[i];
         if (inst) {
-          inst.__setProperty('__key__', key, true);
-          inst.__setProperty(this.as, c.getItem(key), true);
+          if (inst.isPlaceholder) {
+            inst.__key__ = key;
+          } else {
+            inst.__setProperty('__key__', key, true);
+            inst.__setProperty(this.as, c.getItem(key), true);
+          }
         } else {
-          this._instances.push(this._insertRow(i, key));
+          this._insertRow(i, key);
         }
       }
       // Remove any extra instances from previous state
-      for (; i<this._instances.length; i++) {
-        this._detachRow(i);
+      for (var j=this._instances.length-1; j>=i; j--) {
+        this._detachRow(j);
       }
-      this._instances.splice(keys.length, this._instances.length-keys.length);
     },
 
     _keySort: function(a, b) {
@@ -414,7 +550,6 @@ Then the `observe` property should be configured as follows:
       var c = this.collection;
       var instances = this._instances;
       var keyMap = {};
-      var pool = [];
       var sortFn = this._sortFn || this._keySort.bind(this);
       // Dedupe added and removed keys to a final added/removed map
       splices.forEach(function(s) {
@@ -448,8 +583,7 @@ Then the `observe` property should be configured as follows:
           var idx = removedIdxs[i];
           // Removed idx may be undefined if item was previously filtered out
           if (idx !== undefined) {
-            pool.push(this._detachRow(idx));
-            instances.splice(idx, 1);
+            this._detachRow(idx);
           }
         }
       }
@@ -468,12 +602,12 @@ Then the `observe` property should be configured as follows:
         // Insertion-sort new instances into place (from pool or newly created)
         var start = 0;
         for (var i=0; i<addedKeys.length; i++) {
-          start = this._insertRowUserSort(start, addedKeys[i], pool);
+          start = this._insertRowUserSort(start, addedKeys[i]);
         }
       }
     },
 
-    _insertRowUserSort: function(start, key, pool) {
+    _insertRowUserSort: function(start, key) {
       var c = this.collection;
       var item = c.getItem(key);
       var end = this._instances.length - 1;
@@ -497,7 +631,7 @@ Then the `observe` property should be configured as follows:
         idx = end + 1;
       }
       // Insert instance at insertion point
-      this._instances.splice(idx, 0, this._insertRow(idx, key, pool));
+      this._insertRow(idx, key);
       return idx;
     },
 
@@ -507,37 +641,19 @@ Then the `observe` property should be configured as follows:
     // rows are as placeholders, and placeholders are updated to
     // actual rows at the end to take full advantage of removed rows
     _applySplicesArrayOrder: function(splices) {
-      var pool = [];
       var c = this.collection;
       splices.forEach(function(s) {
         // Detach & pool removed instances
         for (var i=0; i<s.removed.length; i++) {
-          var inst = this._detachRow(s.index + i);
-          if (!inst.isPlaceholder) {
-            pool.push(inst);
-          }
+          this._detachRow(s.index);
         }
-        this._instances.splice(s.index, s.removed.length);
-        // Insert placeholders for new rows
         for (var i=0; i<s.addedKeys.length; i++) {
-          var inst = {
-            isPlaceholder: true,
-            key: s.addedKeys[i]
-          };
-          this._instances.splice(s.index + i, 0, inst);
+          this._insertRow(s.index+i, s.addedKeys[i], false, true);
         }
       }, this);
-      // Replace placeholders with actual instances (from pool or newly created)
-      // Iterate backwards to ensure insertBefore refrence is never a placeholder
-      for (var i=this._instances.length-1; i>=0; i--) {
-        var inst = this._instances[i];
-        if (inst.isPlaceholder) {
-          this._instances[i] = this._insertRow(i, inst.key, pool, true);
-        }
-      }
     },
 
-    _detachRow: function(idx) {
+    _detachRow: function(idx, keepInstance) {
       var inst = this._instances[idx];
       if (!inst.isPlaceholder) {
         var parentNode = Polymer.dom(this).parentNode;
@@ -545,22 +661,41 @@ Then the `observe` property should be configured as follows:
           var el = inst._children[i];
           Polymer.dom(inst.root).appendChild(el);
         }
+        this._pool.push(inst);
+      }
+      if (!keepInstance) {
+        this._instances.splice(idx, 1);
       }
       return inst;
     },
 
-    _insertRow: function(idx, key, pool, replace) {
+    _insertRow: function(idx, key, replace, makePlaceholder) {
       var inst;
-      if (inst = pool && pool.pop()) {
-        inst.__setProperty(this.as, this.collection.getItem(key), true);
-        inst.__setProperty('__key__', key, true);
+      if (makePlaceholder || idx >= this.limit) {
+        inst = {
+          isPlaceholder: true,
+          __key__: key
+        };
       } else {
-        inst = this._generateRow(idx, key);
+        if (inst = this._pool.pop()) {
+          inst.__setProperty(this.as, this.collection.getItem(key), true);
+          inst.__setProperty('__key__', key, true);
+        } else {
+          inst = this._generateRow(idx, key);
+        }
+        var beforeRow = this._instances[replace ? idx + 1 : idx];
+        var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;
+        var parentNode = Polymer.dom(this).parentNode;
+        Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);
       }
-      var beforeRow = this._instances[replace ? idx + 1 : idx];
-      var beforeNode = beforeRow ? beforeRow._children[0] : this;
-      var parentNode = Polymer.dom(this).parentNode;
-      Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);
+      if (replace) {
+        if (makePlaceholder) {
+          this._detachRow(idx, true);
+        }
+        this._instances[idx] = inst;
+      } else {
+        this._instances.splice(idx, 0, inst);
+      }
       return inst;
     },
 

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -415,12 +415,13 @@ Then the `observe` property should be configured as follows:
       }
       this._keySplices = [];
       this._indexSplices = [];
-      // Update final _keyToInstIdx, instance indices, and replace placeholders
+      // Update final _keyToInstIdx and instance indices, and
+      // upgrade/downgrade placeholders
       var keyToIdx = this._keyToInstIdx = {};
       for (var i=this._instances.length-1; i>=0; i--) {
         var inst = this._instances[i];
         if (inst.isPlaceholder && i<this._limit) {
-          inst = this._upgradePlaceholder(i, inst.__key__);
+          inst = this._insertInstance(i, inst.__key__);
         } else if (!inst.isPlaceholder && i>=this._limit) {
           inst = this._downgradeInstance(i, inst.__key__);
         }
@@ -484,6 +485,8 @@ Then the `observe` property should be configured as follows:
           if (!inst.isPlaceholder && i < this._limit) {
             inst.__setProperty(this.as, c.getItem(key), true);
           }
+        } else if (i < this._limit) {
+          this._insertInstance(i, key);
         } else {
           this._insertPlaceholder(i, key);
         }
@@ -646,7 +649,7 @@ Then the `observe` property should be configured as follows:
       });
     },
 
-    _generateInstance: function(idx, key) {
+    _stampInstance: function(idx, key) {
       var model = {
         __key__: key
       };
@@ -655,7 +658,7 @@ Then the `observe` property should be configured as follows:
       return this.stamp(model);
     },
 
-    _upgradePlaceholder: function(idx, key) {
+    _insertInstance: function(idx, key) {
       var inst = this._pool.pop();
       if (inst) {
         // TODO(kschaaf): If the pool is shared across turns, parentProps
@@ -663,7 +666,7 @@ Then the `observe` property should be configured as follows:
         inst.__setProperty(this.as, this.collection.getItem(key), true);
         inst.__setProperty('__key__', key, true);
       } else {
-        inst = this._generateInstance(idx, key);
+        inst = this._stampInstance(idx, key);
       }
       var beforeRow = this._instances[idx + 1 ];
       var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -334,7 +334,7 @@ Then the `observe` property should be configured as follows:
     },
 
     _tryRenderChunk: function() {
-      if (this.limit >= 0 && this._chunkCount &&
+      if (this._chunkCount &&
           Math.min(this.limit, this._instances.length) < this.items.length) {
         this.debounce('renderChunk', this._requestRenderChunk);
       }
@@ -662,13 +662,6 @@ Then the `observe` property should be configured as follows:
         this._instances.splice(idx, 1);
       }
       return inst;
-    },
-
-    _detachAllRows: function() {
-      for (var i=0; i<this._instances.length; i++) {
-        this._detachRow(i, true);
-      }
-      this._instances.length = 0;
     },
 
     _insertRow: function(idx, key, replace, makePlaceholder) {

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -191,19 +191,6 @@ Then the `observe` property should be configured as follows:
       delay: Number,
 
       /**
-       * When `limit` is defined, the number of actually rendered template
-       * instances will be limited to this count.
-       *
-       * Note that if `initialCount` is used, the `limit` property will be
-       * automatically controlled and should not be set by the user.
-       */
-      limit: {
-        value: Infinity,
-        type: Number,
-        observer: '_limitChanged'
-      },
-
-      /**
        * Defines an initial count of template instances to render after setting
        * the `items` array, before the next paint, and puts the `dom-repeat`
        * into "chunking mode".  The remaining items will be created and rendered
@@ -213,28 +200,16 @@ Then the `observe` property should be configured as follows:
        */
       initialCount: {
         type: Number,
-        value: 0
+        observer: '_initializeChunking'
       },
 
       /**
-       * When `initialCount` is used, defines the number of instances to be
-       * created at each animation frame after rendering the `initialCount`.
-       * When left to the default `'auto'` value, the chunk count will be
-       * throttled automatically using a best effort scheme to maintain the
-       * value of the `targetFramerate` property.
-       */
-      chunkCount: {
-        type: Number,
-        value: 'auto'
-      },
-
-      /**
-       * When `initialCount` is used and `chunkCount` is set to `'auto'`, this
-       * property defines a frame rate to target by throttling the number of
-       * instances rendered each frame to not exceed the budget for the target
-       * frame rate.  Setting this to a higher number will allow lower latency
-       * and higher throughput for things like event handlers, but will result
-       * in a longer time for the remaining items to complete rendering.
+       * When `initialCount` is used, this property defines a frame rate to
+       * target by throttling the number of instances rendered each frame to
+       * not exceed the budget for the target frame rate.  Setting this to a
+       * higher number will allow lower latency and higher throughput for
+       * things like event handlers, but will result in a longer time for the
+       * remaining items to complete rendering.
        */
       targetFramerate: {
         type: Number,
@@ -252,32 +227,29 @@ Then the `observe` property should be configured as follows:
     ],
 
     observers: [
-      '_itemsChanged(items.*)',
-      '_initializeChunkCount(initialCount, chunkCount)'
+      '_itemsChanged(items.*)'
     ],
 
     created: function() {
       this._instances = [];
       this._pool = [];
-      this._boundRenderChunk = this._renderChunk.bind(this);
+      this._limit = Infinity;
+      var self = this;
+      this._boundRenderChunk = function() {
+        self._renderChunk();
+      };
     },
 
     detached: function() {
       for (var i=0; i<this._instances.length; i++) {
-        var inst = this._instances[i];
-        if (!inst.isPlaceholder) {
-          this._detachRow(i, true);
-        }
+        this._detachInstance(i);
       }
     },
 
     attached: function() {
-      var parentNode = Polymer.dom(this).parentNode;
+      var parent = Polymer.dom(Polymer.dom(this).parentNode);
       for (var i=0; i<this._instances.length; i++) {
-        var inst = this._instances[i];
-        if (!inst.isPlaceholder) {
-          Polymer.dom(parentNode).insertBefore(inst.root, this);
-        }
+        this._attachInstance(i, parent);
       }
     },
 
@@ -316,26 +288,22 @@ Then the `observe` property should be configured as follows:
       }
     },
 
-    _limitChanged: function(limit) {
-      if (this.items) {
-        this._debounceTemplate(this._render);
-      }
-    },
-
     _computeFrameTime: function(rate) {
       return Math.ceil(1000/rate);
     },
 
-    _initializeChunkCount: function() {
+    _initializeChunking: function() {
       if (this.initialCount) {
-        this.limit = this.initialCount;
-        this._chunkCount = parseInt(this.chunkCount, 10) || this.initialCount;
+        this._limit = this.initialCount;
+        this._chunkCount = this.initialCount;
+        this._lastChunkTime = performance.now();
       }
     },
 
     _tryRenderChunk: function() {
-      if (this._chunkCount &&
-          Math.min(this.limit, this._instances.length) < this.items.length) {
+      // Debounced so that multiple calls through `_render` between animation
+      // frames only queue one new rAF (e.g. array mutation & chunked render)
+      if (this.items && this._limit < this.items.length) {
         this.debounce('renderChunk', this._requestRenderChunk);
       }
     },
@@ -345,19 +313,16 @@ Then the `observe` property should be configured as follows:
     },
 
     _renderChunk: function() {
-      if (this.chunkCount == 'auto') {
-        // Simple auto chunkSize throttling algorithm based on feedback loop:
-        // measure actual time between frames and scale chunk count by ratio
-        // of target/actual frame time
-        var prevChunkTime = this._currChunkTime;
-        this._currChunkTime = performance.now();
-        var chunkTime = this._currChunkTime - prevChunkTime;
-        if (chunkTime) {
-          var ratio = this._targetFrameTime / chunkTime;
-          this._chunkCount = Math.round(this._chunkCount * ratio) || 1;
-        }
-      }
-      this.limit += this._chunkCount;
+      // Simple auto chunkSize throttling algorithm based on feedback loop:
+      // measure actual time between frames and scale chunk count by ratio
+      // of target/actual frame time
+      var lastChunkTime = this._lastChunkTime;
+      var currChunkTime = performance.now();
+      var ratio = this._targetFrameTime / (currChunkTime - lastChunkTime);
+      this._chunkCount = Math.round(this._chunkCount * ratio) || 1;
+      this._limit += this._chunkCount;
+      this._lastChunkTime = currChunkTime;
+      this._debounceTemplate(this._render);
     },
 
     _observeChanged: function() {
@@ -375,12 +340,10 @@ Then the `observe` property should be configured as follows:
           this._error(this._logf('dom-repeat', 'expected array for `items`,' +
             ' found', this.items));
         }
-        if (this._instances.length && this.initialCount) {
-          this._initializeChunkCount();
-        }
         this._keySplices = [];
         this._indexSplices = [];
         this._needFullRefresh = true;
+        this._initializeChunking();
         this._debounceTemplate(this._render);
       } else if (change.path == 'items.splices') {
         this._keySplices = this._keySplices.concat(change.value.keySplices);
@@ -432,9 +395,11 @@ Then the `observe` property should be configured as follows:
       var c = this.collection;
       // Choose rendering path: full vs. incremental using splices
       if (this._needFullRefresh) {
+        // Full refresh when items, sort, filter change or render() called
         this._applyFullRefresh();
         this._needFullRefresh = false;
       } else if (this._keySplices.length) {
+        // Incremental refresh when splices were queued
         if (this._sortFn) {
           this._applySplicesUserSort(this._keySplices);
         } else {
@@ -445,6 +410,9 @@ Then the `observe` property should be configured as follows:
             this._applySplicesArrayOrder(this._indexSplices);
           }
         }
+      } else {
+        // Otherwise only limit changed; no change to instances, just need to
+        // upgrade more placeholders to instances
       }
       this._keySplices = [];
       this._indexSplices = [];
@@ -452,10 +420,10 @@ Then the `observe` property should be configured as follows:
       var keyToIdx = this._keyToInstIdx = {};
       for (var i=this._instances.length-1; i>=0; i--) {
         var inst = this._instances[i];
-        if (inst.isPlaceholder && i<this.limit) {
-          inst = this._insertRow(i, inst.__key__, true);
-        } else if (!inst.isPlaceholder && i>=this.limit) {
-          inst = this._insertRow(i, inst.__key__, true, true);
+        if (inst.isPlaceholder && i<this._limit) {
+          inst = this._upgradePlaceholder(i, inst.__key__);
+        } else if (!inst.isPlaceholder && i>=this._limit) {
+          inst = this._downgradeInstance(i, inst.__key__);
         }
         keyToIdx[inst.__key__] = i;
         if (!inst.isPlaceholder) {
@@ -514,16 +482,16 @@ Then the `observe` property should be configured as follows:
         var inst = this._instances[i];
         if (inst) {
           inst.__key__ = key;
-          if (!inst.isPlaceholder && i < this.limit) {
+          if (!inst.isPlaceholder && i < this._limit) {
             inst.__setProperty(this.as, c.getItem(key), true);
           }
         } else {
-          this._insertRow(i, key);
+          this._insertPlaceholder(i, key);
         }
       }
       // Remove any extra instances from previous state
       for (var j=this._instances.length-1; j>=i; j--) {
-        this._detachRow(j);
+        this._removeInstance(j);
       }
     },
 
@@ -576,7 +544,7 @@ Then the `observe` property should be configured as follows:
           var idx = removedIdxs[i];
           // Removed idx may be undefined if item was previously filtered out
           if (idx !== undefined) {
-            this._detachRow(idx);
+            this._removeInstance(idx);
           }
         }
       }
@@ -624,7 +592,7 @@ Then the `observe` property should be configured as follows:
         idx = end + 1;
       }
       // Insert instance at insertion point
-      this._insertRow(idx, key);
+      this._insertPlaceholder(idx, key);
       return idx;
     },
 
@@ -638,71 +606,85 @@ Then the `observe` property should be configured as follows:
       splices.forEach(function(s) {
         // Detach & pool removed instances
         for (var i=0; i<s.removed.length; i++) {
-          this._detachRow(s.index);
+          this._removeInstance(s.index);
         }
         for (var i=0; i<s.addedKeys.length; i++) {
-          this._insertRow(s.index+i, s.addedKeys[i], false, true);
+          this._insertPlaceholder(s.index+i, s.addedKeys[i]);
         }
       }, this);
     },
 
-    _detachRow: function(idx, keepInstance) {
+    _detachInstance: function(idx) {
       var inst = this._instances[idx];
       if (!inst.isPlaceholder) {
-        var parentNode = Polymer.dom(this).parentNode;
         for (var i=0; i<inst._children.length; i++) {
           var el = inst._children[i];
           Polymer.dom(inst.root).appendChild(el);
         }
-        if (!keepInstance) {
-          this._pool.push(inst);
-        }
+        return inst;
       }
-      if (!keepInstance) {
-        this._instances.splice(idx, 1);
-      }
-      return inst;
     },
 
-    _insertRow: function(idx, key, replace, makePlaceholder) {
-      var inst;
-      if (makePlaceholder || idx >= this.limit) {
-        inst = {
-          isPlaceholder: true,
-          __key__: key
-        };
-      } else {
-        if (inst = this._pool.pop()) {
-          // TODO(kschaaf): If the pool is shared across turns, parentProps
-          // need to be re-set to reused instances in addition to item/key
-          inst.__setProperty(this.as, this.collection.getItem(key), true);
-          inst.__setProperty('__key__', key, true);
-        } else {
-          inst = this._generateRow(idx, key);
-        }
-        var beforeRow = this._instances[replace ? idx + 1 : idx];
-        var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;
-        var parentNode = Polymer.dom(this).parentNode;
-        Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);
+    _attachInstance: function(idx, parent) {
+      var inst = this._instances[idx];
+      if (!inst.isPlaceholder) {
+        parent.insertBefore(inst.root, this);
       }
-      if (replace) {
-        if (makePlaceholder) {
-          this._detachRow(idx, true);
-        }
-        this._instances[idx] = inst;
-      } else {
-        this._instances.splice(idx, 0, inst);
-      }
-      return inst;
     },
 
-    _generateRow: function(idx, key) {
+    _removeInstance: function(idx) {
+      var inst = this._detachInstance(idx);
+      if (inst) {
+        this._pool.push(inst);
+      }
+      this._instances.splice(idx, 1);
+    },
+
+    _insertPlaceholder: function(idx, key) {
+      this._instances.splice(idx, 0, {
+        isPlaceholder: true,
+        __key__: key
+      });
+    },
+
+    _generateInstance: function(idx, key) {
       var model = {
         __key__: key
       };
       model[this.as] = this.collection.getItem(key);
       model[this.indexAs] = idx;
       var inst = this.stamp(model);
+      return inst;
+    },
+
+    _upgradePlaceholder: function(idx, key) {
+      var inst = this._pool.pop();
+      if (inst) {
+        // TODO(kschaaf): If the pool is shared across turns, parentProps
+        // need to be re-set to reused instances in addition to item/key
+        inst.__setProperty(this.as, this.collection.getItem(key), true);
+        inst.__setProperty('__key__', key, true);
+      } else {
+        inst = this._generateInstance(idx, key);
+      }
+      var beforeRow = this._instances[idx + 1 ];
+      var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;
+      var parentNode = Polymer.dom(this).parentNode;
+      Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);
+      this._instances[idx] = inst;
+      return inst;
+    },
+
+    _downgradeInstance: function(idx, key) {
+      var inst = this._detachInstance(idx);
+      if (inst) {
+        this._pool.push(inst);
+      }
+      inst = {
+        isPlaceholder: true,
+        __key__: key
+      };
+      this._instances[idx] = inst;
       return inst;
     },
 

--- a/test/unit/dom-repeat-elements.html
+++ b/test/unit/dom-repeat-elements.html
@@ -414,7 +414,7 @@ window.data = [
 
 <dom-module id="x-repeat-limit">
   <template>
-    <template id="repeater" is="dom-repeat" items="{{items}}" limit="2">
+    <template id="repeater" is="dom-repeat" items="{{items}}">
       <div prop="{{outerProp.prop}}">{{item.prop}}</div>
     </template>
   </template>
@@ -422,7 +422,7 @@ window.data = [
     Polymer({
       is: 'x-repeat-limit',
       properties: {
-        items: {
+        preppedItems: {
           value: function() {
             var ar = [];
             for (var i = 0; i < 20; i++) {

--- a/test/unit/dom-repeat-elements.html
+++ b/test/unit/dom-repeat-elements.html
@@ -411,3 +411,64 @@ window.data = [
     });
   </script>
 </dom-module>
+
+<dom-module id="x-repeat-limit">
+  <template>
+    <template id="repeater" is="dom-repeat" items="{{items}}" limit="2">
+      <div prop="{{outerProp.prop}}">{{item.prop}}</div>
+    </template>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-repeat-limit',
+      properties: {
+        items: {
+          value: function() {
+            var ar = [];
+            for (var i = 0; i < 20; i++) {
+              ar.push({prop: i});
+            }
+            return ar;
+          }
+        },
+        outerProp: {
+          value: function() {
+            return {prop: 'outer'};
+          }
+        }
+      }
+    });
+  </script>
+</dom-module>
+
+<dom-module id="x-repeat-chunked">
+  <template>
+    <template id="repeater" is="dom-repeat" items="{{items}}" initial-count="10">
+      <x-wait>{{item.prop}}</x-wait>
+    </template>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-repeat-chunked',
+      properties: {
+        preppedItems: {
+          value: function() {
+            var ar = [];
+            for (var i = 0; i < 100; i++) {
+              ar.push({prop: i});
+            }
+            return ar;
+          }
+        }
+      }
+    });
+    Polymer({
+      is: 'x-wait',
+      created: function() {
+        var time = performance.now();
+        time += 4;
+        while (performance.now() < time) {}
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -71,6 +71,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <h4>x-primitive-large</h4>
   <x-primitive-large id="primitiveLarge"></x-primitive-large>
 
+  <h4>x-repeat-limit</h4>
+  <x-repeat-limit id="limited"></x-repeat-limit>
+
+  <h4>x-repeat-chunked</h4>
+  <x-repeat-chunked id="chunked"></x-repeat-chunked>
+
   <div id="inDocumentContainer">
   </div>
 
@@ -92,6 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       stamped[37] .. 3-3-2
       stamped[38] .. 3-3-3
     */
+
 
     suite('errors', function() {
 
@@ -3344,6 +3351,501 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Revert
         primitive.splice('items', 5, 2);
         primitive.$.repeater1.render();
+      });
+
+    });
+
+
+    suite('limit', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(parseInt(stamped[i].textContent), i);
+        }
+      };
+
+      test('initial limit', function() {
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('change item paths in & out of limit', function() {
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        limited.outerProp = {prop: 'changed'};
+        assert.equal(stamped[0].prop, 'changed');
+        limited.set('items.0.prop', '0-changed');
+        limited.set('items.3.prop', '3-changed');
+        assert.equal(stamped[0].textContent, '0-changed');
+        limited.set('outerProp.prop', 'changed again');
+        assert.equal(stamped[0].prop, 'changed again');
+      });
+
+      test('increase limit', function(done) {
+        // Increase limit and test async rendering
+        limited.$.repeater.limit = 10;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+          assert.equal(stamped[3].prop, 'changed again');
+          assert.equal(stamped[3].textContent, '3-changed');
+          limited.set('items.0.prop', 0);
+          limited.set('items.3.prop', 3);
+          // Increase limit and test sync rendering
+          limited.$.repeater.limit = 20;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 20);
+          checkItemOrder(stamped);
+          done();
+        });
+      });
+
+      test('increase limit above items.length', function() {
+        limited.$.repeater.limit = 30;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 20);
+          checkItemOrder(stamped);
+      });
+
+      test('decrease limit', function(done) {
+        // Decrease limit and test async rendering
+        limited.$.repeater.limit = 15;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 15);
+          checkItemOrder(stamped);
+          // Decrease limit and test sync rendering
+          limited.$.repeater.limit = 0;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 0);
+          done();
+        });
+      });
+
+      test('negative limit', function() {
+        limited.$.repeater.limit = -10;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('limit with sort', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, 19 - i);
+        }
+      };
+
+      test('initial limit', function() {
+        var items = limited.items;
+        limited.$.repeater.limit = 2;
+        limited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        limited.items = null;
+        Polymer.dom.flush();
+        limited.items = items;
+        Polymer.dom.flush();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit', function(done) {
+        // Increase limit and test async rendering
+        limited.$.repeater.limit = 10;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+          // Increase limit and test sync rendering
+          limited.$.repeater.limit = 20;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 20);
+          checkItemOrder(stamped);
+          done();
+        });
+      });
+
+      test('increase limit above items.length', function() {
+        limited.$.repeater.limit = 30;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 20);
+          checkItemOrder(stamped);
+      });
+
+      test('decrease limit', function(done) {
+        // Decrease limit and test async rendering
+        limited.$.repeater.limit = 15;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 15);
+          checkItemOrder(stamped);
+          // Decrease limit and test sync rendering
+          limited.$.repeater.limit = 0;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 0);
+          done();
+        });
+      });
+
+      test('negative limit', function() {
+        limited.$.repeater.limit = -10;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('limit with filter', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, i * 2);
+        }
+      };
+
+      test('initial limit', function() {
+        var items = limited.items;
+        limited.$.repeater.limit = 2;
+        limited.$.repeater.sort = null;
+        limited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        limited.items = null;
+        Polymer.dom.flush();
+        limited.items = items;
+        Polymer.dom.flush();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit', function(done) {
+        // Increase limit and test async rendering
+        limited.$.repeater.limit = 5;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 5);
+          checkItemOrder(stamped);
+          // Increase limit and test sync rendering
+          limited.$.repeater.limit = 10;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+          done();
+        });
+      });
+
+      test('increase limit above items.length', function() {
+        limited.$.repeater.limit = 30;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+      });
+
+      test('decrease limit', function(done) {
+        // Decrease limit and test async rendering
+        limited.$.repeater.limit = 5;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 5);
+          checkItemOrder(stamped);
+          // Decrease limit and test sync rendering
+          limited.$.repeater.limit = 0;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 0);
+          done();
+        });
+      });
+
+      test('negative limit', function() {
+        limited.$.repeater.limit = -10;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('limit with sort & filter', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, (9 - i) * 2);
+        }
+      };
+
+      test('initial limit', function() {
+        var items = limited.items;
+        limited.$.repeater.limit = 2;
+        limited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        limited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        limited.items = null;
+        Polymer.dom.flush();
+        limited.items = items;
+        Polymer.dom.flush();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit', function(done) {
+        // Increase limit and test async rendering
+        limited.$.repeater.limit = 5;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 5);
+          checkItemOrder(stamped);
+          // Increase limit and test sync rendering
+          limited.$.repeater.limit = 10;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+          done();
+        });
+      });
+
+      test('increase limit above items.length', function() {
+        limited.$.repeater.limit = 30;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+      });
+
+      test('decrease limit', function(done) {
+        // Decrease limit and test async rendering
+        limited.$.repeater.limit = 5;
+        setTimeout(function() {
+          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 5);
+          checkItemOrder(stamped);
+          // Decrease limit and test sync rendering
+          limited.$.repeater.limit = 0;
+          Polymer.dom.flush();
+          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+          assert.equal(stamped.length, 0);
+          done();
+        });
+      });
+
+      test('negative limit', function() {
+        limited.$.repeater.limit = -10;
+        Polymer.dom.flush();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('chunked rendering', function() {
+
+      test('basic chunked rendering', function(done) {
+
+        var checkItemOrder = function(stamped) {
+          for (var i=0; i<stamped.length; i++) {
+            assert.equal(stamped[i].textContent, i);
+          }
+        };
+
+        var lastLength = 0;
+        var checkCount = function() {
+          var stamped = Polymer.dom(chunked.root).querySelectorAll('*:not(template)');
+          checkItemOrder(stamped);
+          if (stamped.length && lastLength === 0) {
+            // Initial rendering of initial count
+            assert.equal(stamped.length, 10);
+          } else {
+            // Remaining rendering incremenets
+            assert.isTrue(stamped.length > lastLength);
+          }
+          if (stamped.length < 100) {
+            lastLength = stamped.length;
+            checkUntilComplete();
+          } else {
+            // Final rendering at exact item count
+            assert.equal(stamped.length, 100);
+            done();
+          }
+        };
+        var checkUntilComplete = function() {
+          // On polyfilled MO, need to wait one setTimeout before rAF
+          if (MutationObserver._isPolyfilled) {
+            setTimeout(function() {
+              requestAnimationFrame(checkCount);
+            });
+          } else {
+            requestAnimationFrame(checkCount);
+          }
+        };
+
+        chunked.items = chunked.preppedItems.slice();
+        checkUntilComplete();
+
+      });
+
+      test('mutations during chunked rendering', function(done) {
+
+        var checkItemOrder = function(stamped) {
+          var last = -1;
+          for (var i=0; i<stamped.length; i++) {
+            var curr = parseFloat(stamped[i].textContent);
+            assert.isTrue(curr > last);
+            last = curr;
+          }
+        };
+
+        var mutateArray = function(repeater, renderedCount) {
+          // The goal here is to remove & add some, and do it over
+          // the threshold of where we have currently rendered items, and
+          // ensure that the prop values of the newly inserted items are in
+          // ascending order so we can do a simple check in checkItemOrder
+          var overlap = 2;
+          var remove = 4;
+          var add = 6;
+          var start = renderedCount.length - overlap;
+          if (start + add < repeater.items.length) {
+            var end = start + remove;
+            var args = ['items', start, remove];
+            var startVal = repeater.items[start].prop;
+            var endVal = repeater.items[end].prop;
+            var delta = (endVal - startVal) / add;
+            for (var i=0; i<add; i++) {
+              args.push({prop: startVal + i*delta});
+            }
+            repeater.splice.apply(repeater, args);
+          }
+        };
+
+        var lastLength = 0;
+        var mutateCount = 5;
+        var checkCount = function() {
+          var stamped = Polymer.dom(chunked.root).querySelectorAll('*:not(template)');
+          checkItemOrder(stamped);
+          if (stamped.length && lastLength === 0) {
+            // Initial rendering of initial count
+            assert.equal(stamped.length, 10);
+          } else {
+            // Remaining rendering incremenets
+            assert.isTrue(stamped.length > lastLength);
+          }
+          if (stamped.length < chunked.items.length) {
+            if (mutateCount-- > 0) {
+              mutateArray(chunked, stamped);
+            }
+            lastLength = stamped.length;
+            checkUntilComplete();
+          } else {
+            // Final rendering at exact item count
+            assert.equal(stamped.length, chunked.items.length);
+            done();
+          }
+        };
+        var checkUntilComplete = function() {
+          // On polyfilled MO, need to wait one setTimeout before rAF
+          if (MutationObserver._isPolyfilled) {
+            setTimeout(function() {
+              requestAnimationFrame(checkCount);
+            });
+          } else {
+            requestAnimationFrame(checkCount);
+          }
+        };
+
+        chunked.items = chunked.preppedItems.slice();
+        checkUntilComplete();
+
+      });
+
+
+      test('mutations during chunked rendering, sort & filtered', function(done) {
+
+        var checkItemOrder = function(stamped) {
+          var last = Infinity;
+          for (var i=0; i<stamped.length; i++) {
+            var curr = parseFloat(stamped[i].textContent);
+            assert.isTrue(curr <= last);
+            assert.strictEqual(curr % 2, 0);
+            last = curr;
+          }
+        };
+
+        var mutateArray = function(repeater, stamped) {
+          var start = parseInt(stamped[0].textContent);
+          var end = parseInt(stamped[stamped.length-1].textContent);
+          var mid = (end-start)/2;
+          for (var i=0; i<5; i++) {
+            chunked.push('items', {prop: mid + 1});
+          }
+          chunked.splice('items', Math.round(stamped.length/2), 3);
+        };
+
+        var lastLength = 0;
+        var mutateCount = 5;
+        var checkCount = function() {
+          var stamped = Polymer.dom(chunked.root).querySelectorAll('*:not(template)');
+          checkItemOrder(stamped);
+          var filteredLength = chunked.items.filter(chunked.$.repeater.filter).length;
+          if (stamped.length && lastLength === 0) {
+            // Initial rendering of initial count
+            assert.equal(stamped.length, 10);
+          } else {
+            // Remaining rendering incremenets
+            if (stamped.length < filteredLength) {
+              assert.isTrue(stamped.length > lastLength);
+            }
+          }
+          if (stamped.length < filteredLength) {
+            if (mutateCount-- > 0) {
+              mutateArray(chunked, stamped);
+            }
+            lastLength = stamped.length;
+            checkUntilComplete();
+          } else {
+            assert.equal(stamped.length, filteredLength);
+            done();
+          }
+        };
+        var checkUntilComplete = function() {
+          // On polyfilled MO, need to wait one setTimeout before rAF
+          if (MutationObserver._isPolyfilled) {
+            setTimeout(function() {
+              requestAnimationFrame(checkCount);
+            });
+          } else {
+            requestAnimationFrame(checkCount);
+          }
+        };
+
+        chunked.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        chunked.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        chunked.items = chunked.preppedItems.slice();
+        checkUntilComplete();
+
       });
 
     });

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3365,6 +3365,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
 
       test('initial limit', function() {
+        limited.items = limited.preppedItems;
+        limited.$.repeater._limit = 2;
+        limited.$.repeater.render();
         var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 2);
         checkItemOrder(stamped);
@@ -3381,54 +3384,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(stamped[0].prop, 'changed again');
       });
 
-      test('increase limit', function(done) {
-        // Increase limit and test async rendering
-        limited.$.repeater.limit = 10;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 10);
-          checkItemOrder(stamped);
-          assert.equal(stamped[3].prop, 'changed again');
-          assert.equal(stamped[3].textContent, '3-changed');
-          limited.set('items.0.prop', 0);
-          limited.set('items.3.prop', 3);
-          // Increase limit and test sync rendering
-          limited.$.repeater.limit = 20;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 20);
-          checkItemOrder(stamped);
-          done();
-        });
+      test('increase limit', function() {
+        // Increase limit
+        limited.$.repeater._limit = 10;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+        assert.equal(stamped[3].prop, 'changed again');
+        assert.equal(stamped[3].textContent, '3-changed');
+        limited.set('items.0.prop', 0);
+        limited.set('items.3.prop', 3);
+        // Increase limit
+        limited.$.repeater._limit = 20;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.limit = 30;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = 30;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 20);
-          checkItemOrder(stamped);
+        checkItemOrder(stamped);
       });
 
-      test('decrease limit', function(done) {
-        // Decrease limit and test async rendering
-        limited.$.repeater.limit = 15;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 15);
-          checkItemOrder(stamped);
-          // Decrease limit and test sync rendering
-          limited.$.repeater.limit = 0;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 0);
-          done();
-        });
+      test('decrease limit', function() {
+        // Decrease limit
+        limited.$.repeater._limit = 15;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 15);
+        checkItemOrder(stamped);
+        // Decrease limit
+        limited.$.repeater._limit = 0;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.limit = -10;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = -10;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 0);
       });
@@ -3444,64 +3443,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
 
       test('initial limit', function() {
-        var items = limited.items;
-        limited.$.repeater.limit = 2;
+        limited.$.repeater._limit = 2;
         limited.$.repeater.sort = function(a, b) {
           return b.prop - a.prop;
         };
         limited.items = null;
-        Polymer.dom.flush();
-        limited.items = items;
-        Polymer.dom.flush();
+        limited.$.repeater.render();
+        limited.items = limited.preppedItems;
+        limited.$.repeater.render();
         var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 2);
         checkItemOrder(stamped);
       });
 
-      test('increase limit', function(done) {
-        // Increase limit and test async rendering
-        limited.$.repeater.limit = 10;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 10);
-          checkItemOrder(stamped);
-          // Increase limit and test sync rendering
-          limited.$.repeater.limit = 20;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 20);
-          checkItemOrder(stamped);
-          done();
-        });
+      test('increase limit', function() {
+        // Increase limit
+        limited.$.repeater._limit = 10;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+        // Increase limit
+        limited.$.repeater._limit = 20;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.limit = 30;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = 30;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 20);
-          checkItemOrder(stamped);
+        checkItemOrder(stamped);
       });
 
-      test('decrease limit', function(done) {
-        // Decrease limit and test async rendering
-        limited.$.repeater.limit = 15;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 15);
-          checkItemOrder(stamped);
-          // Decrease limit and test sync rendering
-          limited.$.repeater.limit = 0;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 0);
-          done();
-        });
+      test('decrease limit', function() {
+        // Decrease limit
+        limited.$.repeater._limit = 15;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 15);
+        checkItemOrder(stamped);
+        // Decrease limit
+        limited.$.repeater._limit = 0;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.limit = -10;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = -10;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 0);
       });
@@ -3518,64 +3512,60 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('initial limit', function() {
         var items = limited.items;
-        limited.$.repeater.limit = 2;
+        limited.$.repeater._limit = 2;
         limited.$.repeater.sort = null;
         limited.$.repeater.filter = function(a) {
           return (a.prop % 2) === 0;
         };
         limited.items = null;
-        Polymer.dom.flush();
+        limited.$.repeater.render();
         limited.items = items;
-        Polymer.dom.flush();
+        limited.$.repeater.render();
         var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 2);
         checkItemOrder(stamped);
       });
 
-      test('increase limit', function(done) {
-        // Increase limit and test async rendering
-        limited.$.repeater.limit = 5;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 5);
-          checkItemOrder(stamped);
-          // Increase limit and test sync rendering
-          limited.$.repeater.limit = 10;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 10);
-          checkItemOrder(stamped);
-          done();
-        });
+      test('increase limit', function() {
+        // Increase limit
+        limited.$.repeater._limit = 5;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Increase limit
+        limited.$.repeater._limit = 10;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.limit = 30;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = 30;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 10);
           checkItemOrder(stamped);
       });
 
-      test('decrease limit', function(done) {
-        // Decrease limit and test async rendering
-        limited.$.repeater.limit = 5;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 5);
-          checkItemOrder(stamped);
-          // Decrease limit and test sync rendering
-          limited.$.repeater.limit = 0;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 0);
-          done();
-        });
+      test('decrease limit', function() {
+        // Decrease limit
+        limited.$.repeater._limit = 5;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Decrease limit
+        limited.$.repeater._limit = 0;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.limit = -10;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = -10;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 0);
       });
@@ -3592,7 +3582,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('initial limit', function() {
         var items = limited.items;
-        limited.$.repeater.limit = 2;
+        limited.$.repeater._limit = 2;
         limited.$.repeater.sort = function(a, b) {
           return b.prop - a.prop;
         };
@@ -3600,58 +3590,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return (a.prop % 2) === 0;
         };
         limited.items = null;
-        Polymer.dom.flush();
+        limited.$.repeater.render();
         limited.items = items;
-        Polymer.dom.flush();
+        limited.$.repeater.render();
         var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 2);
         checkItemOrder(stamped);
       });
 
-      test('increase limit', function(done) {
-        // Increase limit and test async rendering
-        limited.$.repeater.limit = 5;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 5);
-          checkItemOrder(stamped);
-          // Increase limit and test sync rendering
-          limited.$.repeater.limit = 10;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 10);
-          checkItemOrder(stamped);
-          done();
-        });
-      });
-
-      test('increase limit above items.length', function() {
-        limited.$.repeater.limit = 30;
-        Polymer.dom.flush();
+      test('increase limit', function() {
+        // Increase limit
+        limited.$.repeater._limit = 5;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Increase limit
+        limited.$.repeater._limit = 10;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 10);
         checkItemOrder(stamped);
       });
 
-      test('decrease limit', function(done) {
-        // Decrease limit and test async rendering
-        limited.$.repeater.limit = 5;
-        setTimeout(function() {
-          var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 5);
-          checkItemOrder(stamped);
-          // Decrease limit and test sync rendering
-          limited.$.repeater.limit = 0;
-          Polymer.dom.flush();
-          stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
-          assert.equal(stamped.length, 0);
-          done();
-        });
+      test('increase limit above items.length', function() {
+        limited.$.repeater._limit = 30;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+      });
+
+      test('decrease limit', function() {
+        // Decrease limit
+        limited.$.repeater._limit = 5;
+        limited.$.repeater.render();
+        var stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Decrease limit
+        limited.$.repeater._limit = 0;
+        limited.$.repeater.render();
+        stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
+        assert.equal(stamped.length, 0);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.limit = -10;
-        Polymer.dom.flush();
+        limited.$.repeater._limit = -10;
+        limited.$.repeater.render();
         stamped = Polymer.dom(limited.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 0);
       });


### PR DESCRIPTION
Adds optional incremental "chunked" rendering to `dom-repeat`.

New API:
* `limit` - a static value that can be used to limit the number of instances rendered
* `initialCount` - enables incremental rendering and sets initial render count (when used, limit will be automatically controlled and should not be set by the user)
* `chunkCount` - sets incremental count to be rendered per rAF; default is `'auto'`, which adjusts the chunk size using simple throttling scheme to target a set frame rate
* `targetFramerate` -  when `'auto'` chunk size is used, determines the target frame budget

If `initialCount` is set, after setting (or re-setting) `items`, the initial count will be rendered pre-paint, and all remaining items will be incrementally rendered at `requestAnimationFrame` timing in increments of `chunkCount`.
