### PR TITLE
Better handling and error msgs for registration oopsies

### DIFF
--- a/src/lib/polymer-bootstrap.html
+++ b/src/lib/polymer-bootstrap.html
@@ -37,13 +37,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var options = {
         prototype: prototype
       };
-      // NOTE: we're specifically supporting older Chrome versions here 
+      // NOTE: we're specifically supporting older Chrome versions here
       // (specifically Chrome 39) that throw when options.extends is undefined.
       if (prototype.extends) {
         options.extends = prototype.extends;
       }
-      Polymer.telemetry._registrate(prototype);
-      document.registerElement(prototype.is, options);
+
+      try {
+        Polymer.telemetry._registrate(prototype);
+        document.registerElement(prototype.is, options);
+      } catch(e) {
+        if (prototype.is.indexOf('-') === -1) {
+          Polymer.Base._warn([prototype.is, '::',
+              'Attempted to register invalid custom element name "' +
+              prototype.is + '". Names must include a "-". See https://goo.gl/RQIJXZ.'
+          ]);
+        } else if (e.name === 'NotSupportedError') {
+           Polymer.Base._warn([
+              prototype.is, '::', 'Element name is already registered.']);
+        } else {
+          throw e; // Throw all other errors we encounter.
+        }
+      }
       return factory;
     };
 

--- a/test/unit/micro.html
+++ b/test/unit/micro.html
@@ -139,6 +139,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var a = document.createElement('falsey-polymer-arg');
       assert.equal(a.is, 'falsey-polymer-arg');
     });
+
+    test('register invalid element names', function() {
+      var func = function() {
+        Polymer({is: 'invalid_element_name'});
+      };
+      assert.doesNotThrow(func, 'SyntaxError: Failed to execute',
+                          'registering invalid element name does not throw');
+    });
+
+    test('re-register element names', function() {
+      var func = function() {
+        Polymer({is: 'x-trivial'});
+      };
+      assert.doesNotThrow(func, 'name is already registered',
+                    're-registration does not throw');
+    });
   });
 
 </script>


### PR DESCRIPTION
- Fixes #2730
- Fixes #1163
- Fixes #2735 

Instead of throwing and preventing apps from loading, this changes warns to the console for:
- attempt to register an element with a name that's already been registered.
- invalid element name (e.g. "x" instead of "x-foo").

R: @kevinpschaaf @sorvell @azakus 
