### PR TITLE
ES5 strict doesn't like function declarations inside inner blocks.

### DIFF
--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="style-transformer.html">
 <link rel="import" href="style-defaults.html">
 
-<!-- 
+<!--
 
 The `custom-style` extension of the native `<style>` element allows defining styles
 in the main document that can take advantage of several special features of
@@ -23,7 +23,7 @@ not leak into local DOM when running on browsers without non-native Shadow DOM.
 browsers without non-native Shadow DOM.
 * Custom properties used by Polymer's shim for cross-scope styling
 may be defined in an `custom-style`.
-* An `include` attribute may be specified to pull in style data from a 
+* An `include` attribute may be specified to pull in style data from a
 `dom-module` matching the include attribute. By using `include`, style data
 can be shared between multiple `custom-style` elements.
 
@@ -37,22 +37,22 @@ Example:
   <link rel="import" href="components/polymer/polymer.html">
 
   <style is="custom-style">
-    
+
     /* Will be prevented from affecting local DOM of Polymer elements */
     * {
       box-sizing: border-box;
     }
-    
+
     /* Can use /deep/ and ::shadow combinators */
     body /deep/ .my-special-view::shadow #thing-inside {
       background: yellow;
     }
-    
+
     /* Custom properties that inherit down the document tree may be defined */
     body {
       --my-toolbar-title-color: green;
     }
-    
+
   </style>
 
 </head>
@@ -95,7 +95,7 @@ Note, all features of `custom-style` are available when defining styles as part 
     },
 
     ready: function() {
-      // NOTE: we cannot just check attached because custom elements in 
+      // NOTE: we cannot just check attached because custom elements in
       // HTMLImports do not get attached.
       this._tryApply();
     },
@@ -107,7 +107,7 @@ Note, all features of `custom-style` are available when defining styles as part 
     _tryApply: function() {
       if (!this._appliesToDocument) {
         // only apply variables iff this style is not inside a dom-module
-        if (this.parentNode && 
+        if (this.parentNode &&
           (this.parentNode.localName !== 'dom-module')) {
           this._appliesToDocument = true;
           // used applied element from HTMLImports polyfill or this
@@ -129,13 +129,13 @@ Note, all features of `custom-style` are available when defining styles as part 
       }
     },
 
-    // polyfill this style with root scoping and 
+    // polyfill this style with root scoping and
     // apply custom properties!
     _apply: function(deferProperties) {
       // used applied element from HTMLImports polyfill or this
       var e = this.__appliedElement || this;
       if (this.include) {
-        e.textContent = styleUtil.cssFromModules(this.include, true) + 
+        e.textContent = styleUtil.cssFromModules(this.include, true) +
           e.textContent;
       }
       if (e.textContent) {
@@ -143,21 +143,21 @@ Note, all features of `custom-style` are available when defining styles as part 
           styleTransformer.documentRule(rule);
         });
         // Allow all custom-styles defined in this turn to register
-        // before applying any properties. This helps ensure that all properties 
+        // before applying any properties. This helps ensure that all properties
         // are defined before any are consumed.
         // Premature application of properties can occur in 2 cases:
-        // (1) A property `--foo` is consumed in a custom-style 
-        // before another custom-style produces `--foo`. 
+        // (1) A property `--foo` is consumed in a custom-style
+        // before another custom-style produces `--foo`.
         // In general, we require custom properties to be defined before being
         // used in elements so supporting this for custom-style
-        // is dubious but is slightly more like native properties where this 
+        // is dubious but is slightly more like native properties where this
         // is supported.
-        // (2) A set of in order styles (A, B) are re-ordered due to a parser 
-        // yield that makes A wait for textContent. This reorders its 
-        // `_apply` after B. 
+        // (2) A set of in order styles (A, B) are re-ordered due to a parser
+        // yield that makes A wait for textContent. This reorders its
+        // `_apply` after B.
         // This case should only occur with native webcomponents.
         var self = this;
-        function fn() {
+        var fn = function fn() {
           self._applyCustomProperties(e);
         }
         if (this._pendingApplyProperties) {
@@ -183,9 +183,9 @@ Note, all features of `custom-style` are available when defining styles as part 
           // so next function isn't confused
           // NOTE: we have 3 categories of css:
           // (1) normal properties,
-          // (2) custom property assignments (--foo: red;), 
+          // (2) custom property assignments (--foo: red;),
           // (3) custom property usage: border: var(--foo); @apply(--foo);
-          // In elements, 1 and 3 are separated for efficiency; here they 
+          // In elements, 1 and 3 are separated for efficiency; here they
           // are not and this makes this case unique.
           css = cssParse.removeCustomPropAssignment(css);
           // replace with reified properties, scenario is same as mixin


### PR DESCRIPTION
(review changes with [github's whitespace-ignoring view](?w=1) to reduce the solid-green diff line-ending fight)