### PR TITLE
Fixes #3065: Add dom-repeat.renderedItemCount property

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -199,7 +199,8 @@ Then the `observe` property should be configured as follows:
        */
       renderedItemCount: {
         type: Number,
-        notify: true
+        notify: true,
+        readOnly: true
       },
 
       /**
@@ -450,7 +451,7 @@ Then the `observe` property should be configured as follows:
       // the same item.
       this._pool.length = 0;
       // Set rendered item count 
-      this.renderedItemCount = this._instances.length;
+      this._setRenderedItemCount(this._instances.length);
       // Notify users
       this.fire('dom-change');
       // Check to see if we need to render more items

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -192,6 +192,17 @@ Then the `observe` property should be configured as follows:
       delay: Number,
 
       /**
+       * Count of currently rendered items after `filter` (if any) has been applied.
+       * If "chunking mode" is enabled, `renderedItemCount` is updated each time a 
+       * set of template instances is rendered.
+       * 
+       */
+      renderedItemCount: {
+        type: Number,
+        notify: true
+      },
+
+      /**
        * Defines an initial count of template instances to render after setting
        * the `items` array, before the next paint, and puts the `dom-repeat`
        * into "chunking mode".  The remaining items will be created and rendered
@@ -438,6 +449,8 @@ Then the `observe` property should be configured as follows:
       // `item` may not be sufficient if the pooled instance happens to be
       // the same item.
       this._pool.length = 0;
+      // Set rendered item count 
+      this.renderedItemCount = this._instances.length;
       // Notify users
       this.fire('dom-change');
       // Check to see if we need to render more items

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3311,6 +3311,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(repeater3.keyForElement(stamped1[4]), coll3.getKey(items3[2]));
       });
 
+      test('renderedItemCount', function() {
+         var repeater1 = primitive.$.repeater1;
+         primitive.items = [ 'a', 'b', 'c', 'd', 'e' ];
+         repeater1.render();
+         assert.equal(repeater1.renderedItemCount, 5, 'renderedItemCount is incorrect');
+         repeater1.renderedItemCount = 0;
+         assert.equal(repeater1.renderedItemCount, 5, 'renderedItemCount is writable');
+         repeater1.filter = function(item) {
+           return (item != 'a' && item != 'e');
+         }
+         repeater1.render();
+         assert.equal(repeater1.renderedItemCount, 3, 'renderedItemCount incorrect after filter');
+         // reset repeater
+         repeater1.filter = undefined;
+         repeater1.render();
+      });
+
       test('__hideTemplateChildren__', function() {
         // Initially all showing
         var stamped1 = Polymer.dom(primitive.$.container1).querySelectorAll('*:not(template)');

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -115,6 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('basic rendering, downward item binding', function() {
         var stamped = Polymer.dom(configured.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 3 + 3*3 + 3*3*3, 'total stamped count incorrect');
+        assert.equal(configured.$.repeater.renderedItemCount, 3, 'rendered item count incorrect');
         assert.equal(stamped[0].itemaProp, 'prop-1');
         assert.equal(stamped[0].computeda, 'prop-1+itemForComputedA');
         assert.equal(stamped[0].indexa, 0);
@@ -282,6 +283,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         CustomElements.takeRecords();
         var stamped = Polymer.dom(configured.root).querySelectorAll('*:not(template)');
         assert.equal(stamped.length, 2 + 2*3 + 2*3*3, 'total stamped count incorrect');
+        assert.equal(configured.$.repeater.renderedItemCount, 2, 'rendered item count incorrect');
         assert.equal(stamped[0].itemaProp, 'prop-1');
         assert.equal(stamped[0].indexa, 0);
         assert.equal(stamped[13].itemaProp, 'prop-3');


### PR DESCRIPTION
I'm not sure whether this is desirable or not, but it seems like the `dom-repeat` has this information readily available, and extracting it yourself relies on either accessing internal properties (`_instances`) or using side effects (`domRepeat.indexForElement(domRepeat.previousSibling)+1` for example).

Seems like it could either be exposed as a property with `notify`, or simply as a property on the `dom-change` event. The event property might be the most efficient, but an element property seemed more Polymeric.

Feel free to close if this isn't the right API or I'm going about it the wrong way. 