### PR TITLE
Added 40382$ utility for local dom querySelectorAll

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -29,6 +29,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
+     * Convenience method to run `querySelectorAll` on this local DOM scope.
+     *
+     * This function calls `Polymer.dom(this.root).querySelectorAll(slctr)`.
+     *
+     * @method $$$
+     * @param {string} slctr Selector to run on this local DOM scope
+     * @return {NodesList} Elements found by the selector, or empty if not found.
+     */
+    $$$: function(slctr) {
+      return Polymer.dom(this.root).querySelectorAll(slctr);
+    },
+
+    /**
      * Toggles a CSS class on or off.
      *
      * @method toggleClass

--- a/test/unit/utils.html
+++ b/test/unit/utils.html
@@ -17,6 +17,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
+<dom-module id="my-element">
+  <template>
+    <span hidden></span>
+    <span hidden class="class-selectable"></span>
+    <span hidden id="id-selectable"></span>
+    <p hidden class="class-selectable"></p>
+    <content></content>
+  </template>
+</dom-module>
+
 <script>
 
   HTMLImports.whenReady(function() {
@@ -34,6 +44,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     document.body.removeChild(window.el1);
     delete window.el1;
     delete window.el2;
+  });
+
+  suite('DOM querying', function() {
+
+    test('$$', function () {
+      var byTag = window.el1.$$('span');
+      assert(byTag, 'querying local dom by tag selector returns first element of given tag-name');
+      assert(!window.el1.$$('div'), 'querying local dom for non-existent tag returns no element');
+
+      var byClass = window.el1.$$('.class-selectable');
+      assert(byClass, 'querying local dom by class selector returns first element with given class');
+      assert(!window.el1.$$('.class-nosuchthing'), 'querying local dom by class selector returns no element if no elements have given class');
+
+      var byId = window.el1.$$('#id-selectable');
+      assert(byId, 'querying local dom by id selector returns element with given id');
+      assert(!window.el1.$$('#id-nosuchthing'), 'querying local dom by id selector returns no element if given id does not exist');
+    });
+
+    test('$$$', function () {
+      var byTag = window.el1.$$$('span');
+      assert(byTag.length === 3
+              && byTag[0].tagName === 'SPAN'
+              && byTag[1].tagName === 'SPAN'
+              && byTag[2].tagName === 'SPAN',
+              'querying local dom by tag selector returns list with all elements of given tag-name');
+      assert(window.el1.$$$('div').length === 0, 'querying local dom for non-existent tag returns list with no elements');
+
+      var byClass = window.el1.$$$('.class-selectable');
+      assert(byClass.length === 2
+              && byClass[0].tagName === 'SPAN'
+              && byClass[0].classList.contains('class-selectable')
+              && byClass[1].tagName === 'P'
+              && byClass[1].classList.contains('class-selectable'),
+              'querying local dom by class selector returns list with all elements with given class');
+      assert(window.el1.$$$('.class-nosuchthing').length === 0, 'querying local dom by class selector returns list with no elements if no elements have given class');
+
+      var byId = window.el1.$$$('#id-selectable');
+      assert(byId.length === 1
+              && byId[0].id === 'id-selectable',
+              'querying local dom by id selector returns list with element with given id');
+      assert(window.el1.$$$('#id-nosuchthing').length === 0, 'querying local dom by id selector returns list with no elements if given id does not exist');
+    });
+
+
   });
 
   suite('CSS utilities', function() {


### PR DESCRIPTION
Added a $$$ convenience method for querySelectorAll against an element's local dom, similar to $$. See issue: https://github.com/Polymer/polymer/issues/3183