### PR TITLE
Fix svg scope

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -283,14 +283,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       applyElementScopeSelector: function(element, selector, old, viaAttr) {
         var c = viaAttr ? element.getAttribute(styleTransformer.SCOPE_NAME) :
-          element.className;
+          (element.getAttribute('class') || '');
         var v = old ? c.replace(old, selector) :
           (c ? c + ' ' : '') + this.XSCOPE_NAME + ' ' + selector;
         if (c !== v) {
           if (viaAttr) {
             element.setAttribute(styleTransformer.SCOPE_NAME, v);
           } else {
-            element.className = v;
+            element.setAttribute('class', v);
           }
         }
       },

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -86,7 +86,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                     .replace(scope, ''));
                 }
               } else {
-                element.setAttribute(CLASS, c + (c ? ' ' : '') +
+                element.setAttribute(CLASS, (c ? c + ' ' : '') +
                   SCOPE_NAME + ' ' + scope);
               }
             }

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -35,8 +35,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
-       * An element's style properties can be directly modified by 
-       * setting key-value pairs in `customStyle` on the element 
+       * An element's style properties can be directly modified by
+       * setting key-value pairs in `customStyle` on the element
        * (analogous to setting `style`) and then calling `updateStyles()`.
        *
        */
@@ -208,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // note: using Polymer.dom here ensures that any attribute sets
         // will provoke distribution if necessary; do this iff necessary
-        node = (this.shadyRoot && this.shadyRoot._hasDistributed) ? 
+        node = (this.shadyRoot && this.shadyRoot._hasDistributed) ?
           Polymer.dom(node) : node;
         serializeValueToAttribute.call(this, value, attribute, node);
       },

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -231,6 +231,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('svg elements properly scoped', function() {
         assert.include(styled.$.circle.getAttribute('class'), 'style-scope x-styled');
+        assert.notInclude(styled.$.circle.getAttribute('class'), 'null');
         assertComputed(styled.$.circle, '1px', 'strokeWidth');
       });
 


### PR DESCRIPTION
Fix a few spots where `null` can creep into `className` calculation for scoping.