### PR TITLE
Add Polymer.DomApi.wrap

### DIFF
--- a/src/lib/dom-api.html
+++ b/src/lib/dom-api.html
@@ -29,22 +29,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var nativeCloneNode = Element.prototype.cloneNode;
     var nativeImportNode = Document.prototype.importNode;
 
+    // ensure nodes are wrapped if SD polyfill is present
+    var needsToWrap = Settings.hasShadow && !Settings.nativeShadow;
+    var wrap = window.wrap ? window.wrap : function(node) { return node; };
+
     var DomApi = function(node) {
-      this.node = node;
+      this.node = needsToWrap ? wrap(node) : node;
       if (this.patch) {
         this.patch();
       }
     };
-
-    // ensure nodes are wrapped if SD polyfill is present
-    if (window.wrap && Settings.useShadow && !Settings.useNativeShadow) {
-      DomApi = function(node) {
-        this.node = wrap(node);
-        if (this.patch) {
-          this.patch();
-        }
-      };
-    }
 
     DomApi.prototype = {
 
@@ -66,7 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var n = node;
         // wrap document for SD polyfill
-        var wrappedDocument = wrap(document);
+        var wrappedDocument = Polymer.DomApi.wrap(document);
 
         // walk from node to `this` or `document`
         while (n && n !== wrappedDocument && n !== this.node) {
@@ -977,7 +971,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       hasInsertionPoint: hasInsertionPoint,
       ctor: DomApi,
       factory: factory,
-      hasDomApi: hasDomApi
+      hasDomApi: hasDomApi,
+      wrap: wrap
     };
 
   })();

--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -199,7 +199,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     handleNative: function(ev) {
       var handled;
       var type = ev.type;
-      var node = wrap(ev.currentTarget);
+      var node = Polymer.DomApi.wrap(ev.currentTarget);
       var gobj = node[GESTURE_KEY];
       if (!gobj) {
         return;
@@ -296,7 +296,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // automate the event listeners for the native events
     add: function(node, evType, handler) {
       // SD polyfill: handle case where `node` is unwrapped, like `document`
-      node = wrap(node);
+      node = Polymer.DomApi.wrap(node);
       var recognizer = this.gestures[evType];
       var deps = recognizer.deps;
       var name = recognizer.name;
@@ -329,7 +329,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // automate event listener removal for native events
     remove: function(node, evType, handler) {
       // SD polyfill: handle case where `node` is unwrapped, like `document`
-      node = wrap(node);
+      node = Polymer.DomApi.wrap(node);
       var recognizer = this.gestures[evType];
       var deps = recognizer.deps;
       var name = recognizer.name;

--- a/test/unit/polymer-dom-elements.html
+++ b/test/unit/polymer-dom-elements.html
@@ -349,3 +349,11 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-wrapped">
+  <script>
+  Polymer({
+    is: 'x-wrapped'
+  });
+  </script>
+</dom-module>

--- a/test/unit/polymer-dom-shadow.html
+++ b/test/unit/polymer-dom-shadow.html
@@ -55,6 +55,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <x-deep-contains></x-deep-contains>
 
+<x-wrapped></x-wrapped>
+
 <script src="polymer-dom.js"></script>
 
 </body>

--- a/test/unit/polymer-dom.html
+++ b/test/unit/polymer-dom.html
@@ -55,6 +55,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <x-deep-contains></x-deep-contains>
 
+<x-wrapped></x-wrapped>
+
 <script src="polymer-dom.js"></script>
 
 </body>

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -936,4 +936,13 @@ suite('Polymer.dom non-distributed elements', function() {
 
     document.body.removeChild(separate);
   });
+
+  test('Polymer.DomApi.wrap', function() {
+    var wrap = window.wrap || function(node) { return node; };
+
+    var node = document.querySelector('x-wrapped');
+    assert.equal(wrap(document), Polymer.DomApi.wrap(document), 'document should be wrapped');
+    assert.equal(wrap(node), Polymer.DomApi.wrap(node), 'node should be wrapped');
+    assert.equal(wrap(node), Polymer.dom(node).node, 'Polymer.dom should always wrap the input node');
+  });
 });


### PR DESCRIPTION
- Make sure nodes are wrapped under ShadowDOMPolyfill
- Forwards `window.wrap` when defined
- Remove weird forked `DomApi` definition
- Remove calls to `wrap` from gestures