### PR TITLE
Remove closures holding element references after mouseup/touchend

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -168,6 +168,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function untrackDocument(stateObj) {
     document.removeEventListener('mousemove', stateObj.movefn);
     document.removeEventListener('mouseup', stateObj.upfn);
+    stateObj.movefn = null;
+    stateObj.upfn = null;
   }
 
   var Gestures = {
@@ -416,8 +418,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     emits: ['down', 'up'],
 
     info: {
-      movefn: function(){},
-      upfn: function(){}
+      movefn: null,
+      upfn: null
     },
 
     reset: function() {
@@ -486,8 +488,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         this.moves.push(move);
       },
-      movefn: function(){},
-      upfn: function(){},
+      movefn: null,
+      upfn: null,
       prevent: false
     },
 

--- a/test/unit/gestures-elements.html
+++ b/test/unit/gestures-elements.html
@@ -148,7 +148,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       stream: {
         type: Array,
         value: function() {
-        return [];
+          return [];
         }
       }
     },

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -406,6 +406,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.stream.length, 1);
       });
     });
+
+    suite('Reference Cleanup', function() {
+      var el;
+
+      setup(function() {
+        el = document.createElement('x-buttons');
+        document.body.appendChild(el);
+      });
+
+      teardown(function() {
+        document.body.removeChild(el);
+      });
+
+      test('down and up clear document tracking', function() {
+        var ev = new CustomEvent('mousedown', {bubbles: true});
+        el.dispatchEvent(ev);
+
+        // some recognizers do not track the document, like tap
+        var recognizers = Polymer.Gestures.recognizers.filter(function(r) {
+          return r.info.hasOwnProperty('movefn') &&
+            r.info.hasOwnProperty('upfn');
+        });
+
+        assert.isAbove(recognizers.length, 0, 'some recognizers track the document');
+
+        recognizers.forEach(function(r) {
+          assert.isFunction(r.info.movefn, r.name + ' movefn');
+          assert.isFunction(r.info.upfn, r.name + ' upfn');
+        });
+
+        ev = new CustomEvent('mouseup', {bubbles: true});
+        el.dispatchEvent(ev);
+
+        recognizers.forEach(function(r) {
+          assert.isNull(r.info.movefn, r.name + ' movefn');
+          assert.isNull(r.info.upfn, r.name + ' upfn');
+        });
+      });
+    });
   </script>
 
 </body>


### PR DESCRIPTION
With tests

Fixes #3083