### PR TITLE
Re-introduction of improved CSS selectors specificity fix

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -87,9 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var parts = cssText.split(';');
         for (var i=0, p; i<parts.length; i++) {
           p = parts[i];
-          if (p.match(this.rx.MIXIN_MATCH) || p.match(this.rx.VAR_MATCH)) {
-            customCssText += p + ';\n';
-          }
+          customCssText += p + ';\n';
         }
         return customCssText;
       },
@@ -277,7 +275,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var parts = selector.split(',');
         for (var i=0, l=parts.length, p; (i<l) && (p=parts[i]); i++) {
           parts[i] = p.match(hostRx) ?
-            p.replace(hostSelector, hostSelector + scope) :
+            p.replace(hostSelector, scope) :
             scope + ' ' + p;
         }
         rule.selector = parts.join(',');

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -700,11 +700,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assertComputed(styled.$.endTerm, '19px');
   });
 
-  // skip for now, until #3326 is fixed
-  test.skip('custom style class overrides css variable', function() {
+  test('custom style class overrides css variable', function() {
     var d = document.createElement('x-variable-override');
     d.classList.add('variable-override');
     document.body.appendChild(d);
+    Polymer.dom.flush();
     assertComputed(d, '10px');
   });
 

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -273,6 +273,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('specificity of ::content > :not(template) selector', function() {
         assertComputed(document.querySelector('[is=x-specificity-nested]'), '10px');
       });
+
+      test('overwriting mixin properties', function() {
+        var root = document.querySelector('x-overriding');
+        assertComputed(root.querySelector('.red'), '1px');
+        assertComputed(root.querySelector('.green'), '2px');
+        assertComputed(root.querySelector('.red-2'), '1px');
+        assertComputed(root.querySelector('.blue'), '3px');
+      });
     });
 
     test('svg classes are dynamically scoped correctly', function() {


### PR DESCRIPTION
Re-introduction of improved CSS selectors specificity fix reverted in 0a0b580981bcd7ba6af33161993355bed99056cd

Now allows `.super-class` to override `:host`'s styling

Fixes #3326

@azakus, @sorvell, @rictic for review