### PR TITLE
Allow newlines in computed binding argument list

### DIFF
--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -190,7 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // method expressions are of the form: `name([arg1, arg2, .... argn])`
     _parseMethod: function(expression) {
       // tries to match valid javascript property names
-      var m = expression.match(/([^\s]+?)\((.*)\)/);
+      var m = expression.match(/([^\s]+?)\(([\s\S]*)\)/);
       if (m) {
         var sig = { method: m[1], static: true };
         if (m[2].trim()) {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -9,7 +9,11 @@
       camel-case="{{value}}"
       computed-inline="{{computeInline(value,add, divide)}}"
       computed-inline2="{{computeInline(value, add,divide)}}"
+      computed-inline3="{{computeInline(value, add,
+                                        divide)}}"
       computedattribute$="{{computeInline(value, add,divide)}}"
+      computedattribute2$="{{computeInline(
+                               value, add, divide)}}"
       neg-computed-inline="{{!computeInline(value,add,divide)}}"
       computed-negative-number="{{computeNegativeNumber(-1)}}"
       computed-negative-literal="{{computeNegativeNumber(-A)}}"
@@ -23,6 +27,8 @@
       computed-from-tricky-function='{{$computeTrickyFunctionFromLiterals( 3, "foo")}}'
       computed-from-tricky-literals="{{computeFromTrickyLiterals(3, 'tricky\,\'zot\'')}}"
       computed-from-tricky-literals2='{{computeFromTrickyLiterals(3,"tricky\,&#39;zot&#39;" )}}'
+      computed-from-tricky-literals3='{{computeFromTrickyLiterals(3,
+                                          "tricky\,&#39;zot&#39;" )}}'
       computed-from-no-args="{{computeFromNoArgs( )}}"
       no-computed="{{foobared(noInlineComputed)}}"
       compoundAttr1$="{{cpnd1}}{{ cpnd2 }}{{cpnd3.prop}}{{ computeCompound(cpnd4, cpnd5, 'literal')}}"

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -173,6 +173,7 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedFromTrickyFunction, '3foo', 'Wrong result from tricky function with pure literal arg computation');
     assert.equal(el.$.boundChild.computedFromTrickyLiterals, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.boundChild.computedFromTrickyLiterals2, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
+    assert.equal(el.$.boundChild.computedFromTrickyLiterals3, '3tricky,\'zot\'', 'Wrong result from tricky literal arg computation');
     assert.equal(el.$.computedContent.textContent, '3tricky,\'zot\'', 'Wrong textContent from tricky literal arg computation');
     assert.equal(el.$.computedContent2.textContent, '(3', 'Wrong textContent from tricky literal arg computation');
   });
@@ -224,6 +225,7 @@ suite('single-element binding effects', function() {
     el.divide = 3;
     assert.equal(el.$.boundChild.computedInline, 20, 'computedInline not correct');
     assert.equal(el.$.boundChild.computedInline2, 20, 'computedInline2 not correct');
+    assert.equal(el.$.boundChild.computedInline3, 20, 'computedInline3 not correct');
     assert.equal(el.$.boundChild.negComputedInline, false, 'negComputedInline not correct');
   });
 
@@ -232,6 +234,7 @@ suite('single-element binding effects', function() {
     el.add = 40;
     el.divide = 3;
     assert.equal(el.$.boundChild.getAttribute('computedattribute'), 20, 'computed attribute not correct');
+    assert.equal(el.$.boundChild.getAttribute('computedattribute2'), 20, 'computed attribute not correct');
   });
 
   test('annotated style attribute binding', function() {


### PR DESCRIPTION
This allows breaking in the middle of computed bindings, e.g.:

```
<div hidden$="[[_someVeryLongFunctionName(
                  someVeryLongArg,
                  anotherCrazyLongArg]]">
```

Note that `[\s\S]*` [doesn't seem to have worse performance]( http://jsperf.com/javascript-multiline-regexp-workarounds/5) than `.*`.

This is a rebase of https://github.com/Polymer/polymer/pull/2486