### PR TITLE
Don't use `translate` as a method for testing

### DIFF
--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -595,13 +595,13 @@
 
 <dom-module id="x-bind-computed-property">
   <template>
-    <div id="check">[[translate('Hello World.')]]</div>
+    <div id="check">[[translateMessage('Hello World.')]]</div>
   </template>
   <script>
     (function(){
       var TranslateBehavior = {
         properties: {
-          translate: {
+          translateMessage: {
             type: Function,
             computed: '_computeTranslateFn(translator)'
           }
@@ -634,7 +634,7 @@
 
 <dom-module id="x-bind-computed-property-late-translator">
   <template>
-    <div id="check">[[translate(message)]]</div>
+    <div id="check">[[translateMessage(message)]]</div>
   </template>
   <script>
     Polymer({
@@ -644,7 +644,7 @@
           type: String,
           value: 'Hello'
         },
-        translate: {
+        translateMessage: {
           type: Function,
           computed: '_computeTranslateFn(translator)'
         },

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -296,10 +296,6 @@ suite('computed bindings with dynamic functions', function() {
 
   var el;
 
-  setup(function() {
-
-  });
-
   teardown(function() {
     document.body.removeChild(el);
   });
@@ -334,7 +330,7 @@ suite('computed bindings with dynamic functions', function() {
     Polymer({
       is: 'x-observer-with-dynamic-function',
       properties: {
-        translate: {
+        translateMessage: {
           type: Function
         },
         message: {
@@ -343,7 +339,7 @@ suite('computed bindings with dynamic functions', function() {
         }
       },
 
-      observers: ['translate(message)']
+      observers: ['translateMessage(message)']
 
     });
 
@@ -351,7 +347,7 @@ suite('computed bindings with dynamic functions', function() {
     document.body.appendChild(el);
 
     var called = 0;
-    el.translate = function() {
+    el.translateMessage = function() {
       called += 1;
     };
 
@@ -364,9 +360,9 @@ suite('computed bindings with dynamic functions', function() {
       is: 'x-computed-property-with-dynamic-function',
       properties: {
         computedValue: {
-          computed: "translate('Hello')"
+          computed: "translateMessage('Hello')"
         },
-        translate: {
+        translateMessage: {
           type: Function
         }
       }
@@ -378,7 +374,7 @@ suite('computed bindings with dynamic functions', function() {
     assert.equal(el.computedValue, undefined);
 
     var called = 0;
-    el.translate = function(message) {
+    el.translateMessage = function(message) {
       called += 1;
       return 'translated: ' + message;
     };


### PR DESCRIPTION
`.translate` is some magical property in Safari (and Chrome)
Safari 7 puts this on the instance, and breaks tests for property
effects