### PR TITLE
Loosen undefined rule for computational expressions

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -90,7 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _bindingRegex: (function() {
-      var IDENT  = '(?:' + '[a-zA-Z_$][\\w.:$\\-*]*' + ')';
+      var IDENT  = '(?:' + '[?]?[a-zA-Z_$][\\w.:$\\-*]*' + ')';
       var NUMBER = '(?:' + '[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?' + ')';
       var SQUOTE_STRING = '(?:' + '\'(?:[^\'\\\\]|\\\\.)*\'' + ')';
       var DQUOTE_STRING = '(?:' + '"(?:[^"\\\\]|\\\\.)*"' + ')';

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -133,7 +133,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           v = model[name];
         }
-        if (bailoutEarly && v === undefined) {
+        if (!arg.optional && bailoutEarly && v === undefined) {
           return;
         }
         if (arg.wildcard) {

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -79,11 +79,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _computeEffect: function(source, value, effect) {
       var fn = this[effect.method];
       if (fn) {
-        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
-        if (args) {
-          var computedvalue = fn.apply(this, args);
-          this.__setProperty(effect.name, computedvalue);
-        }
+        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source,
+                                             value);
+        var computedvalue = args ? fn.apply(this, args) : undefined;
+        this.__setProperty(effect.name, computedvalue);
       } else if (effect.dynamicFn) {
         // dynamic functions can be just like every other property `undefined`
         // so we MUST ignore an undefined value here. (That's totally the
@@ -98,14 +97,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var computedHost = this._rootDataHost || this;
       var fn = computedHost[effect.method];
       if (fn) {
-        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
-        if (args) {
-          var computedvalue = fn.apply(computedHost, args);
-          if (effect.negate) {
-            computedvalue = !computedvalue;
-          }
-          this._applyEffectValue(effect, computedvalue);
+        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source,
+                                             value);
+        var computedvalue = args ? fn.apply(this, args) : undefined;
+        if (effect.negate) {
+          computedvalue = !computedvalue;
         }
+        this._applyEffectValue(effect, computedvalue);
       } else if (effect.dynamicFn) {
         // dynamic functions can be just like every other property `undefined`
         // so we MUST ignore an undefined value here. (That's totally the

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -289,6 +289,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       // if not literal, look for structured path
       if (!a.literal) {
+        if (arg[0] === '?') {
+          a.optional = true;
+          a.name = arg = arg.slice(1);
+        }
         a.model = this._modelForPath(arg);
         // detect structured path (has dots)
         a.structured = arg.indexOf('.') > 0;

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -682,3 +682,20 @@
     })
   </script>
 </dom-module>
+
+<dom-module id="x-optional-argument-on-computed-annotation">
+  <template>
+    <div id="check" prop="[[compute(?foo.bar, 'literal')]]"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-optional-argument-on-computed-annotation',
+      properties: {
+        foo: Object
+      },
+      compute: function(bar, literal) {
+        return bar + literal;
+      }
+    })
+  </script>
+</dom-module>

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -662,3 +662,23 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-undefined-default-for-computeds">
+  <template>
+    <div id="check" prop="[[compute(foo.bar, 'literal')]]"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-undefined-default-for-computeds',
+      properties: {
+        foo: Object,
+        computed: {
+          computed: 'compute(foo.bar, "literal")'
+        }
+      },
+      compute: function(bar, literal) {
+        return bar + literal;
+      }
+    })
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -398,17 +398,10 @@ suite('optional arguments for complex expressions', function() {
 
   var el;
 
-  setup(function() {
-    el = document.createElement('x-undefined-default-for-computeds');
-    document.body.appendChild(el);
-  });
-
-  teardown(function() {
-    document.body.removeChild(el);
-  });
-
   test('if an argument becomes unreachable, set undefined (annotation)',
        function() {
+    el = document.createElement('x-undefined-default-for-computeds');
+
     el.foo = {bar: 'quux'};
     assert.equal(el.$.check.prop, 'quuxliteral');
 
@@ -418,6 +411,8 @@ suite('optional arguments for complex expressions', function() {
 
   test('if an argument becomes unreachable, set undefined (computed)',
        function() {
+    el = document.createElement('x-undefined-default-for-computeds');
+
     el.foo = {bar: 'quux'};
     assert.equal(el.computed, 'quuxliteral');
 
@@ -425,6 +420,42 @@ suite('optional arguments for complex expressions', function() {
     assert.equal(el.computed, undefined);
   });
 
+  test('optional arguments can be undefined', function() {
+    var called = 0;
+    var calledWith;
+    Polymer({
+      is: 'optional-arguments-can-be-undefined',
+      properties: {
+        foo: Object
+      },
+      observers: ['compute(?foo.bar, "literal")'],
+
+      compute: function(bar, literal) {
+        called += 1;
+        calledWith = [bar, literal];
+      }
+    });
+
+    el = document.createElement('optional-arguments-can-be-undefined');
+
+    el.foo = {bar: 'quux'};
+    assert.equal(called, 1);
+    assert.deepEqual(calledWith, ['quux', 'literal']);
+
+    el.foo = {baz: 'quod'};
+    assert.equal(called, 2);
+    assert.deepEqual(calledWith, [undefined, 'literal']);
+  });
+
+  test('check that optional arguments work on annotations', function() {
+    el = document.createElement("x-optional-argument-on-computed-annotation");
+
+    el.foo = {bar: 'quux'};
+    assert.equal(el.$.check.prop, 'quuxliteral');
+
+    el.foo = {baz: 'quod'};
+    assert.equal(el.$.check.prop, 'undefinedliteral');
+  });
 });
 
 </script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -393,6 +393,43 @@ suite('computed bindings with dynamic functions', function() {
 </script>
 
 <script>
+
+suite('optional arguments for complex expressions', function() {
+
+  var el;
+
+  setup(function() {
+    el = document.createElement('x-undefined-default-for-computeds');
+    document.body.appendChild(el);
+  });
+
+  teardown(function() {
+    document.body.removeChild(el);
+  });
+
+  test('if an argument becomes unreachable, set undefined (annotation)',
+       function() {
+    el.foo = {bar: 'quux'};
+    assert.equal(el.$.check.prop, 'quuxliteral');
+
+    el.foo = {baz: 'quod'};
+    assert.equal(el.$.check.prop, undefined);
+  });
+
+  test('if an argument becomes unreachable, set undefined (computed)',
+       function() {
+    el.foo = {bar: 'quux'};
+    assert.equal(el.computed, 'quuxliteral');
+
+    el.foo = {baz: 'quod'};
+    assert.equal(el.computed, undefined);
+  });
+
+});
+
+</script>
+
+<script>
 suite('2-way binding effects between elements', function() {
 
   var el;


### PR DESCRIPTION
- Let developers opt-in to see undefined's in observers et.al.
- Let computed properties and annotations evaluate to undefined if their dependencies cannot be fulfilled

Can be seen as an add-on to #3423, could be applied individually as well. All in all non breaking change. 

Ref issue #3453, fixes #2158.
