### PR TITLE
Add pre-hook for properties

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -182,16 +182,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         if (info.set) {
           var setFn = model[info.set];
-          var processing = false;
 
-          setter = function(value) {
-            // When setting the value, effects are triggered. In order to
-            // prevent stackoverflows, do not re-process the updated value
-            if (!processing) {
-              processing = true;
-              this._propertySetter(property, setFn(value), effects);
-              processing = false;
+          if (setFn) {
+            var processing = false;
+
+            setter = function(value) {
+              // When setting the value, effects are triggered. In order to
+              // prevent stackoverflows, do not re-process the updated value
+              if (!processing) {
+                processing = true;
+                this._propertySetter(property, setFn(value), effects);
+                processing = false;
+              }
             }
+          } else {
+            Polymer.Base._warn(Polymer.Base._logf('_createAccessors', 'set method `' +
+              info.set + '` not defined for property ' + property));
           }
         }
 

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _notifyChange: function(source, event, value) {
         value = value === undefined ? this[source] : value;
         event = event || Polymer.CaseMap.camelToDashCase(source) + '-changed';
-        this.fire(event, {value: value}, 
+        this.fire(event, {value: value},
           {bubbles: false, cancelable: false, _useCache: true});
       },
 
@@ -180,6 +180,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           model['_set' + this.upper(property)] = setter;
         }
       } else {
+        if (info && info.set) {
+          var setFn = model[info.set];
+
+          setter = function(value) {
+            this._propertySetter(property, setFn(value), effects);
+          }
+        }
+
         defun.set = setter;
       }
       Object.defineProperty(model, property, defun);
@@ -221,8 +229,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           // TODO(sorvell): even though we have a `value` argument, we *must*
           // lookup the current value of the property. Multiple listeners and
-          // queued events during configuration can theoretically lead to 
-          // divergence of the passed value from the current value, but we 
+          // queued events during configuration can theoretically lead to
+          // divergence of the passed value from the current value, but we
           // really need to track down a specific case where this happens.
           value = target[property];
           if (!isStructured) {

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -172,19 +172,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // be interrogating the prototype here
       // TODO(sorvell): we want to avoid using `getPropertyInfo` here, but
       // this requires more data in `_propertyInfo`
-      var info = model.getPropertyInfo && model.getPropertyInfo(property);
-      if (info && info.readOnly) {
+      var info = model.getPropertyInfo && model.getPropertyInfo(property) || {};
+      if (info.readOnly) {
         // Computed properties are read-only (no property setter), but also don't
         // need a private setter since they should not be called by the user
         if (!info.computed) {
           model['_set' + this.upper(property)] = setter;
         }
       } else {
-        if (info && info.set) {
+        if (info.set) {
           var setFn = model[info.set];
+          var processing = false;
 
           setter = function(value) {
-            this._propertySetter(property, setFn(value), effects);
+            // When setting the value, effects are triggered. In order to
+            // prevent stackoverflows, do not re-process the updated value
+            if (!processing) {
+              processing = true;
+              this._propertySetter(property, setFn(value), effects);
+              processing = false;
+            }
           }
         }
 

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               attribute: Polymer.CaseMap.camelToDashCase(p)
             });
           }
-          if (prop.readOnly) {
+          if (prop.readOnly || prop.set) {
             // Ensure accessor is created
             Polymer.Bind.ensurePropertyEffects(this, p);
           }

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -468,3 +468,47 @@
     <input id="input" value$="{{inputValue}}">
   </template>
 </dom-module>
+
+<dom-module id="child-binding-of-parent-setter">
+  <template>
+    <span>{{binding}}</span>
+  </template>
+  <script>
+    Polymer({
+      is: 'child-binding-of-parent-setter',
+      properties: {
+        binding: {
+          type: String,
+          notify: true
+        }
+      }
+    });
+  </script>
+</dom-module>
+
+<dom-module id="setter-with-child-binding">
+  <template>
+    <child-binding-of-parent-setter id="child" binding="{{binding}}"></child-binding-of-parent-setter>
+  </template>
+  <script>
+    Polymer({
+      is: 'setter-with-child-binding',
+      properties: {
+        binding: {
+          type: String,
+          set: '_setBinding'
+        },
+        computed: {
+          type: String,
+          computed: 'compute(binding)'
+        }
+      },
+      _setBinding: function(newValue) {
+        return 'Binding is ' + newValue;
+      },
+      compute: function(binding) {
+        return binding + '!';
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -292,7 +292,7 @@ suite('set hook for properties', function() {
       _setFoo: function(value) {
         return 'Foo was set to: ' + value;
       }
-    })
+    });
 
     var el = document.createElement('set-overrides-value');
     el.foo = 'Yes';
@@ -340,7 +340,7 @@ suite('set hook for properties', function() {
       _observeFoo: function(newValue) {
         throw new Error('Not allowed to reach');
       }
-    })
+    });
 
     var el = document.createElement('set-value-throws-error');
 
@@ -356,6 +356,28 @@ suite('set hook for properties', function() {
     assert.equal(el.$.child.binding, 'Binding is New value');
     assert.equal(el.binding, 'Binding is New value');
     assert.equal(el.computed, 'Binding is New value!');
+  });
+
+  test('undefined setter warns user', function() {
+    var warned = false;
+    var oldWarn = Polymer.Base._warn;
+    Polymer.Base._warn = function(message, what) {
+      assert.equal(message[4], 'set method `_setFoo` not defined for property foo');
+      warned = true;
+    };
+
+    Polymer({
+      is: 'undefined-setter-warns',
+      properties: {
+        foo: {
+          type: String,
+          set: '_setFoo'
+        }
+      }
+    });
+
+    assert.equal(warned, true, 'Undefined setter must warn user');
+    Polymer.Base._warn = oldWarn;
   });
 });
 

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -278,6 +278,78 @@ suite('single-element binding effects', function() {
 
 });
 
