### PR TITLE
Remove reference to _composedChildren

### DIFF
--- a/src/lib/dom-innerHTML.html
+++ b/src/lib/dom-innerHTML.html
@@ -116,7 +116,6 @@ Polymer.domInnerHTML = (function() {
       node = node.content;
     var s = '';
     var c$ = Polymer.dom(node).childNodes;
-    c$ = composed ? node._composedChildren : c$;
     for (var i=0, l=c$.length, child; (i<l) && (child=c$[i]); i++) {  
       s += getOuterHTML(child, node, composed);
     }


### PR DESCRIPTION
AFAICT this is the only reference to `_composedChildren`, and this code will throw if `composed` is true and `_composedChildren` doesn't exist.

`_composedChildren` doesn't seem to be set in either Polymer or WebComponents.js:
* https://github.com/Polymer/polymer/search?utf8=%E2%9C%93&q=_composedChildren
* https://github.com/webcomponents/webcomponentsjs/search?utf8=%E2%9C%93&q=_composedChildren