### PR TITLE
Implement method for dirty-checking of properties

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -15,7 +15,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // for prototypes (usually)
     prepareModel: function(model) {
+      // TODO(timvdlippe): temporarily store this method as it is explicitly
+      // overridable by the user. Will be fixed in the refactoring for 2.0
+      var dirty = model._isPropertyDirty;
       Polymer.Base.mixin(model, this._modelApi);
+      if (dirty) {
+        model._isPropertyDirty = dirty;
+      }
     },
 
     _modelApi: {

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -44,10 +44,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // in the closure for the accessor for efficiency
       _propertySetter: function(property, value, effects, fromAbove) {
         var old = this.__data__[property];
-        // NaN is always not equal to itself,
-        // if old and value are both NaN we treat them as equal
-        // x === x is 10x faster, and equivalent to !isNaN(x)
-        if (old !== value && (old === old || value === value)) {
+
+        if (this._isPropertyDirty(old, value)) {
           this.__data__[property] = value;
           if (typeof value == 'object') {
             this._clearPath(property);
@@ -60,6 +58,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         }
         return old;
+      },
+
+      /**
+       * Check if a property has changed.
+       * @param  {*} old   The old value of the property
+       * @param  {*} value The new value of the property
+       * @return {Boolean}       Whether the property has changed.
+       */
+      _isPropertyDirty: function(old, value) {
+        // NaN is always not equal to itself,
+        // if old and value are both NaN we treat them as equal
+        // x == x is 10x faster and equivalent to !isNaN(x)
+        return (old !== value && (old === old || value === value));
       },
 
       // Called during _applyConfig (well-known downward data-flow hot path)

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -302,6 +302,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // _propertySetter API may need to be copied onto the template,
         // and it needs to come first to allow the property swizzle below
         template._propertySetter = proto._propertySetter;
+        template._isPropertyDirty = proto._isPropertyDirty;
       }
       for (var i=0, n; (i<n$.length) && (n=n$[i]); i++) {
         var val = template[n];

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -142,6 +142,32 @@ suite('single-element binding effects', function() {
                  'NaN was not handled as expected');
   });
 
+  test('_isPropertyDirty invoked to compare Dates', function() {
+    var observed = false;
+    Polymer({
+      is: 'changes-date',
+      properties: {
+        date: {
+          type: Date,
+          value: new Date(123),
+          observer: '_observeDate'
+        }
+      },
+      _observeDate: function(newValue, oldValue) {
+        if (oldValue !== undefined) {
+          observed = true;
+        }
+      },
+      _isPropertyDirty: function(old, value) {
+        return old && value && old.getTime() !== value.getTime();
+      }
+    });
+    var el = document.createElement('changes-date');
+    el.date = new Date(123);
+    assert.equal(observed, false, 'Should not change on same date');
+    el.date = new Date(859);
+    assert.equal(observed, true, 'Should change on different date');
+  });
 
   test('computed notification sent', function() {
     var notified = 0;

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -159,7 +159,7 @@ suite('single-element binding effects', function() {
         }
       },
       _isPropertyDirty: function(old, value) {
-        return old && value && old.getTime() !== value.getTime();
+        return !(old && value && old.getTime() === value.getTime());
       }
     });
     var el = document.createElement('changes-date');


### PR DESCRIPTION
To solve dirty-checking issues with (native) Javascript Objects, this PR extracts a method to check if a property is dirty. The implementation allows custom types to be used by Polymer. Custom types should only implement the function `isNotEqualTo`. Additionally, the previous NaN checks are now only performed on Numbers as opposed to during all updates.

I did not observe any performance problems, the test suite runs on my computer in almost equal time (roughly 50 seconds).

The reason for using a function called `isNotEqualTo` is to prevent collisions with other Javascript libraries/frameworks that could possibly implement/depend on an equally named function. (for example `equals`)

Fixes #2719 
