### PR TITLE
added polymer-mini and polymer-micro to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,9 @@
   "name": "polymer",
   "version": "1.2.3",
   "main": [
-    "polymer.html"
+    "polymer.html",
+    "polymer-mini.html",
+    "polymer-micro.html"
   ],
   "license": "http://polymer.github.io/LICENSE.txt",
   "ignore": [


### PR DESCRIPTION
Fixes #2617 by adding both files to main so they get copied over.

When using `bower-installer` (when I don't want to send dev files to production servers, and vulcanisation isn't set up yet) currently only `polymer.html` gets copied over. This fixes that.