### PR TITLE
Fix caching the original target causing memory leaks.

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -516,7 +516,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!hasLeftMouseButton(e)) {
         return;
       }
-      var t = Gestures.findOriginalTarget(e);
       var self = this;
       var movefn = function movefn(e) {
         var x = e.clientX, y = e.clientY;
@@ -529,7 +528,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             self.info.state = 'end';
             untrackDocument(self.info);
           }
-          self.fire(t, e);
+          self.fire(Gestures.findOriginalTarget(e), e);
           self.info.started = true;
         }
       };

--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -428,22 +428,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!hasLeftMouseButton(e)) {
         return;
       }
-      var t = Gestures.findOriginalTarget(e);
       var self = this;
       var movefn = function movefn(e) {
         if (!hasLeftMouseButton(e)) {
-          self.fire('up', t, e);
+          self.fire('up', Gestures.findOriginalTarget(e), e);
           untrackDocument(self.info);
         }
       };
       var upfn = function upfn(e) {
         if (hasLeftMouseButton(e)) {
-          self.fire('up', t, e);
+          self.fire('up', Gestures.findOriginalTarget(e), e);
         }
         untrackDocument(self.info);
       };
       trackDocument(this.info, movefn, upfn);
-      this.fire('down', t, e);
+      this.fire('down', Gestures.findOriginalTarget(e), e);
     },
     touchstart: function(e) {
       this.fire('down', Gestures.findOriginalTarget(e), e.changedTouches[0]);


### PR DESCRIPTION
Caching the original target in `t` causes a reference to be held for
that target in detached DOM nodes.

I am binding to the `tap` gesture for a “close” action. The element is removed on the close action.

![screen shot 2015-11-24 at 11 29 20 am](https://cloud.githubusercontent.com/assets/193887/11375058/cbfc1ece-929e-11e5-8737-97f659714f03.png)

![screen shot 2015-11-24 at 11 29 55 am](https://cloud.githubusercontent.com/assets/193887/11375063/cf49be9c-929e-11e5-9f82-082a0caeba22.png)
