### PR TITLE
Fix for scoping when class is not specified on element

### DIFF
--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -215,7 +215,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _scopeElementClass: function(element, selector) {
         if (!nativeShadow && !this._scopeCssViaAttr) {
-          selector += (selector ? ' ' : '') + SCOPE_NAME + ' ' + this.is +
+          selector = (selector ? selector + ' ' : '') + SCOPE_NAME + ' ' + this.is +
             (element._scopeSelector ? ' ' +  XSCOPE_NAME + ' ' +
             element._scopeSelector : '');
         }

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -442,3 +442,12 @@
     is: 'x-overriding'
   });
 </script>
+
+<script>
+  Polymer({
+    is: 'x-scope-no-class',
+    ready: function() {
+      this.scopeSubtree(this, true);
+    }
+  });
+</script>

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -51,6 +51,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </div>
   <x-overriding></x-overriding>
 
+  <x-scope-no-class>
+    <div></div>
+  </x-scope-no-class>
+
 <script>
   suite('scoped-styling', function() {
 
@@ -273,6 +277,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('specificity of ::content > :not(template) selector', function() {
         assertComputed(document.querySelector('[is=x-specificity-nested]'), '10px');
       });
+
+      test('x-scope with no class attribute', function () {
+        assert.equal(document.querySelector('x-scope-no-class > div').className, 'style-scope x-scope-no-class');
+      })
     });
 
     test('svg classes are dynamically scoped correctly', function() {


### PR DESCRIPTION
If class on element is not present then 
```javascript
(selector = element.getAttribute('class')) === null
```
And as result:
```javascript
(selector + 'style-scope') === 'nullstyle-scope'
```
While just `style-scope` was expected.