### PR TITLE
Enabling caching of node_modules on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
     packages:
     - google-chrome-stable
     - g++-4.8
+cache:
+  directories:
+    - node_modules
 before_script:
 - npm install -g bower
 - bower install


### PR DESCRIPTION
This pull request should speed up the building time on Travis, by caching the node_modules. Consecutive builds will check when installing node dependencies with the cache before downloading from the internet. On our project, we sped up our build with 2,5 minutes by enabling caching.

