### PR TITLE
Put beforeRegister in the behaviorProperties.

### DIFF
--- a/src/micro/behaviors.html
+++ b/src/micro/behaviors.html
@@ -146,6 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // for calling via doBehavior (e.g. created, ready)
   Polymer.Base._behaviorProperties = {
     hostAttributes: true,
+    beforeRegister: true,
     registered: true,
     properties: true,
     observers: true,


### PR DESCRIPTION
Fix a problem where beforeRegister was being copied into the element prototype, causing doBehavior_ to call beforeRegister twice.

Fixes #3076.