### PR TITLE
Use CustomEvent instead of Event

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -242,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var event = useCache && this.__eventCache[type];
       if (!event || ((event.bubbles != bubbles) || 
           (event.cancelable != cancelable))) {
-        event = new Event(type, {
+        event = new CustomEvent(type, {
           bubbles: Boolean(bubbles),
           cancelable: cancelable
         });


### PR DESCRIPTION
Per the issue described here, https://github.com/Polymer/polymer/issues/3014, new Event breaks functionality in IE11. This is easily resolved by using new CustomEvent as was previously. This also makes more sense as we are, indeed, creating a custom event.