### PR TITLE
Simpler travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,20 @@
 language: node_js
 sudo: false
-matrix:
-  include:
-  - node_js: stable
-    script: xvfb-run wct
-    addons:
-      firefox: latest
-      apt:
-        sources:
-        - google-chrome
-        packages:
-        - google-chrome-stable
-  - node_js: node
-    script:
-    - |
-      if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-        wct -s 'default'
-      fi
+node_js: 4
+addons:
+  firefox: '42.0'
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
 before_script:
 - npm install bower
 - export PATH=$PWD/node_modules/.bin:$PATH
 - bower install
+script:
+- xvfb-run wct
+- "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"
 env:
   global:
   - secure: eFrp9xwSYG579rAR9/XyXYKh+UtIQJ1xS5q5PABu4ndYFckdJb8o3m7oXqRSikbiPWbCSd3Fkd6+ZKXlcQFdjJ+nx9gFitGthtH93qkvZCO3XhWEEBPj65igIo3hrRSOB6dIWyiZcnoH9IXLLQtKXY9uL1NCqCcyVHg1omPKr9w=


### PR DESCRIPTION
Use a simpler, serial test structure:
- one build for a push, and one for a pr
  -  rather than 2 for each
- Use nodejs 4 LTS for faster installation
- Hardcode firefox 42.0 to work around travis-ci/travis-ci#5082