### PR TITLE
Make notifyPath's value argument optional. 

### DIFF
--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -330,7 +330,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Call extension point for Templatizer sub-classes
       dataHost._forwardInstancePath.call(dataHost, this, path, value);
       if (root in dataHost._parentProps) {
-        dataHost._templatized.notifyPath(dataHost._parentPropPrefix + path, value);
+        dataHost._templatized._notifyPath(dataHost._parentPropPrefix + path, value);
       }
     },
 

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -70,20 +70,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Example:
        *
        *     this.item.user.name = 'Bob';
-       *     this.notifyPath('item.user.name', this.item.user.name);
+       *     this.notifyPath('item.user.name');
        *
        * @param {string} path Path that should be notified.
-       * @param {*} value Value of the specified path.
-       * @param {boolean=} fromAbove When true, specifies that the change came
-       *   from above this element and thus upward notification is not
-       *   necessary.
-       * @return {boolean} Returns true if notification actually took place,
-       *   based on a dirty check of whether the new value was already known.
       */
       notifyPath: function(path, value, fromAbove) {
         // Convert any array indices to keys before notifying path
         var info = {};
-        this._get(path, this, info);
+        var v = this._get(path, this, info);
+        if (arguments.length === 1) {
+          value = v;
+        }
         // Notify change to key-based path
         if (info.path) {
           this._notifyPath(info.path, value, fromAbove);


### PR DESCRIPTION
Fixes #3179. Mentioned here #2606.

Make second and third argument of notifyPath optional. Deprecate them?

An optional `value` argument would be of course useful, as a hint, so that Polymer did not had to look it up. But we have the `_get` call anyway.

`notifyPath` does not return a Boolean, so I removed that comment as well.  

