### PR TITLE
Namespace support (a.k.a. SVG handling)

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -329,7 +329,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Attribute or property
         var origName = name;
         var kind = 'property';
-        if (name[name.length-1] == '$') {
+        var last = name[name.length-1]
+        if (last == '$' || last == '_') { //hack because setting attribName$ when we create element is not allowed
           name = name.slice(0, -1);
           kind = 'attribute';
         }

--- a/src/lib/polymer-bootstrap.html
+++ b/src/lib/polymer-bootstrap.html
@@ -51,9 +51,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Note: need to chain user prototype with the correct type-extended
       // version of Polymer.Base; this is especially important when you can't
       // prototype swizzle (e.g. IE10), since CustomElements uses getPrototypeOf
+
       var base = Polymer.Base;
       if (prototype.extends) {
-        base = Polymer.Base._getExtendedPrototype(prototype.extends);
+        base = Polymer.Base._getExtendedPrototype(prototype.extends, prototype.namespace);
       }
       prototype = Polymer.Base.chainObject(prototype, base);
       prototype.registerCallback();

--- a/src/micro/constructor.html
+++ b/src/micro/constructor.html
@@ -42,10 +42,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _prepConstructor: function() {
       // support both possible `createElement` signatures
       this._factoryArgs = this.extends ? [this.extends, this.is] : [this.is];
-      // thunk the constructor to delegate allocation to `createElement`
-      var ctor = function() { 
-        return this._factory(arguments); 
-      };
+
+      var ctor;
+      if (this.namespace) {
+          this._factoryArgs = [this.namespace].concat(this._factoryArgs);
+          ctor = function() { 
+            return this._factoryNS(arguments); 
+          };        
+      } else {
+        // thunk the constructor to delegate allocation to `createElement`
+        ctor = function() { 
+            return this._factory(arguments); 
+          };    
+      }
+
       if (this.hasOwnProperty('extends')) {
         ctor.extends = this.extends; 
       }
@@ -63,7 +73,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.factoryImpl.apply(elt, args);
       }
       return elt;
+    },
+
+    // Not sure if this is usefull 
+    _factoryNS: function(args) {
+      var elt = document.createElementNS.apply(document, this._factoryArgs);
+      if (this.factoryImpl) {
+        this.factoryImpl.apply(elt, args);
+      }
+      return elt;
     }
+
 
   });
 

--- a/src/micro/constructor.html
+++ b/src/micro/constructor.html
@@ -8,7 +8,6 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
-
   /**
    * Generates a boilerplate constructor.
    * 
@@ -34,28 +33,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * 
    * @class base feature: constructor
    */
-
   Polymer.Base._addFeature({
-
     // registration-time
-
     _prepConstructor: function() {
       // support both possible `createElement` signatures
       this._factoryArgs = this.extends ? [this.extends, this.is] : [this.is];
-
-      var ctor;
-      if (this.namespace) {
-          this._factoryArgs = [this.namespace].concat(this._factoryArgs);
-          ctor = function() { 
-            return this._factoryNS(arguments); 
-          };        
-      } else {
-        // thunk the constructor to delegate allocation to `createElement`
-        ctor = function() { 
-            return this._factory(arguments); 
-          };    
-      }
-
+      // thunk the constructor to delegate allocation to `createElement`
+      var ctor = function() { 
+        return this._factory(arguments); 
+      };
       if (this.hasOwnProperty('extends')) {
         ctor.extends = this.extends; 
       }
@@ -66,25 +52,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         writable: true, configurable: true});
       ctor.prototype = this;
     },
-
     _factory: function(args) {
       var elt = document.createElement.apply(document, this._factoryArgs);
       if (this.factoryImpl) {
         this.factoryImpl.apply(elt, args);
       }
       return elt;
-    },
-
-    // Not sure if this is usefull 
-    _factoryNS: function(args) {
-      var elt = document.createElementNS.apply(document, this._factoryArgs);
-      if (this.factoryImpl) {
-        this.factoryImpl.apply(elt, args);
-      }
-      return elt;
     }
-
-
   });
-
 </script>

