### PR TITLE
querySelector now stops querying on first match

### DIFF
--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -345,7 +345,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // TODO(sorvell): consider doing native QSA and filtering results.
     querySelector: function(selector) {
-      return this.querySelectorAll(selector)[0];
+      return this._queryFirst(function(n) {
+        return DomApi.matchesSelector.call(n, selector);
+      }, this.node);
+    },
+
+    _queryFirst: function(matcher, node) {
+      node = node || this.node;
+      return this._queryElementsForFirstMatch(TreeApi.Logical.getChildNodes(node), matcher);
+    },
+
+    _queryElementsForFirstMatch: function (elements, matcher) {
+      for (var i=0, l=elements.length, c; (i<l) && (c=elements[i]); i++) {
+        if (c.nodeType === Node.ELEMENT_NODE) {
+          if (matcher(c)) {
+            return c;
+          }
+          var childMatch = this._queryElementsForFirstMatch(TreeApi.Logical.getChildNodes(c), matcher);
+          if (childMatch) {
+            return childMatch;
+          }
+        }
+      }
     },
 
     querySelectorAll: function(selector) {


### PR DESCRIPTION
I noticed that querySelector delegates to querySelectorAll and then returns the first element in the list. Rather than finding all matches in the tree, I adjusted querySelector to only seek to find the first match.