### PR TITLE
use destination insertion points when calculating the path

### DIFF
--- a/src/lib/dom-api-event.html
+++ b/src/lib/dom-api-event.html
@@ -15,13 +15,13 @@ Polymer.EventApi = (function() {
   var DomApi = Polymer.DomApi.ctor;
   var Settings = Polymer.Settings;
 
-  
+
   /**
-   * DomApi.Event allows maniuplation of events compatible with 
-   * the scoping concepts in Shadow DOM and compatible with both Shady DOM 
-   * and Shadow DOM. The general usage is 
-   * `Polymer.dom(event).property`. The `path` property returns `event.path` 
-   * matching Shadow DOM. The `rootTarget` property returns the first node 
+   * DomApi.Event allows maniuplation of events compatible with
+   * the scoping concepts in Shadow DOM and compatible with both Shady DOM
+   * and Shadow DOM. The general usage is
+   * `Polymer.dom(event).property`. The `path` property returns `event.path`
+   * matching Shadow DOM. The `rootTarget` property returns the first node
    * in the `path` and is the original event target. The `localTarget` property
    * matches event.target under Shadow DOM and is the scoped event target.
    */
@@ -32,7 +32,7 @@ Polymer.EventApi = (function() {
   if (Settings.useShadow) {
 
     DomApi.Event.prototype = {
-      
+
       get rootTarget() {
         return this.event.path[0];
       },
@@ -50,7 +50,7 @@ Polymer.EventApi = (function() {
   } else {
 
     DomApi.Event.prototype = {
-    
+
       get rootTarget() {
         return this.event.target;
       },
@@ -71,10 +71,18 @@ Polymer.EventApi = (function() {
       get path() {
         if (!this.event._path) {
           var path = [];
-          var o = this.rootTarget;
-          while (o) {
-            path.push(o);
-            o = Polymer.dom(o).parentNode || o.host;
+          var current = this.rootTarget;
+          while (current) {
+            path.push(current);
+            var insertionPoints = Polymer.dom(current).getDestinationInsertionPoints();
+            if (insertionPoints.length) {
+              for (var i = 0; i < insertionPoints.length - 1; i++) {
+                path.push(insertionPoints[i]);
+              }
+              current = insertionPoints[insertionPoints.length - 1];
+            } else {
+              current = Polymer.dom(current).parentNode || current.host;
+            }
           }
           // event path includes window in most recent native implementations
           path.push(window);

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -663,6 +663,25 @@ suite('Polymer.dom', function() {
     assert.sameMembers(order, [cb1, cbReentrant, cb2, cb3, cb4]);
   });
 
+  test('path correctly calculated for elements with destination insertion points', function(done) {
+    var re = document.createElement('x-reproject');
+    var p = Polymer.dom(re.root).querySelector('x-project');
+    var child = document.createElement('p');
+    child.innerHTML = "hello";
+    // child will be inserted into p after distributeContent is performed.
+    Polymer.dom(re).appendChild(child);
+    Polymer.dom(document.body).appendChild(re);
+    Polymer.dom.flush();
+    child.addEventListener('child-event', function(e){
+      var path = Polymer.dom(e).path;
+      assert.isTrue(path.indexOf(p) !== -1, 'path contains p');
+      assert.isTrue(path.indexOf(re) !== -1, 'path contains re');
+      done();
+    });
+    var evt = new CustomEvent('child-event');
+    child.dispatchEvent(evt);
+  });
+
 });
 
 suite('Polymer.dom accessors', function() {


### PR DESCRIPTION
Fixes #3201 by using destination insertion points for computing the path (following this algorithm https://github.com/w3c/webcomponents/blob/91f9a1fa681c39cf8ee9dff898db78fc7797354c/spec/shadow/index.html#L536). Specifically:
If a node has destination insertion points:
- append them all (except the last one) to `path`
- set `current` to be the last destination insertion point  