### PR TITLE
Fixes #3337. When a doc fragment is added, only update the invalidati…

### DIFF
--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -91,8 +91,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _addNode: function(node, ref_node) {
       var root = this.getOwnerRoot();
       if (root) {
-        root._invalidInsertionPoints = 
-          this._maybeAddInsertionPoint(node, this.node);
+        // note: we always need to see if an insertion point is added
+        // since this saves logical tree info; however, invalidation state
+        // needs 
+        var ipAdded = this._maybeAddInsertionPoint(node, this.node);
+        // invalidate insertion points IFF not already invalid!
+        if (!root._invalidInsertionPoints) {
+          root._invalidInsertionPoints = ipAdded;
+        }
         this._addNodeToHost(root.host, node);
       }
       if (TreeApi.Logical.hasChildNodes(this.node)) {

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -168,6 +168,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-dynamic-content-and-dynamic-no-content">
+  <template>
+    <div id="container">
+      <template is="dom-if" id="staticIf" restamp>
+        <div id="static">satatic</div>
+      </template>
+      <template is="dom-if" id="contentIf" restamp>
+        <content select="*"></content>
+      </template>
+    </div>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-dynamic-content-and-dynamic-no-content'});
+  });
+  </script>
+</dom-module>
+
 <dom-module id="x-multi-dist">
   <template>
     <x-dist id="dist1"><content id="content1"></content></x-dist>
@@ -204,15 +222,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div id="container1">
       <template id="foo" is="dom-if" if="{{foo}}" restamp>
         <span>foo</span>
-        <content select="#one"></content>
-        <content select="#two"></content>
+        <content id="1.1" select="#one"></content>
+        <content id="1.2" select="#two"></content>
       </template>
     </div>
     <div id="container2">
       <template id="notFoo" is="dom-if" if="{{!foo}}" restamp>
         <span>Not foo</span>
-        <content select="#one"></content>
-        <content select="#two"></content>
+        <content id="2.1" select="#one"></content>
+        <content id="2.2" select="#two"></content>
       </template>
     </div>
   </template>
@@ -1647,7 +1665,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(c1.parentNode, el.$.container1);
         assert.equal(c2.parentNode, el.$.container1);
       }
-      el.foo = !el.foo;
+      el.foo = false;
       el.$.foo.render();
       el.$.notFoo.render();
       Polymer.dom.flush();
@@ -1655,7 +1673,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(c1.parentNode, el.$.container2);
         assert.equal(c2.parentNode, el.$.container2);
       }
-      el.foo = !el.foo;
+      el.foo = true;
       el.$.foo.render();
       el.$.notFoo.render();
       Polymer.dom.flush();
@@ -1663,7 +1681,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(c1.parentNode, el.$.container1);
         assert.equal(c2.parentNode, el.$.container1);
       }
-      el.foo = !el.foo;
+      el.foo = false;
       el.$.foo.render();
       el.$.notFoo.render();
       Polymer.dom.flush();
@@ -1671,7 +1689,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(c1.parentNode, el.$.container2);
         assert.equal(c2.parentNode, el.$.container2);
       }
-      el.foo = !el.foo;
+      el.foo = true;
       el.$.foo.render();
       el.$.notFoo.render();
       Polymer.dom.flush();
@@ -1680,6 +1698,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(c2.parentNode, el.$.container1);
       }
       document.body.removeChild(el);
+    });
+
+    test('x-dynamic-content-and-dynamic-no-content', function() {
+      var el = document.createElement('x-dynamic-content-and-dynamic-no-content');
+      document.body.appendChild(el);
+      var c1 = document.createElement('div');
+      c1.id = 'one';
+      Polymer.dom(el).appendChild(c1);
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(el).querySelector('#one'), c1);
+      assert.notOk(Polymer.dom(el.root).querySelector('#static'));
+      assert.notOk(Polymer.dom(el.root).querySelector('content'));
+      el.$.contentIf.if = true;
+      el.$.staticIf.if = true;
+      Polymer.dom.flush();
+      assert.ok(Polymer.dom(el.root).querySelector('#static'));
+      var ip = Polymer.dom(el.root).querySelector('content');
+      assert.ok(ip);
+      assert.equal(Polymer.dom(ip).getDistributedNodes()[0], c1);
+      if (el.shadyRoot) {
+        assert.ok(el.$.container.querySelector('#one'));
+      }
+      el.$.contentIf.if = false;
+      el.$.staticIf.if = false;
+      Polymer.dom.flush();
+      assert.equal(Polymer.dom(el).querySelector('#one'), c1);
+      assert.notOk(Polymer.dom(el.root).querySelector('#static'));
+      assert.notOk(Polymer.dom(el.root).querySelector('content'));
+      el.$.contentIf.if = true;
+      el.$.staticIf.if = true;
+      Polymer.dom.flush();
+      assert.ok(Polymer.dom(el.root).querySelector('#static'));
+      var ip = Polymer.dom(el.root).querySelector('content');
+      assert.ok(ip);
+      assert.equal(Polymer.dom(ip).getDistributedNodes()[0], c1);
+      if (el.shadyRoot) {
+        assert.ok(el.$.container.querySelector('#one'));
+      }
+      document.body.removeChild(el);
+
     });
 
   });


### PR DESCRIPTION
…on state of the insertion point list of the shadyRoot IFF it is not already invalid. This fixes an issue that was detected when an a doc fragment that did not include an insertion point was added after one that did but before distribution.