### PR TITLE
Restrict early property set to properties that have accessors. This a…

### DIFF
--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -120,7 +120,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // to override default values. This allows late upgrade + an early set
         // to not b0rk accessors on the prototype.
         // Perf testing has shown `hasOwnProperty` to be ok here.
-        if (!usePolyfillProto && this.hasOwnProperty(i)) {
+        if (!usePolyfillProto && this.hasOwnProperty(i) &&
+            this._propertyEffects && this._propertyEffects[i]) {
           config[i] = this[i];
           delete this[i];
         } else if (c.value !== undefined) {

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -133,6 +133,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(x.shouldChange, x.textContent);
       document.body.removeChild(x);
     });
+
+    test('setting properties in created works with configuration', function() {
+      // don't test if __proto__ is polyfilled (IE10); cannot be fixed in this case.
+      if (Polymer.Settings.usePolyfillProto) {
+        return;
+      }
+      var x = document.createElement('x-late-register2');
+      document.body.appendChild(x);
+      // now register element
+      Polymer({
+        is: 'x-late-register2',
+        properties: {
+          a: {
+            type: Number
+          },
+          b: {
+            value: function() {
+              return this.a * 2;
+            }
+          }
+        },
+        created: function() {
+          this.a = 1;
+        }
+      });
+      CustomElements.takeRecords();
+      assert.equal(x.b, 2);
+      document.body.removeChild(x);
+    });
   });
 
 </script>


### PR DESCRIPTION
…llows users to set properties in `created` which are listed in `properties` but which have no accessor.