### PR TITLE
Fix compound bindings with braces in literals

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._parseElementAnnotations(node, list);
     },
 
-    _bindingRegex: /([^{[]*)({{|\[\[)([^}\]]*)(?:]]|}})/g,
+    _bindingRegex: /([^{[]*)(\{\{|\[\[)(?!\}\}|\]\])(.+?)(?:\]\]|\}\})/g,
 
     // TODO(kschaaf): We could modify this to allow an escape mechanism by
     // looking for the escape sequence in each of the matches and converting

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -26,6 +26,7 @@
       no-computed="{{foobared(noInlineComputed)}}"
       compoundAttr1$="{{cpnd1}}{{ cpnd2 }}{{cpnd3.prop}}{{ computeCompound(cpnd4, cpnd5, 'literal')}}"
       compoundAttr2$="literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4"
+      compoundAttr3$="{{computeCompound('world', 'username ', 'Hello {0} ')}}"
       >
       Test
       </div>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -767,6 +767,12 @@ suite('compound binding / string interpolation', function() {
     assert.equal(el.$.boundChild.getAttribute('compoundAttr2'), 'literal1  literal2  literal3 literal literal4');
   });
 
+  test('compound property attribute with {} in text', function() {
+    var el = document.createElement('x-basic');
+
+    assert.equal(el.$.boundChild.getAttribute('compoundAttr3'), 'Hello {0} username world')
+  })
+
   test('compound adjacent textNode bindings', function() {
     var el = document.createElement('x-basic');
     // The single space is due to the gambit to prevent empty text nodes


### PR DESCRIPTION
The problem in this regex was the `[^}\]]*` which also triggers on a single `}`. Therefore we have to check for a group of two `}` or `]`. This is now changed to a negative look-ahead `?!` which checks for `\}\}` and `\]\]`. After that the rest of the matches are non-greedy, to prevent double consuming of `{{binding1}}{{binding2}}` to be translated into a binding with variable name `binding1}}{{binding2`.

I also escaped all `}` and `]` to force matching on literal characters.

![image](https://cloud.githubusercontent.com/assets/5948271/11040468/bb835b72-870c-11e5-92d5-0535da94e6a8.png)

Fixes #2704 