### PR TITLE
dom-if: Don't forward property changes if instance is about to teardown

### DIFF
--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -168,6 +168,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Called as side-effect of a host property change, responsible for
     // notifying parent.<prop> path change on instance
     _forwardParentProp: function(prop, value) {
+      // B/c of the debounced render, `this._instance` might be alive 
+      // until the end of the microtask.
+      if (this.restamp && !this.if) { return; }
       if (this._instance) {
         this._instance[prop] = value;
       }
@@ -177,6 +180,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Called as side-effect of a host path change, responsible for
     // notifying parent.<path> path change on each row
     _forwardParentPath: function(path, value) {
+      if (this.restamp && !this.if) { return; }
       if (this._instance) {
         this._instance._notifyPath(path, value, true);
       }


### PR DESCRIPTION
Because of the debounced render, the instance might be alive until the end of the microtask, thus seeing all property changes within this exact microtask coming from host. See #3353.