### PR TITLE
Fix compound binding regex when a binding is preceded with text with { or ]

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._parseElementAnnotations(node, list);
     },
 
-    _bindingRegex: /([^{[]*)(\{\{|\[\[)(?!\}\}|\]\])(.+?)(?:\]\]|\}\})/g,
+    _bindingRegex: /((?!\{\{|\[\[).+?)?(\{\{|\[\[)(.+?)(?:\]\]|\}\})/g,
 
     // TODO(kschaaf): We could modify this to allow an escape mechanism by
     // looking for the escape sequence in each of the matches and converting

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -26,7 +26,7 @@
       no-computed="{{foobared(noInlineComputed)}}"
       compoundAttr1$="{{cpnd1}}{{ cpnd2 }}{{cpnd3.prop}}{{ computeCompound(cpnd4, cpnd5, 'literal')}}"
       compoundAttr2$="literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4"
-      compoundAttr3$="{{computeCompound('world', 'username ', 'Hello {0} ')}}"
+      compoundAttr3$="[yes/no]: {{cpnd1}}, {{computeCompound('world', 'username ', 'Hello {0} ')}}"
       >
       Test
       </div>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -767,10 +767,12 @@ suite('compound binding / string interpolation', function() {
     assert.equal(el.$.boundChild.getAttribute('compoundAttr2'), 'literal1  literal2  literal3 literal literal4');
   });
 
-  test('compound property attribute with {} in text', function() {
+  test('compound property attribute with {} and [] in text', function() {
     var el = document.createElement('x-basic');
 
-    assert.equal(el.$.boundChild.getAttribute('compoundAttr3'), 'Hello {0} username world')
+    el.cpnd1 = 'cpnd1';
+
+    assert.equal(el.$.boundChild.getAttribute('compoundAttr3'), '[yes/no]: cpnd1, Hello {0} username world')
   })
 
   test('compound adjacent textNode bindings', function() {


### PR DESCRIPTION
As outlined by @david-saslawsky in [his comment](https://github.com/Polymer/polymer/pull/2705#issuecomment-155527368) another edge-case for the regex is
`[YES]/[NO] {{computeCompound('world', 'username ', 'Hello {0} ')}}`

Therefore the regex is once again (sorry for the multiple PR's) changed to also cover this edge-case. Updated the original test-case to reflect this change.

![image](https://cloud.githubusercontent.com/assets/5948271/11073659/fca2da58-87eb-11e5-9348-e463932daf35.png)

@kevinpschaaf PTAL