### PR TITLE
Fixes #3023: Add style support for css selectors type [foo~=bar].

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -250,7 +250,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var SCOPE_DOC_SELECTOR = ':not([' + SCOPE_NAME + '])' +
       ':not(.' + SCOPE_NAME + ')';
     var COMPLEX_SELECTOR_SEP = ',';
-    var SIMPLE_SELECTOR_SEP = /(^|[\s>+~]+)([^\s>+~]+)/g;
+    var SIMPLE_SELECTOR_SEP = /(^|[\s>+~]+)([^\s>+~=]+)/g;
     var HOST = ':host';
     var ROOT = ':root';
     // NOTE: this supports 1 nested () pair for things like

--- a/test/unit/css-parse.html
+++ b/test/unit/css-parse.html
@@ -49,6 +49,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-left: 0 !important;
       }
     }
+
+    .foo[bar~=baz] {
+      background: black;
+    }
   </style>
 
   <style id="test-ignore">
@@ -123,6 +127,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(tree.rules[0].selector, ':host', 'unexpected selector');
       assert.equal(tree.rules[2].selector, '@-webkit-keyframes fill-unfill-rotate', 'unexpected selector in keyframes');
       assert.equal(tree.rules[3].selector, '@media (max-width: 400px)', 'unexpected selector in @media');
+      assert.equal(tree.rules[4].selector, '.foo[bar~=baz]', 'unexpected selector in attributes');
     });
 
     test('rule cssText parse', function() {

--- a/test/unit/css-parse.html
+++ b/test/unit/css-parse.html
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('css rules parse', function() {
-      assert.equal(tree.rules.length, 4, 'unexpected number of rules');
+      assert.equal(tree.rules.length, 5, 'unexpected number of rules');
       assert.equal(tree.rules[2].rules.length, 8, 'unexpected number of rules in keyframes');
       assert.equal(tree.rules[3].rules.length, 1, 'unexpected number of rules in @media');
       console.log('test');


### PR DESCRIPTION
It was a problem with css separators. It was just looking for ~ as separator but there is a possibility to use ~ as part of an attribute css selector.

```css
element[myattribute~=partial] {
    // some visuals
}
```

Edit: http://www.w3.org/TR/css3-selectors/