### PR TITLE
Fix using value$ on input element

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -313,7 +313,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // `value` attribute if it previously had a value (can't
         // unconditionally set '' before removing since attributes with `$`
         // can't be set using setAttribute)
-        if (node.localName == 'input' && name == 'value') {
+        if (node.localName === 'input' && origName === 'value') {
           node.setAttribute(origName, '');
         }
         // Remove annotation

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -434,20 +434,26 @@
 </script>
 
 <dom-module id="x-entity-and-binding">
-    <template>
-      <p>&copy;</p>
-      <p id="binding">{{myText}}</p>
-    </template>
-  </dom-module>
+  <template>
+    <p>&copy;</p>
+    <p id="binding">{{myText}}</p>
+  </template>
+</dom-module>
 
-  <script>
-    Polymer({
-      is: "x-entity-and-binding",
-      properties: {
-        myText: {
-          type: String,
-          value: 'binding'
-        }
+<script>
+  Polymer({
+    is: "x-entity-and-binding",
+    properties: {
+      myText: {
+        type: String,
+        value: 'binding'
       }
-    });
-  </script>
+    }
+  });
+</script>
+
+<dom-module id="x-input-value">
+  <template>
+    <input id="input" value$="{{inputValue}}">
+  </template>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -16,7 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../polymer.html">
   <link rel="import" href="bind-elements.html">
 <body>
-
 <script>
 
 suite('single-element binding effects', function() {
@@ -593,6 +592,17 @@ suite('binding to attribute', function() {
       el.attrvalue.getTime());
     el.attrvalue = null;
     assert(!el.$.boundChild.hasAttribute('attrvalue'));
+  });
+
+  test('bind to value attribute on input should not fail', function() {
+    Polymer({
+      is: 'x-input-value'
+    });
+
+    var el = document.createElement('x-input-value');
+    el.inputValue = "the value";
+    assert.equal(el.$.input.value, "the value", "The value of the input is not propagated");
+    assert.equal(el.$.input.value$, undefined, "value$ should be removed from input");
   });
 
 });


### PR DESCRIPTION
The error was thrown because of a specific edge case for `<input value$="">`. This check was introduced in #1589 for #1578 and latest modified on https://github.com/Polymer/polymer/commit/a300862f5d3d34b01f09f7290eb8540f501c424d#diff-870cfe064a36c23b69e8da891fdff6beR299

For both `value$` and `value` `name === 'value'`. However, if it was originally `value$` it should not be executed. Therefore the check should be changed to `origName === 'value'`.

Fixes #2666 