### PR TITLE
Improved performance of Polymer.CaseMap.* functions

### DIFF
--- a/src/lib/case-map.html
+++ b/src/lib/case-map.html
@@ -12,32 +12,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.CaseMap = {
 
     _caseMap: {},
+    _rx: {
+      dashToCamel: /-[a-z]/g,
+      camelToDash: /([A-Z])/g
+    },
 
     dashToCamelCase: function(dash) {
-      var mapped = Polymer.CaseMap._caseMap[dash];
-      if (mapped) {
-        return mapped;
-      }
-      // TODO(sjmiles): is rejection test actually helping perf?
-      if (dash.indexOf('-') < 0) {
-        return Polymer.CaseMap._caseMap[dash] = dash;
-      }
-      return Polymer.CaseMap._caseMap[dash] = dash.replace(/-([a-z])/g, 
-        function(m) {
-          return m[1].toUpperCase(); 
-        }
+      return this._caseMap[dash] || (
+        this._caseMap[dash] = dash.indexOf('-') < 0 ? dash : dash.replace(this._rx.dashToCamel,
+          function(m) {
+            return m[1].toUpperCase();
+          }
+        )
       );
     },
 
     camelToDashCase: function(camel) {
-      var mapped = Polymer.CaseMap._caseMap[camel];
-      if (mapped) {
-        return mapped;
-      }
-      return Polymer.CaseMap._caseMap[camel] = camel.replace(/([a-z][A-Z])/g, 
-        function (g) { 
-          return g[0] + '-' + g[1].toLowerCase() 
-        }
+      return this._caseMap[camel] || (
+        this._caseMap[camel] = camel.replace(this._rx.camelToDash, '-$1').toLowerCase()
       );
     }
 


### PR DESCRIPTION
Doubled `Polymer.CaseMap.dashToCamelCase` performance with simplified and once compiled RegExp.
5 times faster `Polymer.CaseMap.camelToDashCase` using simplified replace part, simplified and once compiled RegExp.

Code is more condenced, but still readable and doesn't use temporary variables.