### PR TITLE
Add raw html bind annotation

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -143,7 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           compoundIndex: parts.length,
           value: value,
           mode: mode,
-          safe: m[1][1] === '#',
+          raw: m[1][1] === '#',
           negate: negate,
           event: notifyEvent,
           customEvent: customEvent
@@ -180,12 +180,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Initialize the textContent with any literal parts
         // NOTE: default to a space here so the textNode remains; some browsers
         // (IE) evacipate an empty textNode following cloneNode/importNode.
-        var safe = parts.length !== 1 ? false : parts[0].safe;
+        var raw = parts.length !== 1 ? false : parts[0].raw;
         node.textContent = this._literalFromParts(parts) || ' ';
         var annote = {
           bindings: [{
             kind: 'text',
-            name: safe ? 'innerHTML' : 'textContent',
+            name: raw ? 'innerHTML' : 'textContent',
             parts: parts,
             isCompound: parts.length !== 1
           }]

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -101,8 +101,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                                     '(?:' + ARGUMENTS + '?' + ')' +
                                   '\\)\\s*' + ')';
       var BINDING = '(' + IDENT + '\\s*' + ARGUMENT_LIST + '?' + ')'; // Group 3
-      var OPEN_BRACKET = '(\\[\\[|{{)' + '\\s*';
-      var CLOSE_BRACKET = '(?:]]|}})';
+      var OPEN_BRACKET = '(\\[\\[|{{|{#)' + '\\s*';
+      var CLOSE_BRACKET = '(?:]]|}}|#})';
       var NEGATE = '(?:(!)\\s*)?'; // Group 2
       var EXPRESSION = OPEN_BRACKET + NEGATE + BINDING + CLOSE_BRACKET;
       return new RegExp(EXPRESSION, "g");
@@ -143,6 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           compoundIndex: parts.length,
           value: value,
           mode: mode,
+          safe: m[1][1] === '#',
           negate: negate,
           event: notifyEvent,
           customEvent: customEvent
@@ -179,11 +180,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Initialize the textContent with any literal parts
         // NOTE: default to a space here so the textNode remains; some browsers
         // (IE) evacipate an empty textNode following cloneNode/importNode.
+        var safe = parts.length !== 1 ? false : parts[0].safe;
         node.textContent = this._literalFromParts(parts) || ' ';
         var annote = {
           bindings: [{
             kind: 'text',
-            name: 'textContent',
+            name: safe ? 'innerHTML' : 'textContent',
             parts: parts,
             isCompound: parts.length !== 1
           }]

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -290,9 +290,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           value = this._scopeElementClass(node, value);
         }
         // Some browsers serialize `undefined` to `"undefined"`
-        if (property === 'textContent' ||
+        if (property === 'textContent' || property === 'innerHTML' ||
             (node.localName == 'input' && property == 'value')) {
           value = value == undefined ? '' : value;
+        }
+        if (property === 'innerHTML') {
+          this._nodes[info.index] = node.nodeType === node.TEXT_NODE ? node.parentElement : node;
+          node = this._nodes[info.index];
         }
         // Ideally we would call setProperty using fromAbove: true to avoid
         // spinning the wheel needlessly, but we found that users were listening

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -50,6 +50,7 @@
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4
       </div>
       <div id="unescapedhtml">{#unescapedHtml#}</div>
+      <div id="unescapedhtmlcpnd">{#unescapedHtml#} literal</div>
   </template>
   <script>
     Polymer({

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -49,6 +49,7 @@
       <div id="compound2">
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4
       </div>
+      <div id="unescapedhtml">{#unescapedHtml#}</div>
   </template>
   <script>
     Polymer({
@@ -128,6 +129,9 @@
         },
         noComputedProp: {
           computed: 'foobared(noComputed)'
+        },
+        unescapedHtml: {
+          value: '<b>unescaped</b>'
         }
       },
       observers: [

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -52,6 +52,12 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.unescapedhtml.innerHTML, '<i>updated</i>', 'unescaped html did not update');
   });
 
+  test('unescaped html binding updates deeply', function() {
+    var html = '<i>updated</i> with <p>nested <b>tags</b></p>';
+    el.unescapedHtml = html;
+    assert.equal(el.$.unescapedhtml.innerHTML, html, 'unescaped html did not render deep html');
+  });
+
   test('unescaped html not allowed in compound', function() {
     el.unescapedHtml = '<b>unescaped</b>';
     assert.equal(el.$.unescapedhtmlcpnd.textContent, '<b>unescaped</b> literal', 'unescaped html rendered in compound binding');

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -52,6 +52,11 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.unescapedhtml.innerHTML, '<i>updated</i>', 'unescaped html did not update');
   });
 
+  test('unescaped html not allowed in compound', function() {
+    el.unescapedHtml = '<b>unescaped</b>';
+    assert.equal(el.$.unescapedhtmlcpnd.textContent, '<b>unescaped</b> literal', 'unescaped html rendered in compound binding');
+  });
+
   test('textContent binding updates', function() {
     el.text = 'this is a test';
     assert.equal(el.$.boundText.textContent, 'this is a test', 'Value not propagated to textContent');

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -43,6 +43,15 @@ suite('single-element binding effects', function() {
     assert.equal(Polymer.dom(el.root).querySelector('span[idtest]').id, 'span', 'id bound to <span> not found');
   });
 
+  test('unescaped html binding renders', function() {
+    assert.equal(el.$.unescapedhtml.innerHTML, '<b>unescaped</b>', 'unescaped html did not render');
+  });
+
+  test('unescaped html binding updates', function() {
+    el.unescapedHtml = '<i>updated</i>';
+    assert.equal(el.$.unescapedhtml.innerHTML, '<i>updated</i>', 'unescaped html did not update');
+  });
+
   test('textContent binding updates', function() {
     el.text = 'this is a test';
     assert.equal(el.$.boundText.textContent, 'this is a test', 'Value not propagated to textContent');


### PR DESCRIPTION
This adds a new `{# #}` annotation which will bind to `innerHTML` instead of `textContent`. By design it does not work on compound bindings for some reason I can't really justify. After the 5th or so request in the Polymer slack on advice on how to bind a value with html I threw this together. Please don't ban me for this insanity.

Usage:

```html
<dom-module id="x-foo">
  <template>
    <p class="message">{#messageBody#}</p>
  </template>
  <script>
  Polymer({
    is: 'x-foo',
    properties: {
      messageBody: {
        value: '<b>Some html string here</b>'
      }
    }
  });
  </script>
</dom-module>
```
