### PR TITLE
Fix bindings with special characters

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -90,7 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _bindingRegex: (function() {
-      var IDENT  = '(?:' + '[a-zA-Z_$][\\w.:$-*]*' + ')';
+      var IDENT  = '(?:' + '[a-zA-Z_$][\\w.:$\\-*]*' + ')';
       var NUMBER = '(?:' + '[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?' + ')';
       var SQUOTE_STRING = '(?:' + '\'(?:[^\'\\\\]|\\\\.)*\'' + ')';
       var DQUOTE_STRING = '(?:' + '"(?:[^"\\\\]|\\\\.)*"' + ')';

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -55,6 +55,7 @@
       <div id="compound2">
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4
       </div>
+      <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
   </template>
   <script>
     Polymer({
@@ -134,6 +135,9 @@
         },
         noComputedProp: {
           computed: 'foobared(noComputed)'
+        },
+        objectWithDash: {
+          type: Object
         }
       },
       observers: [

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -279,6 +279,13 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedWildcard, 15);
   });
 
+  test('binding with dash', function() {
+    el.objectWithDash = {
+      'binding-with-dash': 'yes'
+    };
+    assert.equal(el.$.boundWithDash.textContent, 'yes');
+  })
+
 });
 
 </script>


### PR DESCRIPTION
The special regex characters must be escaped to match correctly the literal meaning. 

Fixes #3349 