### PR TITLE
Fix templatizer under the template polyfill. forceDocumentUpgrade

### DIFF
--- a/src/lib/dom-module.html
+++ b/src/lib/dom-module.html
@@ -98,12 +98,16 @@
   document.registerElement('dom-module', DomModule);
 
   function forceDocumentUpgrade() {
+    var script = document._currentScript || document.currentScript;
+    var doc = script && script.ownerDocument || document;
+    if (!doc) {
+      return;
+    }
+    if (HTMLTemplateElement && HTMLTemplateElement.bootstrap) {
+      HTMLTemplateElement.bootstrap(doc);
+    }
     if (cePolyfill) {
-      var script = document._currentScript || document.currentScript;
-      var doc = script && script.ownerDocument || document;
-      if (doc) {
-        CustomElements.upgradeAll(doc);
-      }
+      CustomElements.upgradeAll(doc);
     }
   }
 

--- a/src/mini/template.html
+++ b/src/mini/template.html
@@ -33,12 +33,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'must not be a type-extension, found', this._template,
           'Move inside simple <template>.'));
       }
-      // bootstrap the template if it has not already been
-      if (this._template && !this._template.content && HTMLTemplateElement.bootstrap) {
-        HTMLTemplateElement.decorate(this._template);
-        // recurse if necessary
-        HTMLTemplateElement.bootstrap(this._template.content);
-      }
     },
 
     _stampTemplate: function() {


### PR DESCRIPTION
was interacting problematically with un-prepped HTMLTemplateElements.
By forcing a bootstrap before the document upgrade, we sidestep this issue.