### PR TITLE
Fix merging of property metadata

### DIFF
--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -151,8 +151,8 @@ elements to the template itself as the binding scope.
         this._prepEffects();
         this._prepBehaviors();
         this._prepConfigure();
-        this._prepBindings();
         this._prepPropertyInfo();
+        this._prepBindings();
         Polymer.Base._initFeatures.call(this);
         this._children = Polymer.TreeApi.arrayCopyChildNodes(this.root);
       }

--- a/src/micro/properties.html
+++ b/src/micro/properties.html
@@ -105,34 +105,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {string} property Name of property to introspect.
      * @return {Object} Property descriptor for specified property.
     */
-    // TODO(sorvell): This function returns the first property object found
-    // and this is not the property info Polymer acts on for readOnly or type
-    // This api should be combined with _propertyInfo.
     getPropertyInfo: function(property) {
-      var info = this._getPropertyInfo(property, this.properties);
-      if (!info) {
-        for (var i=0; i < this.behaviors.length; i++) {
-          info = this._getPropertyInfo(property, this.behaviors[i].properties);
-          if (info) {
-            return info;
-          }
-        };
-      }
-      return info || Polymer.nob;
-    },
-
-    _getPropertyInfo: function(property, properties) {
-      var p = properties && properties[property];
-      if (typeof(p) === 'function') {
-        p = properties[property] = {
-          type: p
-        };
-      }
-      // Let users determine whether property was defined without null check
-      if (p) {
-        p.defined = true;
-      }
-      return p;
+      return this._propertyInfo[property] || Polymer.nob;
     },
 
     // union properties, behaviors.properties, and propertyEffects
@@ -148,9 +122,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // list of propertyInfo with {readOnly, type, attribute}
     _addPropertyInfo: function(target, source) {
       if (source) {
-        var t, s;
+        var s;
         for (var i in source) {
-          t = target[i];
           s = source[i];
           // optimization: avoid info'ing properties that are protected and
           // not read only since they are not needed for attributes or
@@ -159,17 +132,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             continue;
           }
           if (!target[i]) {
-            target[i] = {
-              type: typeof(s) === 'function' ? s : s.type,
-              readOnly: s.readOnly,
-              attribute: Polymer.CaseMap.camelToDashCase(i)
-            }
+            target[i] = s;
+
+            target[i].type = typeof(s) === 'function' ? s : s.type;
+            target[i].attribute = Polymer.CaseMap.camelToDashCase(i);
           } else {
-            if (!t.type) {
-              t.type = s.type;
-            }
-            if (!t.readOnly) {
-              t.readOnly = s.readOnly;
+            for (var a in s) {
+              target[i][a] = s[a];
             }
           }
         }

--- a/src/micro/properties.html
+++ b/src/micro/properties.html
@@ -132,7 +132,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             continue;
           }
           if (!target[i]) {
-            target[i] = s;
+            target[i] = {};
+
+            for (var a in s) {
+              target[i][a] = s[a];
+            }
 
             target[i].type = typeof(s) === 'function' ? s : s.type;
             target[i].attribute = Polymer.CaseMap.camelToDashCase(i);

--- a/src/micro/properties.html
+++ b/src/micro/properties.html
@@ -132,11 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             continue;
           }
           if (!target[i]) {
-            target[i] = {};
-
-            for (var a in s) {
-              target[i][a] = s[a];
-            }
+            target[i] = this.chainObject({}, s);
 
             target[i].type = typeof(s) === 'function' ? s : s.type;
             target[i].attribute = Polymer.CaseMap.camelToDashCase(i);

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -134,7 +134,8 @@ suite('multi-behaviors element', function() {
     var Behavior1 = {
       properties: {
         value: {
-          type: String
+          type: String,
+          value: 'String'
         }
       }
     };
@@ -154,8 +155,14 @@ suite('multi-behaviors element', function() {
       is: 'x-overriding-properties-with-different-type',
       behaviors: [Behavior1, Behavior2]
     });
+    Polymer({
+      is: 'x-overriding-properties-with-same-type',
+      behaviors: [Behavior1]
+    })
     var el = document.createElement('x-overriding-properties-with-different-type');
     assert.equal(typeof el.value, 'number');
+    el = document.createElement('x-overriding-properties-with-same-type');
+    assert.equal(typeof el.value, 'string', 'type should not modify super behavior');
   });
 
   test('properties from itself', function() {

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -92,6 +92,72 @@ suite('multi-behaviors element', function() {
     assert.equal(el.__disabled, true);
   });
 
+  test('boolean properties merge correctly from super behavior', function() {
+    var Behavior1 = {
+      properties: {
+        prop: {
+          notify: false,
+          observer: 'ob1',
+          value: 1,
+          reflectToAttribute: true
+        }
+      },
+      ob1: function(prop) {
+        this._propCalled = true;
+      }
+    };
+    Polymer({
+      is: 'x-overriding-properties-with-observer',
+      behaviors: [ Behavior1 ],
+      properties: {
+        prop: {
+          observer: 'ob'
+        }
+      },
+      ob: function(prop) {
+        this._prop = prop;
+      }
+    });
+    var el = document.createElement('x-overriding-properties-with-observer');
+    var prop = el.getPropertyInfo('prop');
+
+    assert.equal(prop.notify, false);
+    assert.equal(prop.reflectToAttribute, true);
+    assert.equal(prop.observer, 'ob');
+    assert.equal(prop.value, 1);
+    el.prop = 'Hello World';
+    assert.equal(el._prop, 'Hello World');
+    assert.equal(el._propCalled, true);
+  });
+
+  test('type of properties are overriden from super behavior', function() {
+    var Behavior1 = {
+      properties: {
+        value: {
+          type: String
+        }
+      }
+    };
+    var Behavior2 = {
+      properties: {
+        value: {
+          type: Number,
+          value: 0
+        }
+      },
+      observers: ['_checkType(value)'],
+      _checkType: function(value) {
+        assert.equal(typeof value, 'number');
+      }
+    };
+    Polymer({
+      is: 'x-overriding-properties-with-different-type',
+      behaviors: [Behavior1, Behavior2]
+    });
+    var el = document.createElement('x-overriding-properties-with-different-type');
+    assert.equal(typeof el.value, 'number');
+  });
+
   test('properties from itself', function() {
     assert.isDefined(el._setFoo, 'readOnly setter not available');
     el._setFoo('bar');


### PR DESCRIPTION
Before `this._propertyInfo` was unused. It took the first occurrence of `this.properties[property]` and returned only this metadata. As described in #2242, all metadata of a super behavior is ignored. Additionally, inconsistencies regarding types were discovered in #2493.

This pull-request corrects the construction `this._propertyInfo` and let `this.getPropertyInfo` utilize this object.

As a result, a performance increase should be observed, as the object is only constructed at element create time. It is therefore not needed to traverse the properties every time `this.getPropertyInfo` is called.

Fixes #2242
Fixes #2493
