### PR TITLE
Fix parsing of minimized css output

### DIFF
--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -171,7 +171,7 @@ Polymer.CssParse = (function() {
     _rx: {
       comments: /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim,
       port: /@import[^;]*;/gim,
-      customProp: /(?:^|[\s;])--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
+      customProp: /(?:^[^;\-\s}]+)?--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
       mixinProp: /(?:^|[\s;])?--[^;{]*?:[^{;]*?{[^}]*?}(?:[;\n]|$)?/gim,
       mixinApply: /@apply[\s]*\([^)]*?\)[\s]*(?:[;\n]|$)?/gim,
       varApply: /[^;:]*?:[^;]*?var\([^;]*\)(?:[;\n]|$)?/gim,

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -235,6 +235,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           --variable-property-after-property: 3px;
           --variable-property-after-assignment: 4px;
           --variable-property-before-assignment: 5px;
+          --variable-into-first-variable: 9px;
+          --variable-into-second-variable: 10px;
+          --variable-into-third-variable: 11px;
         }
       </style>
       <child-variable-with-var id="child"></child-variable-with-var>
@@ -251,7 +254,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           --variable-between-properties: 6px;
           background-color: var(--variable-property-before-property); padding-top: var(--variable-property-after-property);
           --variable-assignment-before-property: 7px; padding-bottom: var(--variable-property-after-assignment);
-          padding-left: var(--variable-property-before-assignment);--variable-assignment-after-property: 8px
+          padding-left: var(--variable-property-before-assignment);--variable-assignment-after-property: 8px;
+          top: 12px;--variable-from-other-variable: var(--variable-into-first-variable);--variable-from-another-variable: var(--variable-into-second-variable); --variable-from-last-variable: var(--variable-into-third-variable);
         }
       </style>
       <child-of-child-with-var id="child"></child-of-child-with-var>
@@ -266,6 +270,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           padding-right: var(--variable-between-properties);
           margin-left: var(--variable-assignment-before-property);
           margin-right: var(--variable-assignment-after-property);
+          bottom: var(--variable-from-other-variable);
+          left: var(--variable-from-another-variable);
+          right: var(--variable-from-last-variable);
         }
       </style>
       Text
@@ -468,11 +475,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertComputed(el, '7px', 'margin-left');
         assertComputed(el, '8px', 'margin-right');
         assertComputed(el, 'rgb(255, 255, 0)', 'background-color');
+        assertComputed(el, '9px', 'bottom');
+        assertComputed(el, '10px', 'left');
+        assertComputed(el, '11px', 'right');
+        assertComputed(el, '12px', 'top');
 
         // Because FireFox and Chrome parse font-family differently...
         var computed = getComputedStyle(el);
         assert.equal(computed['font-family'].replace(/['"]+/g, ''), 'Varela font');
       });
+
       test('BEM-like CSS selectors under media queries', function() {
         assertComputed(document.querySelector('.foo--bar'), '3px');
       });

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #gc4 {
-        --grand-child-scope-var: 
+        --grand-child-scope-var:
         var(--gc4-scope);
       }
     </style>
@@ -286,7 +286,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
     </script>
   </dom-module>
- 
+
   <dom-module id="x-scope">
     <style>
       :host {
@@ -439,14 +439,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </style>
   <template>
-    
+
   </template>
   <script>
   HTMLImports.whenReady(function() {
     Polymer({
       is: 'x-inside'
     });
-  });  
+  });
   </script>
 </dom-module>
 
@@ -679,7 +679,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // test('var values can be overridden by subsequent concrete properties', function() {
   //   assertComputed(styled.$.overridesConcrete, '4px');
   // });
-  
+
 });
 
 </script>


### PR DESCRIPTION
The problem was the expression `[\s;]` in the first non-capturing group. This incorrectly consumed the `;` from a previous css rule. 

![image](https://cloud.githubusercontent.com/assets/5948271/10973537/25f7e388-83de-11e5-9c7b-f8412ef9fe0a.png)

This check was introduced at https://github.com/Polymer/polymer/commit/6433f626c02c1037dbe30f755b67f018cddf4ef6 for #1389.

Fixes #2483 