+suite('set hook for properties', function() {
+
+  test('set overrides initial value', function() {
+    Polymer({
+      is: 'set-overrides-value',
+      properties: {
+        foo: {
+          type: String,
+          set: '_setFoo'
+        }
+      },
+      _setFoo: function(value) {
+        return 'Foo was set to: ' + value;
+      }
+    })
+
+    var el = document.createElement('set-overrides-value');
+    el.foo = 'Yes';
+    assert.equal(el.foo, 'Foo was set to: Yes', 'New value was not override by setter');
+  });
+
+  test('overriden set value is propagated in observer', function() {
+    var observed = false;
+    Polymer({
+      is: 'set-value-to-observer',
+      properties: {
+        foo: {
+          type: String,
+          set: '_setFoo',
+          observer: '_observeFoo'
+        }
+      },
+      _setFoo: function(value) {
+        return 'Foo was set to: ' + value;
+      },
+      _observeFoo: function(newValue) {
+        assert.equal(newValue, 'Foo was set to: Yes', 'New value was not overridden by setter');
+        observed = true;
+      }
+    })
+
+    var el = document.createElement('set-value-to-observer');
+    el.foo = 'Yes';
+    assert.equal(observed, true, 'Observer is not called.');
+  });
+
+  test('error in setter prevents value propagation', function() {
+    Polymer({
+      is: 'set-value-throws-error',
+      properties: {
+        foo: {
+          type: String,
+          set: '_setFoo',
+          observer: '_observeFoo'
+        }
+      },
+      _setFoo: function(value) {
+        throw new Error('Must reach');
+      },
+      _observeFoo: function(newValue) {
+        throw new Error('Not allowed to reach');
+      }
+    })
+
+    var el = document.createElement('set-value-throws-error');
+
+    assert.throws(function() {
+      el.foo = 'Invalid';
+    }, Error, 'Must reach', 'Setter did not throw error');
+  });
+});
+
 </script>
 
 <script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -348,6 +348,15 @@ suite('set hook for properties', function() {
       el.foo = 'Invalid';
     }, Error, 'Must reach', 'Setter did not throw error');
   });
+
+  test('update child binding does not overflow call-stack', function() {
+    var el = document.createElement('setter-with-child-binding');
+    el.$.child.binding = 'New value';
+
+    assert.equal(el.$.child.binding, 'Binding is New value');
+    assert.equal(el.binding, 'Binding is New value');
+    assert.equal(el.computed, 'Binding is New value!');
+  });
 });
 
 </script>


### PR DESCRIPTION
Add pre-hooks for properties to validate and transform properties.
Adds a new field to a property called `set` that references the name of a function. This function takes a `value` and returns the new value.

Fixes #3099 