### PR TITLE
loosen isLightDescendant's @param type to Node

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -402,7 +402,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Checks whether an element is in this element's light DOM tree.
      *
      * @method isLightDescendant
-     * @param {Node} node The element to be checked.
+     * @param {?Node} node The element to be checked.
      * @return {Boolean} true if node is in this element's light DOM tree.
      */
     isLightDescendant: function(node) {

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -402,7 +402,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Checks whether an element is in this element's light DOM tree.
      *
      * @method isLightDescendant
-     * @param {HTMLElement=} node The element to be checked.
+     * @param {Node} node The element to be checked.
      * @return {Boolean} true if node is in this element's light DOM tree.
      */
     isLightDescendant: function(node) {


### PR DESCRIPTION
`isLightDescendant` doesn't use any `HTMLElement`'s API and can validly be simply `Node` when processing events on `document`.

also, I've removed the trailing `{...=}` because `Polymer.dom()` requires `?Node|?Event` as far as I can tell (from the externs) and `node` probably shouldn't be optional.  if somewhere really does use `.isLightDescendant()`, closure should let us know.

note: this doesn't address the `EventTarget` use-case (i.e. events on `window`).

/cc @notwaldorf @sorvell 