### PR TITLE
Ensure Annotator recognizes dynamic fn as dependency for parent props.

### DIFF
--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -195,6 +195,9 @@ TODO(sjmiles): this module should produce either syntactic metadata
                   pp[model] = true;
                 }
               }
+              if (p.signature.dynamicFn) {
+                pp[p.signature.method] = true;
+              }
             } else {
               if (p.model) {
                 pp[p.model] = true;

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -685,3 +685,31 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-child-template-with-dynamic-fn">
+  <template>
+    <template is="dom-if" if="[[visible]]">
+      <p>[[translate('text')]]</p>
+    </template>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-child-template-with-dynamic-fn',
+
+      properties: {
+        translate: {
+          type: Function,
+          value: function () {
+            return function(str) {
+              return str;
+            }
+          }
+        },
+        visible: {
+          type: Boolean,
+          value: true
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -388,6 +388,18 @@ suite('computed bindings with dynamic functions', function() {
 
   });
 
+  test('ensure annotator can pass dynamic fn to parent props', function(done) {
+    el = document.createElement('x-child-template-with-dynamic-fn');
+    document.body.appendChild(el);
+
+    setTimeout(function() {
+      var check = Polymer.dom(el.root).querySelector('p');
+      assert.equal(check.textContent, 'text');
+      done();
+    });
+
+  });
+
 });
 
 </script>


### PR DESCRIPTION
The annotator sort of 'copies' all dependencies of a computed annotation from a child template to its host (to populate _parentProps). We forgot to include the `method` as a dependency for 'dynamic'/late bound functions.
  
Fixes #3515 

