### PR TITLE
Fix undefined class attribute in undefined template scope

### DIFF
--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -395,6 +395,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (host) {
         return host._scopeElementClass(node, value);
       }
+      return value;
     },
 
     /**

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -16,6 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../polymer.html">
   <link rel="import" href="bind-elements.html">
 <body>
+  <template id="class-repeat" is="dom-repeat" items='["class1", "class2"]'>
+    <div class$=[[item]] clazz$="[[item]]">[[item]]</div>
+  </template>
 <script>
 
 suite('single-element binding effects', function() {
@@ -284,6 +287,13 @@ suite('single-element binding effects', function() {
       'binding-with-dash': 'yes'
     };
     assert.equal(el.$.boundWithDash.textContent, 'yes');
+  });
+
+  test('class attribute without template scope not erased', function() {
+    var el = document.querySelector('.class1');
+    assert.notEqual(el, null, 'class without template scope is undefined');
+    var el2 = document.querySelector('.class2');
+    assert.notEqual(el2, null, 'class without template scope is undefined');
   });
 
 });


### PR DESCRIPTION
### Reference Issue
Fixes #3364

### Description
If the `dom-repeat` has no template host, `this._rootDataHost` is undefined. Therefore it will not invoke `this._rootDataHost._scopeElementClass`. As fallback, return the plain value received, as Polymer should not perform any scoped styling.