### PR TITLE
Set propertyName on parent props for config phase.

### DIFF
--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -161,10 +161,12 @@ TODO(sjmiles): this module should produce either syntactic metadata
             this._discoverTemplateParentProps(note.templateContent._notes);
           var bindings = [];
           for (var prop in pp) {
+            var name = '_parent_' + prop;
             bindings.push({
               index: note.index,
               kind: 'property',
-              name: '_parent_' + prop,
+              name: name,
+              propertyName: name,
               parts: [{
                 mode: '{',
                 model: prop,

--- a/test/unit/templatizer.html
+++ b/test/unit/templatizer.html
@@ -256,6 +256,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.notOk(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(host), 33));
     });
 
+    test('ensure undefined is not set on templatizee', function() {
+      assert.equal(host.$.templatizee[undefined], undefined);
+    });
+
   });
 
 </script>


### PR DESCRIPTION
Ensure `propertyName` is set by the Annotator even for parent properties. 

The side-effect/bug is that an element when it gets configured via simple `node._configValue(name, value)` the name can be otherwise `undefined`. See configure.html `_distributeConfig()` wherein we do `var name = x.effect.propertyName;`. 