### PR TITLE
Expose public API to reset mouse cancelling for testing touch

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -231,10 +231,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
           // disable synth mouse events, unless this event is itself simulated
-          if (type === 'touchend' && !ev.__polymerSimulatedTouch) {
+          if (type === 'touchend') {
             POINTERSTATE.mouse.target = Polymer.dom(ev).rootTarget;
             // ignore syntethic mouse events after a touch
-            ignoreMouse(true);
+            ignoreMouse();
           }
         }
       }
@@ -403,6 +403,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var recognizer = this.findRecognizerByEvent(evName);
       if (recognizer.info) {
         recognizer.info.prevent = true;
+      }
+    },
+    /**
+     * Reset the 2500ms timeout on processing mouse input after detecting touch input.
+     *
+     * Touch inputs create synthesized mouse inputs anywhere from 0 to 2000ms after the touch.
+     * This method should only be called during testing with simulated touch inputs.
+     * Calling this method in production may cause duplicate taps or other gestures.
+     *
+     * @method resetMouseCanceller
+     */
+    resetMouseCanceller: function() {
+      if (POINTERSTATE.mouse.mouseIgnoreJob) {
+        POINTERSTATE.mouse.mouseIgnoreJob.complete();
       }
     }
   };

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -256,6 +256,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
       teardown(function() {
         el.parentNode.removeChild(el);
+        Polymer.Gestures.resetMouseCanceller();
       });
 
       test('tap', function() {
@@ -313,7 +314,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ];
         ev.clientX = clientX;
         ev.clientY = clientY;
-        ev.__polymerSimulatedTouch = true;
         child.dispatchEvent(ev);
 
         for (var i = 0; i < 10; i++) {
@@ -330,7 +330,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ev.clientX = clientX;
           ev.clientY = clientY;
           // tell gestures to not turn off mouse events
-          ev.__polymerSimulatedTouch = true;
           child.dispatchEvent(ev);
         }
 


### PR DESCRIPTION
Remove undocument `event.__polymerSyntheticTouch` hack

Fixes #3540