### PR TITLE
Fix typo in documentation for set()

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -144,7 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method set
        * @param {(string|Array<(string|number)>)} path Path to the value
-       *   to read.  The path may be specified as a string (e.g. `foo.bar.baz`)
+       *   to write.  The path may be specified as a string (e.g. `foo.bar.baz`)
        *   or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that
        *   bracketed expressions are not supported; string-based path parts
        *   *must* be separated by dots.  Note that when dereferencing array


### PR DESCRIPTION
Probably copy-pasted from documentation for get().