### PR TITLE
Refactorings around how computational expressions get their arguments

### DIFF
--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -130,6 +130,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var v;
         if (arg.literal) {
           v = arg.value;
+        } else if (path === name) {
+          v = value;
         } else {
           // Take advantage of the fact that all values sent through the path
           // notifications system are cached on the model. Trivially, all the

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -130,10 +130,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var v;
         if (arg.literal) {
           v = arg.value;
-        } else if (arg.structured) {
-          v = Polymer.Base._get(name, model);
         } else {
+          // Take advantage of the fact that all values sent through the path
+          // notifications system are cached on the model. Trivially, all the
+          // user properties can be looked up there as well.
           v = model[name];
+          if (v === undefined && arg.structured) {
+            // All initial values and base assignments don't go through the
+            // notifications API, so we must construct/evaluate the correct
+            // value. (E.g. you assign a new object to `this.foo`, but your
+            // observer actually listens to `foo.bar.quux`)
+            v = Polymer.Base._get(name, model);
+          }
         }
         if (bailoutEarly && v === undefined) {
           return;

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -150,9 +150,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         if (arg.wildcard) {
           // Only send the actual path changed info if the change that
-          // caused the observer to run matched the wildcard
-          var baseChanged = (name.indexOf(path + '.') === 0);
-          var matches = (effect.trigger.name.indexOf(name) === 0 && !baseChanged);
+          // caused the observer to run matches this arg. Note that this holds
+          // also true when `path === name`. We can skip this check b/c then
+          // `name` and `v` already have the values we want.
+          // Read the following as: `head(path) === name`.
+          var matches = path.indexOf(name + '.') === 0;
           values[i] = {
             path: matches ? path : name,
             value: matches ? value : v,

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -438,12 +438,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           keySplices: Polymer.Collection.applySplices(array, splices),
           indexSplices: splices
         };
-        this._notifyPath(path + '.splices', change);
+        var splicesPath = path + '.splices';
+        this._notifyPath(splicesPath, change);
         this._notifyPath(path + '.length', array.length);
         // All path notification values are cached on `this.__data__`.
         // Null here to allow potentially large splice records to be GC'ed.
-        change.keySplices = null;
-        change.indexSplices = null;
+        this.__data__[splicesPath] = {keySplices: null, indexSplices: null};
       },
 
       _notifySplice: function(array, path, index, added, removed) {

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -438,14 +438,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           keySplices: Polymer.Collection.applySplices(array, splices),
           indexSplices: splices
         };
-        if (!array.hasOwnProperty('splices')) {
-          Object.defineProperty(array, 'splices',
-            {configurable: true, writable: true});
-        }
-        array.splices = change;
         this._notifyPath(path + '.splices', change);
         this._notifyPath(path + '.length', array.length);
-        // Null here to allow potentially large splice records to be GC'ed
+        // All path notification values are cached on `this.__data__`.
+        // Null here to allow potentially large splice records to be GC'ed.
         change.keySplices = null;
         change.indexSplices = null;
       },

--- a/test/unit/notify-path-elements.html
+++ b/test/unit/notify-path-elements.html
@@ -209,6 +209,7 @@
           assert.equal(splices.keySplices[0].added.length, 3,
             'arrayChanged keySplices incorrect');
         }
+        this.arraySplices = splices;
       },
       arrayChangedDeep: function() { },
       arrayNoCollChanged: function(splices) {

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -370,6 +370,16 @@ suite('path effects', function() {
     assert.equal(Polymer.Collection.get(el.array).getKeys().length, 6);
   });
 
+  test('ensure splices sent into userland dont get nulled', function(){
+    el.array = [];
+    // Ensure keySplices are generated for test purposes
+    Polymer.Collection.get(el.array);
+
+    el.push('array', 1, 2, 3);
+    assert.notEqual(el.arraySplices.indexSplices, null);
+    assert.notEqual(el.arraySplices.keySplices, null);
+  });
+
   test('array.splices notified, multiple args, prop first', function() {
     el.array = [];
     // Ensure keySplices are generated for test purposes


### PR DESCRIPTION
- Do not set splices property on userland arrays. Fixes #2415, #2350
- Use value sent through the notification system (#3179)
- Don't mutate splices sent into userland. As reported #3239 

Should fix #3179