### PR TITLE
Add support for multiple handlers in on-* annotations

### DIFF
--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -311,7 +311,17 @@ TODO(sjmiles): this module should produce either syntactic metadata
         if (a.events && a.events.length) {
           var node = this._findAnnotatedNode(this.root, a);
           for (var j=0, e$=a.events, e; (j<e$.length) && (e=e$[j]); j++) {
-            this.listen(node, e.name, e.value);
+            // Fast check if there are multiple events, else don't bother
+            // and continue with a single event
+            if (e.value[0] !== '[') {
+              this.listen(node, e.name, e.value);
+            }
+            else {
+              var methods = methods=e.value.slice(1, -1).split(' ');
+              for (var m=0, method; (m<methods.length) && (method=methods[m]); m++) {
+                this.listen(node, e.name, method);
+              }
+            }
           }
         }
       }

--- a/test/unit/events-elements.html
+++ b/test/unit/events-elements.html
@@ -13,6 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   var EventLoggerImpl = {
     created: function() {
+      this.reset();
+    },
+    reset: function() {
       this._handled = {};
       this._warned = [];
       this._removed = [];
@@ -57,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="x-on">
   <template>
     <div id="inner" on-foo="handle" on-bar="missing"></div>
+    <div id="multiple" on-multiple="[handle missing]"></div>
   </template>
   <script>
     Polymer({

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -67,6 +67,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           document.body.appendChild(el);
         });
 
+        teardown(function() {
+          el.reset();
+        })
+
         suiteTeardown(function() {
           document.body.removeChild(el);
         });
@@ -89,6 +93,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(el._handled.div, 'foo');
           assert(!el._handled[el.localName]);
           el.fire('bar', {}, options);
+          assert.equal(el._warned.length, 1);
+          assert.equal(el._warned[0], 'listener method `missing` not defined');
+        });
+
+        test('fire multiple events', function() {
+          var options = {node: el.$.multiple};
+          el.fire('multiple', {}, options);
+          assert.equal(el._handled.div, 'multiple');
+          assert(!el._handled[el.localName]);
           assert.equal(el._warned.length, 1);
           assert.equal(el._warned[0], 'listener method `missing` not defined');
         });


### PR DESCRIPTION
Added support for declaring multiple handlers between brackets.
E.g. `on-multiple="[oneMethod anotherMethod]"`. Using brackets, the performance impact on existing single method annotations is minimal. The only check extra introduced is for checking the existence of `[` as first character of the annotation.

Fixes #1593