### PR TITLE
Add sugar for child-delegation for on-* methods

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -129,14 +129,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _createEventHandler: function(node, eventName, methodName) {
       var host = this;
-      var handler = function(e) {
-        if (host[methodName]) {
-          host[methodName](e, e.detail);
+      var handler = (function() {
+        var processingNode, processingMethod;
+
+        if (methodName.indexOf('.') > 0) {
+          var split = methodName.split('.');
+          processingNode = host.$[split[0]];
+          processingMethod = split[1];
         } else {
-          host._warn(host._logf('_createEventHandler', 'listener method `' +
-            methodName + '` not defined'));
+          processingNode = host;
+          processingMethod = methodName
         }
-      };
+
+        return function(e) {
+          if (processingNode[processingMethod]) {
+            processingNode[processingMethod](e, e.detail);
+          } else {
+            host._warn(host._logf('_createEventHandler', 'listener method `' +
+              methodName + '` not defined'));
+          }
+        }
+      })();
+
       handler._listening = false;
       this._recordEventHandler(host, eventName, node, methodName, handler);
       return handler;

--- a/test/unit/events-elements.html
+++ b/test/unit/events-elements.html
@@ -70,6 +70,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-on-with-child">
+  <template>
+    <x-on-child id="child"></x-on-child>
+    <div id="inner" on-foo="child.handle"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-on-child',
+      behaviors: [EventLoggerImpl]
+    });
+    Polymer({
+      is: 'x-on-with-child',
+      teardown: function() {
+        this.unlisten(this.$.inner, 'foo', 'handle');
+      }
+    });
+  </script>
+</dom-module>
+
 <dom-module id="x-dynamic">
   <template>
     <div id="inner"></div>

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -93,6 +93,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(el._warned[0], 'listener method `missing` not defined');
         });
 
+        test('child-fire', function() {
+          var childEl = document.createElement('x-on-with-child');
+          childEl.fire('foo', {}, {node: childEl.$.inner});
+          assert.equal(childEl.$.child._handled.div, 'foo');
+        });
+
         test('teardown', function() {
           el.teardown();
           assert.deepEqual(el._removed[0], {target: 'div', event: 'foo'});


### PR DESCRIPTION
The `on-*` events are checked for containing a `.`. If this is the case, reference the corresponding child with name before the `.` and the `methodName` following the `.`.

Fixes #3259