### PR TITLE
Clean the .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,2 @@
-node_modules/*
-bower_components/*
 src/**/demo/*
 src/**/experimental/*


### PR DESCRIPTION
The `node_modules/` and `bower_components/` will be ignored by default like described in [the ESLint documentation](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).