### PR TITLE
Give dom-repeat#_targetFrameTime a type

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -217,6 +217,7 @@ Then the `observe` property should be configured as follows:
       },
 
       _targetFrameTime: {
+        type: Number,
         computed: '_computeFrameTime(targetFramerate)'
       }
 


### PR DESCRIPTION
Makes the compiler happy.