### PR TITLE
Enforce undefined rule for observers

### DIFF
--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -121,9 +121,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _marshalArgs: function(model, effect, path, value) {
       var values = [];
       var args = effect.args;
-      // Actually we should return early as soon as we see an `undefined`,
-      // but dom-repeat relies on this behavior.
-      var bailoutEarly = (args.length > 1 || effect.dynamicFn);
       for (var i=0, l=args.length; i<l; i++) {
         var arg = args[i];
         var name = arg.name;
@@ -135,9 +132,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           v = model[name];
         }
-        if (bailoutEarly && v === undefined) {
+        // We bail out immediately when we see the first `undefined`.
+        // This implements a major feature within Polymer, notably that
+        // observers are not called before ALL its dependencies have a value.
+        // Thus `undefined` has the notion of not-yet-initialized within
+        // the framework. The drawback is that you MUST NOT set a property
+        // to 'the value of undefined' (sic!) in your program. Always use
+        // `null` for that.
+        if (v === undefined) {
           return;
         }
+
         if (arg.wildcard) {
           // Only send the actual path changed info if the change that
           // caused the observer to run matched the wildcard

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -124,7 +124,8 @@ Then the `observe` property should be configured as follows:
        * to stamp and that that each template instance should bind to.
        */
       items: {
-        type: Array
+        type: Array,
+        observer: '_handleUndefinedValue'
       },
 
       /**
@@ -347,15 +348,27 @@ Then the `observe` property should be configured as follows:
         this.observe.replace('.*', '.').split(' ');
     },
 
+    _handleUndefinedValue: function(items) {
+      // Since `_itemsChanged` wont be notified about undefined values, we
+      // handle this invariant here within a property observer.
+      if (items === undefined) {
+        this.collection = null;
+        this._keySplices = [];
+        this._indexSplices = [];
+        this._needFullRefresh = true;
+        this._initializeChunking();
+        this._debounceTemplate(this._render);
+      }
+    },
+
     _itemsChanged: function(change) {
       if (change.path == 'items') {
-        if (Array.isArray(this.items)) {
-          this.collection = Polymer.Collection.get(this.items);
-        } else if (!this.items) {
-          this.collection = null;
-        } else {
+        var items = change.value;
+        if (Array.isArray(items)) {
+          this.collection = Polymer.Collection.get(items);
+        } else if (items !== null) {
           this._error(this._logf('dom-repeat', 'expected array for `items`,' +
-            ' found', this.items));
+            ' found', items));
         }
         this._keySplices = [];
         this._indexSplices = [];

--- a/test/unit/notify-path-elements.html
+++ b/test/unit/notify-path-elements.html
@@ -198,6 +198,7 @@
         assert.equal(c, this.nested.obj.c, 'multiplePathsChanged `c` arg incorrect');
       },
       arrayChanged: function(splices) {
+        assert.notEqual(splices, undefined);
         this.observerCounts.arrayChanged++;
         if (this.array.length) {
           assert.equal(splices.indexSplices.length, 1,
@@ -212,6 +213,7 @@
       },
       arrayChangedDeep: function() { },
       arrayNoCollChanged: function(splices) {
+        assert.notEqual(splices, undefined);
         this.observerCounts.arrayNoCollChanged++;
         if (this.arrayNoColl.length) {
           assert.equal(splices.indexSplices.length, 1,

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -348,12 +348,12 @@ suite('path effects', function() {
 
   test('array.splices notified (no Collection)', function() {
     el.arrayNoColl = [];
-    assert.equal(el.observerCounts.arrayNoCollChanged, 1);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 0);
     el.push('arrayNoColl', 1, 2, 3);
-    assert.equal(el.observerCounts.arrayNoCollChanged, 2);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 1);
     assert.equal(Polymer.Collection.get(el.arrayNoColl).getKeys().length, 3);
     el.push('arrayNoColl', 4, 5, 6);
-    assert.equal(el.observerCounts.arrayNoCollChanged, 3);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 2);
     assert.equal(Polymer.Collection.get(el.arrayNoColl).getKeys().length, 6);
   });
 
@@ -361,12 +361,12 @@ suite('path effects', function() {
     el.array = [];
     // Ensure keySplices are generated for test purposes
     Polymer.Collection.get(el.array);
-    assert.equal(el.observerCounts.arrayChanged, 1);
+    assert.equal(el.observerCounts.arrayChanged, 0);
     el.push('array', 1, 2, 3);
-    assert.equal(el.observerCounts.arrayChanged, 2);
+    assert.equal(el.observerCounts.arrayChanged, 1);
     assert.equal(Polymer.Collection.get(el.array).getKeys().length, 3);
     el.push('array', 4, 5, 6);
-    assert.equal(el.observerCounts.arrayChanged, 3);
+    assert.equal(el.observerCounts.arrayChanged, 2);
     assert.equal(Polymer.Collection.get(el.array).getKeys().length, 6);
   });
 


### PR DESCRIPTION
Enforce (again) the rule that observers are never called with undefined values. Basically reverts f68c30e21eec7d1fae04dc032c81df497444099e.
- Ensures observers on `*.splices` don't get undefined's initially. See #3239, https://github.com/Polymer/polymer/issues/2470#issuecomment-174199175
- Reduces confusion, e.g. #3401  
- Marks an invariant (dom-repeat sees unexpectedly undefineds) where it belongs, instead of masking it. Removes a confusing dependency between observers `marshalArgs` and `dom-repeat`.
