### PR TITLE
Ensure that dom-bind always waits until DOMContentLoaded to render.

### DIFF
--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -69,7 +69,13 @@ elements to the template itself as the binding scope.
       // have resolved
       var self = this;
       Polymer.RenderStatus.whenReady(function() {
-        self._markImportsReady();
+        if (document.readyState == 'loading') {
+          document.addEventListener('DOMContentLoaded', function() {
+            self._markImportsReady(); 
+          });
+        } else {  
+          self._markImportsReady();
+        }
       });
     },
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -69,6 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dom-if.html',
       'unit/dom-template.html',
       'unit/dom-bind.html',
+      'unit/dom-bind-yield.html',
       'unit/script-after-import-in-head.html',
       'unit/globals.html'
     ];

--- a/test/unit/dom-bind-yield.html
+++ b/test/unit/dom-bind-yield.html
@@ -35,12 +35,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     if (window.Polymer) {
       var now = Date.now() + 1000;
-      while (Date.now() < now) {}
+      while (Date.now() < now) {
+        Math.random();
+      }
     }
   </script>
 
   <script>
-    domBind.fired = function() {
+    window.domBind.fired = function() {
       this.didFire = true;
     }
   </script>
@@ -52,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('bind stamps after page fully loads (despite yielding)', function() {
 
         test('event handled', function() {
-          assert.isTrue(domBind.didFire);
+          assert.isTrue(window.domBind.didFire);
         });
 
       });

--- a/test/unit/dom-bind-yield.html
+++ b/test/unit/dom-bind-yield.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../web-component-tester/browser.js"></script>
+</head>
+<body>
+
+  <link rel="import" href="../../polymer.html">
+
+  <script>
+    if (window.Polymer) {
+      Polymer({
+        is: 'x-fire',
+        ready: function() {
+          this.fire('fired');
+        }
+      })
+    }
+  </script>
+
+  <template is="dom-bind" id="domBind">
+    <x-fire on-fired="fired"></x-fire>
+  </template>
+
+  <script>
+    if (window.Polymer) {
+      var now = Date.now() + 1000;
+      while (Date.now() < now) {}
+    }
+  </script>
+
+  <script>
+    domBind.fired = function() {
+      this.didFire = true;
+    }
+  </script>
+
+  <script>
+
+    if (window.Polymer) {
+
+      suite('bind stamps after page fully loads (despite yielding)', function() {
+
+        test('event handled', function() {
+          assert.isTrue(domBind.didFire);
+        });
+
+      });
+
+    }
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #3484.

This ensures a script can install api on the dom-bind prior to it rendering. Previously dom-bind waited for first render, but an early parser yield can make this occur unexpectedly early.