--- a/src/micro/extends.html
+++ b/src/micro/extends.html
@@ -47,18 +47,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.Base._addFeature({
 
-    _getExtendedPrototype: function(tag) {
-      return this._getExtendedNativePrototype(tag);
+    _getExtendedPrototype: function(tag, namespace) {
+      return this._getExtendedNativePrototype(tag, namespace);
     },
 
     _nativePrototypes: {}, // static
 
-    _getExtendedNativePrototype: function(tag) {
-      var p = this._nativePrototypes[tag];
+    _getExtendedNativePrototype: function(tag, namespace) {
+      var key = namespace ? (tag + '_' + namespace) : tag;
+      var p = this._nativePrototypes[key];
       if (!p) {
-        var np = this.getNativePrototype(tag);
+        var np = this.getNativePrototype(tag, namespace);
         p = this.extend(Object.create(np), Polymer.Base);
-        this._nativePrototypes[tag] = p;
+        this._nativePrototypes[key] = p;
       }
       return p;
     },
@@ -70,8 +71,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {string} tag  HTML tag name.
      * @return {Object} Native prototype for specified tag.
     */
-    getNativePrototype: function(tag) {
+    getNativePrototype: function(tag, namespace) {
       // TODO(sjmiles): sad necessity
+      if(namespace) {
+        return Object.getPrototypeOf(document.createElementNS(namespace, tag));
+      }
       return Object.getPrototypeOf(document.createElement(tag));
     }
 

--- a/src/mini/template.html
+++ b/src/mini/template.html
@@ -8,62 +8,118 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
+/**
+ * Automatic template management.
+ *
+ * The `template` feature locates and instances a `<template>` element
+ * corresponding to the current Polymer prototype.
+ *
+ * The `<template>` element may be immediately preceeding the script that
+ * invokes `Polymer()`.
+ *
+ * @class standard feature: template
+ */
+
+Polymer.Base._addFeature({
+
+  _prepTemplate: function() {
+    // locate template using dom-module
+    if (this._template === undefined) {
+      this._template = Polymer.DomModule.import(this.is, 'template');
+    }
+    // stick finger in footgun
+    if (this._template && this._template.hasAttribute('is')) {
+      this._warn(this._logf('_prepTemplate', 'top-level Polymer template ' +
+        'must not be a type-extension, found', this._template,
+        'Move inside simple <template>.'));
+    }
+    this._setTemplateContentNamespace();
+
+    // bootstrap the template if it has not already been
+    if (this._template && !this._template.content &&
+      window.HTMLTemplateElement && HTMLTemplateElement.decorate) {
+      HTMLTemplateElement.decorate(this._template);
+    }
+  },
+
+  _setTemplateContentNamespace: function() {
+    // we put the content of the templage in the appropriate namespace 
+    // the _template  and content tag need to stay in the html namespace 
+    if (this._template && this.namespace) {
+      var _newTemplate = document.createElement('template'),
+        namespace = this.namespace;
+
+      function copy(el, target) {
+        function copyAttr(el, t) {
+          var attribs = el.attributes,
+            count = attribs.length,
+            attrib,name;
+          while (count-- > 0) {
+            attrib = attribs[count];
+            name = attrib.name;
+            if (name[name.length-1] == '$') {
+                // hack attribName$ is invalid when we create the namespace element
+                // we will need to check if attrib name also ends with '_' when we compute teh binding.
+                name = name.slice(0, -1) + '_';  
+            }
+            t.setAttribute(name, attrib.value);
+          }
+        }
+
+        function copyText(el, t) {
+          if (!el.children.length) {
+            t.textContent = el.textContent;
+          }
+        }
+        var t = (namespace && el.tagName != 'TEMPLATE' &&  el.tagName != 'CONTENT' ) ? document.createElementNS(namespace, el.localName) : document.createElement(el.localName);
+        target.appendChild(t);
+        copyAttr(el, t);
+        copyText(el, t);
+        if (el.children) {
+          move(el, t);
+        }
+      }
+
+      function move(source, target) {
+        var s;
+        while (source.children && source.children.length) {
+          s = source.children[0];
+          copy(s, target);
+          source.removeChild(s)
+            // target.appendChild(c);
+        }
+      }
+
+      move(this._template.content, _newTemplate.content);
+      this._template.parentElement.appendChild(_newTemplate);
+      this._template.parentElement.removeChild(this._template);
+      this._template = _newTemplate;
+
+    }
+  },
+
+  _stampTemplate: function() {
+    if (this._template) {
+      // note: root is now a fragment which can be manipulated
+      // while not attached to the element.
+      this.root = this.instanceTemplate(this._template);
+    }
+  },
 
   /**
-   * Automatic template management.
+   * Calls `importNode` on the `content` of the `template` specified and
+   * returns a document fragment containing the imported content.
    *
-   * The `template` feature locates and instances a `<template>` element
-   * corresponding to the current Polymer prototype.
-   *
-   * The `<template>` element may be immediately preceeding the script that
-   * invokes `Polymer()`.
-   *
-   * @class standard feature: template
+   * @method instanceTemplate
+   * @param {HTMLTemplateElement} template HTML template element to instance.
+   * @return {DocumentFragment} Document fragment containing the imported
+   *   template content.
    */
+  instanceTemplate: function(template) {
+    var dom =
+      document.importNode(template._content || template.content, true);
+    return dom;
+  }
 
-  Polymer.Base._addFeature({
-
-    _prepTemplate: function() {
-      // locate template using dom-module
-      if (this._template === undefined) {
-        this._template = Polymer.DomModule.import(this.is, 'template');
-      }
-      // stick finger in footgun
-      if (this._template && this._template.hasAttribute('is')) {
-        this._warn(this._logf('_prepTemplate', 'top-level Polymer template ' +
-          'must not be a type-extension, found', this._template,
-          'Move inside simple <template>.'));
-      }
-      // bootstrap the template if it has not already been
-      if (this._template && !this._template.content &&
-          window.HTMLTemplateElement && HTMLTemplateElement.decorate) {
-        HTMLTemplateElement.decorate(this._template);
-      }
-    },
-
-    _stampTemplate: function() {
-      if (this._template) {
-        // note: root is now a fragment which can be manipulated
-        // while not attached to the element.
-        this.root = this.instanceTemplate(this._template);
-      }
-    },
-
-    /**
-     * Calls `importNode` on the `content` of the `template` specified and
-     * returns a document fragment containing the imported content.
-     *
-     * @method instanceTemplate
-     * @param {HTMLTemplateElement} template HTML template element to instance.
-     * @return {DocumentFragment} Document fragment containing the imported
-     *   template content.
-    */
-    instanceTemplate: function(template) {
-      var dom =
-        document.importNode(template._content || template.content, true);
-      return dom;
-    }
-
-  });
-
+});
 </script>


### PR DESCRIPTION
A first go at allowing custom elements to be defined in other namespaces than html.

This is especially useful when working with SVG. Two main tricks : 
- get the proper native prototype when a namespace is declared (src/micro/extends.html, line 76), and 
- re create template elements defined in appropriate namespace (src/mini/template.html, line 45 and below) .

This allows to declare template like (note **`<g is="d3-enable-zoom">`**):  

``` html
 <template>
    <h2>Testing bindings</h2>
    <p>opacity</p>
    <paper-slider step="0.1" min="0" max="1" value="{{opacity}}"></paper-slider>
    <svg id="svg" width="900" height="450">
      <g is="d3-enable-zoom" test="here we go" opacity="[[opacity]]">
        <g id="content"></g>
      </g>
    </svg>
  </template>
```

and `d3-enable-zoom` declared as 

``` html
<dom-module id="d3-enable-zoom">
  <template>
    <rect id="zoom" class="zoom" data-prevent-focus="true" width="200%" height="200%" x="-50%" y="-50%" opacity$="[[opacity]]" fill="#123"></rect>'
    <g id="zoomGroup" class="zoomGroup">
      <content></content>
    </g>
  </template>
</dom-module>
<script>
(function() {
  'use strict';

  Polymer({
    is: 'd3-enable-zoom',
    extends: 'g',
    namespace: 'http://www.w3.org/2000/svg',
 ....
```

Live example to follow
Cheers,
C.
