### PR TITLE
Fix parsing of parenthesis in default of variable declaration

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -160,12 +160,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             if (m) {
               p = this.valueForProperty(props[m[1]], props);
             } else {
-              var pp = p.split(':');
-              if (pp[1]) {
-                pp[1] = pp[1].trim();
-                pp[1] = this.valueForProperty(pp[1], props) || pp[1];
+              var colon = p.indexOf(':');
+              if (colon !== -1) {
+                var pp = p.substring(colon);
+                pp = pp.trim();
+                pp = this.valueForProperty(pp, props) || pp;
+                p = p.substring(0, colon) + pp;
               }
-              p = pp.join(':');
             }
             parts[i] = (p && p.lastIndexOf(';') === p.length - 1) ?
               // strip trailing ;
@@ -449,7 +450,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // var(--a, --b)
         // var(--a, fallback-literal)
         // var(--a, fallback-literal(with-one-nested-parentheses))
-        VAR_MATCH: /(^|\W+)var\([\s]*([^,)]*)[\s]*,?[\s]*((?:[^,)]*)|(?:[^;]*\([^;)]*\)))[\s]*?\)/gi,
+        VAR_MATCH: /(^|\W+)var\([\s]*([^,)]*)[\s]*,?[\s]*((?:[^,()]*)|(?:[^;()]*\([^;)]*\)))[\s]*?\)/gi,
         VAR_CAPTURE: /\([\s]*(--[^,\s)]*)(?:,[\s]*(--[^,\s)]*))?(?:\)|,)/gi,
         ANIMATION_MATCH: /(animation\s*:)|(animation-name\s*:)/,
         IS_VAR: /^--/,

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -445,6 +445,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         #endTerm {border: var(--end-term)}
+
+        #parenthesis {
+          background-image: var(--foo-background-image, url(http://placehold.it/400x300));
+        }
       </style>
       <div id="me">x-scope</div>
       <x-keyframes id="keyframes"></x-keyframes>
@@ -473,6 +477,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <x-dynamic id="dynamic"></x-dynamic>
       <div id="wsTerm">new line var</div>
       <div id="endTerm">end var</div>
+      <div id="parenthesis">parenthesis</div>
     </template>
     <script>
     HTMLImports.whenReady(function() {
@@ -556,8 +561,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   suite('scoped-styling-var', function() {
 
-  function assertComputed(element, value, pseudo) {
-    var name = 'border-top-width';
+  function assertComputed(element, value, pseudo, name) {
+    var name = name || 'border-top-width';
     var computed = element.getComputedStyleValue && !pseudo ?
       element.getComputedStyleValue(name) :
       getComputedStyle(element, pseudo)[name];
@@ -792,6 +797,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('vars with trailing new line or } apply', function() {
     assertComputed(styled.$.wsTerm, '18px');
     assertComputed(styled.$.endTerm, '19px');
+  });
+
+  test('variable with parenthesis', function() {
+    assertComputed(styled.$.parenthesis, 'url("http://placehold.it/400x300")', false, 'background-image');
   });
 
   // skip for now, until #3326 is fixed


### PR DESCRIPTION
There were two separate issues which lead to un-parsable default declarations with parenthesis:

1. The regex to match the default declaration of a `var()` did not ignore `(` and matched on every variable declaration. Even if there was 1 pair of parenthesis in the default declaration.
* For extraction of a default declaration with a `colon`, the `String.split` would cut the declaration into three pieces instead of one. Therefore only the first occurrence of the colon should be used to split the declaration.

There is one other separate bug that became apparent: Matching with a default declaration with parenthesis leads to a double declaration of the css rule. The second rule is always `css-property: var( };`. I assume this is a bug, but I am not certain.

Fixes #3221 