### PR TITLE
Fixed parsers interpreting regex as comment

### DIFF
--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -169,7 +169,7 @@ Polymer.CssParse = (function() {
 
     // helper regexp's
     _rx: {
-      comments: /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim,
+      comments: /\/\*[^*]*\*+([^/\*][^*]*\*+)*\//gim,
       port: /@import[^;]*;/gim,
       customProp: /(?:^|[\s;])--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
       mixinProp: /(?:^|[\s;])?--[^;{]*?:[^{;]*?{[^}]*?}(?:[;\n]|$)?/gim,


### PR DESCRIPTION
rails-polymer and emcee were both interpreting this as an actual comment, causing them to compile incorrectly.