### PR TITLE
Make tests succeed in Safari

### DIFF
--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -248,6 +248,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <style>
         child-of-child-with-var {
+          position: relative;
           --variable-own-line: "Varela font";
           margin-top: var(--variable-property-own-line);
           margin-bottom: var(--variable-property-preceded-property);


### PR DESCRIPTION
This PR solves issue https://github.com/Polymer/polymer/issues/3166

As far as I can see, the element in the test suite is given `bottom`, `left` and `right` properties, however the element doesn't have any value for `position` (default `static`). The difference between Chrome and Safari for `window.getComputedStyle(document.querySelector('child-of-child-with-var')).bottom` is:

- Safari: `"auto"`
- Chrome: `"9px"`

Applying `position: relative` solves this.