### PR TITLE
Implement linkPath as (custom) property effect.

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -79,7 +79,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _effectEffects: function(property, value, effects, old, fromAbove) {
         for (var i=0, l=effects.length, fx; (i<l) && (fx=effects[i]); i++) {
-          fx.fn.call(this, property, value, fx.effect, old, fromAbove);
+          if (!fx.disabled) {
+            fx.fn.call(this, property, value, fx.effect, old, fromAbove);
+          }
         }
       },
 
@@ -111,7 +113,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var propEffect = {
         kind: kind,
         effect: effect,
-        fn: Polymer.Bind['_' + kind + 'Effect']
+        fn: Polymer.Bind['_' + kind + 'Effect'],
+        trigger: property
       };
       fx.push(propEffect);
       return propEffect;
@@ -129,7 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // effects have priority
           fx.sort(this._sortPropertyEffects);
           // create accessors
-          this._createAccessors(model, n, fx);
+          this._createAccessors(model, n);
         }
       }
       //console.groupEnd();
@@ -157,7 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // create accessors that implement effects
 
-    _createAccessors: function(model, property, effects) {
+    _createAccessors: function(model, property) {
       var defun = {
         get: function() {
           // TODO(sjmiles): elide delegation for performance, good ROI?
@@ -165,6 +168,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       };
       var setter = function(value) {
+        var effects = this._propertyEffects && this._propertyEffects[property];
         this._propertySetter(property, value, effects);
       };
       // ReadOnly properties have a private setter only
@@ -224,7 +228,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // queued events during configuration can theoretically lead to
           // divergence of the passed value from the current value, but we
           // really need to track down a specific case where this happens.
-          value = target[property];
+          value = target.__data__ ? target.__data__[property] : target[property];
 
           if (negated) {
             value = !value;

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -120,7 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       archetype._prepBindings();
 
       // boilerplate code
-      archetype._notifyPathUp = this._notifyPathUpImpl;
+      archetype._notifyPathUp = function() {};
       archetype._scopeElementClass = this._scopeElementClassImpl;
       archetype.listen = this._listenImpl;
       archetype._showHideChildren = this._showHideChildrenImpl;
@@ -193,7 +193,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       for (prop in this._instanceProps) {
         archetype._addPropertyEffect(prop, 'function',
-          this._createInstancePropEffector(prop));
+          this._createInstancePropEffector());
       }
     },
 
@@ -215,13 +215,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       archetype._parentProps = c._parentProps;
     },
 
-    // Sets up accessors on the template to call abstract _forwardParentProp
-    // API that should be implemented by Templatizer users to get parent
-    // properties to their template instances.  These accessors are memoized
-    // on the archetype and copied to instances.
+    // Sets up accessors on the template to call abstract
+    // _forwardParentProp/Path API that should be implemented by Templatizer
+    // users to get parent properties to their template instances.  These
+    // accessors are memoized on the archetype and copied to instances.
     _prepParentProperties: function(archetype, template) {
       var parentProps = this._parentProps = archetype._parentProps;
-      if (this._forwardParentProp && parentProps) {
+      if ((this._forwardParentProp || this._forwardParentPath) &&
+          parentProps) {
         // Prototype setup (memoized on archetype)
         var proto = archetype._parentPropProto;
         var prop;
@@ -229,17 +230,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (prop in this._instanceProps) {
             delete parentProps[prop];
           }
-          proto = archetype._parentPropProto = Object.create(null);
-          if (template != this) {
-            // Assumption: if `this` isn't the template being templatized,
-            // assume that the template is not a Poylmer.Base, so prep it
-            // for binding
-            Polymer.Bind.prepareModel(proto);
-            Polymer.Base.prepareModelNotifyPath(proto);
-          }
-          // Create accessors for each parent prop that forward the property
-          // to template instances through abstract _forwardParentProp API
-          // that should be implemented by Templatizer users
+          // Create accessors for each parent prop that forward the property to
+          // template instances through abstract _forwardParentProp/Path API
+          // that should be implemented by Templatizer users.
+          var propertyEffects = this.mixin({}, this._propertyEffects);
+          var propertyInfo = this.mixin({}, this._propertyInfo);
+          var prefixedParentProps = {};
           for (prop in parentProps) {
             var parentProp = this._parentPropPrefix + prop;
             // TODO(sorvell): remove reference Bind library functions here.
@@ -247,69 +243,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var effects = [{
               kind: 'function',
               effect: this._createForwardPropEffector(prop),
-              fn: Polymer.Bind._functionEffect
+              fn: Polymer.Bind._functionEffect,
+              pathFn: this._functionPathEffect
             }, {
               kind: 'notify',
               fn: Polymer.Bind._notifyEffect,
               effect: {event:
                 Polymer.CaseMap.camelToDashCase(parentProp) + '-changed'}
             }];
-            Polymer.Bind._createAccessors(proto, parentProp, effects);
+            propertyEffects[parentProp] = effects;
+            propertyInfo[parentProp] = {};
+            prefixedParentProps[parentProp] = true;
           }
+          proto = archetype._parentPropProto = {
+            _propertyEffects: propertyEffects,
+            _propertyInfo: propertyInfo,
+            prefixedParentProps: prefixedParentProps
+          };
         }
         // capture this reference for use below
         var self = this;
         // Instance setup
         if (template != this) {
+          Polymer.Bind.prepareModel(template);
+          Polymer.Base.prepareModelNotifyPath(template);
           Polymer.Bind.prepareInstance(template);
-          template._forwardParentProp = function(source, value) {
-            self._forwardParentProp(source, value);
+          if (self._forwardParentProp) {
+            template._forwardParentProp = function(prop, value) {
+              self._forwardParentProp(prop, value);
+            }
+          }
+          if (self._forwardParentPath) {
+            template._forwardParentPath = function(path, value) {
+              self._forwardParentPath(path, value);
+            }
           }
         }
         this._extendTemplate(template, proto);
-        template._pathEffector = function(path, value, fromAbove) {
-          return self._pathEffectorImpl(path, value, fromAbove);
-        }
       }
     },
 
+
     _createForwardPropEffector: function(prop) {
-      return function(source, value) {
-        this._forwardParentProp(prop, value);
+      var prefixLength = this._parentPropPrefix.length;
+      return function(path, value) {
+        if (path.indexOf('.') !== -1) {
+          if (this._forwardParentPath) {
+            var newPath = path.slice(prefixLength);
+            this._forwardParentPath(newPath, value);
+          }
+        } else if (this._forwardParentProp) {
+          this._forwardParentProp(prop, value);
+        }
       };
     },
 
     _createHostPropEffector: function(prop) {
       var prefix = this._parentPropPrefix;
-      return function(source, value) {
-        this.dataHost._templatized[prefix + prop] = value;
-      };
-    },
-
-    _createInstancePropEffector: function(prop) {
-      return function(source, value, old, fromAbove) {
+      var prefixedProp = prefix + prop;
+      return function(path, value, old, fromAbove) {
         if (!fromAbove) {
-          this.dataHost._forwardInstanceProp(this, prop, value);
+          var dataHost = this.dataHost;
+          if (path.indexOf('.') !== -1) {
+            dataHost._templatized._notifyPath(prefix + path, value, false);
+          } else {
+            dataHost._templatized.__setProperty(prefixedProp, value, false);
+          }
         }
       };
     },
 
-    // Similar to Polymer.Base.extend, but retains any previously set instance
-    // values (_propertySetter back on instance once accessor is installed)
-    _extendTemplate: function(template, proto) {
-      var n$ = Object.getOwnPropertyNames(proto);
-      if (proto._propertySetter) {
-        // _propertySetter API may need to be copied onto the template,
-        // and it needs to come first to allow the property swizzle below
-        template._propertySetter = proto._propertySetter;
-      }
-      for (var i=0, n; (i<n$.length) && (n=n$[i]); i++) {
-        var val = template[n];
-        var pd = Object.getOwnPropertyDescriptor(proto, n);
-        Object.defineProperty(template, n, pd);
-        if (val !== undefined) {
-          template._propertySetter(n, val);
+    _createInstancePropEffector: function() {
+      return function(path, value, old, fromAbove) {
+        if (!fromAbove) {
+          if (path.indexOf('.') !== -1) {
+            this.dataHost._forwardInstancePath(this, path, value);
+          } else {
+            this.dataHost._forwardInstanceProp(this, path, value);
+          }
         }
+      };
+    },
+
+    // Extends template with parent property info & effects and seed pre-bound data
+    _extendTemplate: function(template, proto) {
+      template._propertyEffects = proto._propertyEffects;
+      template._propertyInfo = proto._propertyInfo;
+      var prefixedParentProps = proto.prefixedParentProps;
+      for (var p in prefixedParentProps) {
+        var val = template[p];
+        template.__data__[p] = val;
       }
     },
 
@@ -322,31 +345,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // _forwardParentPath: function(path, value) { },
     // _forwardParentProp: function(prop, value) { },
     /* eslint-enable no-unused-vars */
-
-    _notifyPathUpImpl: function(path, value) {
-      var dataHost = this.dataHost;
-      var dot = path.indexOf('.');
-      var root = dot < 0 ? path : path.slice(0, dot);
-      // Call extension point for Templatizer sub-classes
-      dataHost._forwardInstancePath.call(dataHost, this, path, value);
-      if (root in dataHost._parentProps) {
-        dataHost._templatized._notifyPath(dataHost._parentPropPrefix + path, value);
-      }
-    },
-
-    // Overrides Base notify-path module
-    _pathEffectorImpl: function(path, value, fromAbove) {
-      if (this._forwardParentPath) {
-        if (path.indexOf(this._parentPropPrefix) === 0) {
-          var subPath = path.substring(this._parentPropPrefix.length);
-          var model = this._modelForPath(subPath);
-          if (model in this._parentProps) {
-            this._forwardParentPath(subPath, value);
-          }
-        }
-      }
-      Polymer.Base._pathEffector.call(this._templatized, path, value, fromAbove);
-    },
 
     _constructorImpl: function(model, host) {
       this._rootDataHost = host._getRootDataHost();
@@ -425,7 +423,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var templatized = this._templatized;
         for (var prop in this._parentProps) {
           if (model[prop] === undefined) {
-            model[prop] = templatized[this._parentPropPrefix + prop];
+            model[prop] = templatized.__data__[this._parentPropPrefix + prop];
           }
         }
       }

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -35,6 +35,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var prop = Polymer.Bind.addPropertyEffect(this, property, kind, effect);
       // memoize path function for faster lookup.
       prop.pathFn = this['_' + prop.kind + 'PathEffect'];
+      return prop;
+    },
+
+    _ensureOwnEffects: function(property) {
+      // Move the property effects from the prototype to the instance, so
+      // we can mutate them. We use prototypal inheritance here to go cheap.
+      var pE = this._propertyEffects;
+      if (pE) {
+        if (!this.hasOwnProperty('_propertyEffects')) {
+          pE = this._propertyEffects = Polymer.Base.chainObject({}, pE);
+        }
+
+        // Shallow-copy the effects array for this property, to the instance.
+        if (pE[property] && !pE.hasOwnProperty(property)) {
+          pE[property] = pE[property].slice();
+        }
+      }
+    },
+
+    addPropertyEffect: function(property, fn) {
+      this._ensureOwnEffects(property);
+
+      // We have to create the underlying trigger machinery here, if this is
+      // the first effect of the property.
+      var effects = Polymer.Bind.ensurePropertyEffects(this, property);
+      if (effects.length === 0) {
+        // The current value will be masked by the descriptor, read it ...
+        var val = this[property];
+        Polymer.Bind._createAccessors(this, property);
+        // ... and put it in our data store
+        this.__data__[property] = val;
+      }
+
+      // Theoretically the effects must be sorted again, but `function`-effects
+      // are executed last anyway, so we can skip this for now. NOTE that, if
+      // you add a custom effect inside another effect, t.i. the notification-
+      // loop is already running, mutating the effects in place like we do here
+      // would be usually catastrophic. This 'just' works b/c we prestore the
+      // loop-length in our for-loops (see `effectEffects`). Note as well that
+      // the  newly added effect will not be executed before the next
+      // notification we have to propagate. This is intended and a bonus point
+      // for appending only.
+      return this._addPropertyEffect(property, 'function', fn);
+    },
+
+    removePropertyEffect: function(fx) {
+      // Since effects can be removed as a side-effect, t.i. within a running
+      // effects-loop, we must ensure not to shorten the effects-array in
+      // place, otherwise the for-loop would break. On the other side removing
+      // an effect must be immediate, so we use a flag here to indicate that
+      // this effect should be skipped.
+      fx.disabled = true;
+
+      // We then slice and splice and reassign the effects-array. This new
+      // array will be used not before the next notification we have to
+      // propagate.
+      var property = fx.trigger;
+      var effects = property && this._propertyEffects &&
+                    this._propertyEffects[property];
+      if (effects) {
+        var index = effects.indexOf(fx);
+        if (index !== -1) {
+          effects = effects.slice();
+          effects.splice(index, 1);
+          this._propertyEffects[property] = effects;
+        }
+      }
     },
 
     // prototyping

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -283,10 +283,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
         }
-        // notify runtime-bound paths
-        if (this._boundPaths) {
-          this._notifyBoundPaths(path, value);
-        }
       },
 
       _annotationPathEffect: function(path, value, effect) {
@@ -344,14 +340,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       linkPaths: function(to, from) {
         this._boundPaths = this._boundPaths || {};
+
         if (from) {
-          this._boundPaths[to] = from;
+          this._boundPaths[to] = this._addLinkPathEffect(to, from);
           // this.set(to, this._get(from));
         } else {
           this.unlinkPaths(to);
           // this.set(to, from);
         }
       },
+
+      _addLinkPathEffect: function(to, from) {
+        var locked = false;
+        var makeLinkPathEffect = function(thisPath, thatPath) {
+          return function(path, value) {
+            if (locked) return;
+            // We only forward deep property changes, deeper than `thisPath`.
+            // Shouldn't we open this up?
+            if (path.indexOf(thisPath + '.') !== 0) return;
+
+            locked = true;
+            var newPath = this._fixPath(thatPath, thisPath, path)
+            try {
+              // Don't pass fromAbove et.al., we forward a notification as if
+              // it came from `this`, not from above or down under.
+              this._notifyPath(newPath, value);
+            } finally {
+              locked = false;
+            }
+          };
+        };
+
+        return [
+          this.addPropertyEffect(this._modelForPath(to),
+                                 makeLinkPathEffect(to, from)),
+          this.addPropertyEffect(this._modelForPath(from),
+                                 makeLinkPathEffect(from, to))
+        ];
+      },
+
 
       /**
        * Removes a data path alias previously established with `linkPaths`.
@@ -363,19 +390,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} path Target path to unlink.
        */
       unlinkPaths: function(path) {
-        if (this._boundPaths) {
-          delete this._boundPaths[path];
-        }
-      },
-
-      _notifyBoundPaths: function(path, value) {
-        for (var a in this._boundPaths) {
-          var b = this._boundPaths[a];
-          if (path.indexOf(a + '.') == 0) {
-            this._notifyPath(this._fixPath(b, a, path), value);
-          } else if (path.indexOf(b + '.') == 0) {
-            this._notifyPath(this._fixPath(a, b, path), value);
+        var fx = this._boundPaths && this._boundPaths[path];
+        if (fx) {
+          for (var i=0, l=fx.length; i<l; i++) {
+            this.removePropertyEffect(fx[i]);
           }
+          this._boundPaths[path] = undefined;
         }
       },
 

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // console.group((this.localName || this.dataHost.id + '-' + this.dataHost.dataHost.index) + '#' + (this.id || this.index) + ' ' + path, value);
           // Take path effects at this level for exact path matches,
           // and notify down for any bindings to a subset of this path
-          this._pathEffector(path, value);
+          this._pathEffector(path, value, fromAbove);
           // Send event to notify the path change upwards
           // Optimization: don't notify up if we know the notification
           // is coming from above already (avoid wasted event dispatch)
@@ -267,17 +267,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return prop;
       },
 
-      _pathEffector: function(path, value) {
+      _pathEffector: function(path, value, fromAbove) {
         // get root property
         var model = this._modelForPath(path);
         // search property effects of the root property for 'annotation' effects
         var fx$ = this._propertyEffects && this._propertyEffects[model];
         if (fx$) {
           for (var i=0, fx; (i<fx$.length) && (fx=fx$[i]); i++) {
-            // use memoized path functions
-            var fxFn = fx.pathFn;
-            if (fxFn) {
-              fxFn.call(this, path, value, fx.effect);
+            if (!fx.disabled) {
+              // use memoized path functions
+              var fxFn = fx.pathFn;
+              if (fxFn) {
+                fxFn.call(this, path, value, fx.effect, fromAbove);
+              }
             }
           }
         }
@@ -318,6 +320,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this._pathMatchesEffect(path, effect)) {
           Polymer.Bind._annotatedComputationEffect.call(this, path, value, effect);
         }
+      },
+
+      _functionPathEffect: function(path, value, effect, fromAbove) {
+        Polymer.Bind._functionEffect.call(this, path, value, effect,
+                                          undefined, fromAbove);
       },
 
       _pathMatchesEffect: function(path, effect) {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -713,3 +713,7 @@
     });
   </script>
 </dom-module>
+
+<script>
+  Polymer({is: 'x-custom-effect'});
+</script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -1023,6 +1023,149 @@ suite('order of effects', function() {
   });
 });
 
+suite('custom user effects', function() {
+
+  test('Add custom effect', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(path, 'foo');
+      assert.equal(value, 'bar');
+      assert.equal(old, undefined);
+    });
+
+    el.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Remove custom effect', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var fx = el.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    el.removePropertyEffect(fx);
+
+    el.foo = 'bar';
+    assert.equal(called, 0);
+  });
+
+  test('Ensure old values are sent', function() {
+    var el = document.createElement('x-custom-effect');
+    el.foo = 'bar';
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(old, 'bar');
+    });
+
+    el.foo = 'quux';
+    assert.equal(called, 1);
+  });
+
+  test('Ensure path effects can be seen', function() {
+    var el = document.createElement('x-custom-effect');
+    el.foo = {bar: 'quux'};
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(path, 'foo.bar');
+      assert.equal(value, 'quod');
+      assert.equal(old, undefined);  // always undefined for structured paths!
+    });
+
+    el.set('foo.bar', 'quod');
+    assert.equal(called, 1);
+  });
+
+  test('Ensure independence', function() {
+    var el1 = document.createElement('x-custom-effect');
+    var called = 0;
+    el1.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    var el2 = document.createElement('x-custom-effect');
+
+    el2.foo = 'bar';
+    assert.equal(called, 0);
+  });
+
+  test('Ensure independence (property effects already created on prototype)',
+       function() {
+    Polymer({
+      is: 'x-custom-effect2',
+      properties: {
+        foo: {
+          observer: '_foo'
+        }
+      },
+      _foo: function(){}
+    });
+    var el1 = document.createElement('x-custom-effect2');
+
+    var called = 0;
+    el1.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+    el1.foo = 'bar';
+    assert.equal(called, 1);
+
+    var el2 = document.createElement('x-custom-effect2');
+    el2.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Removing an effect as a side-effect does not break the running ' +
+       'effect loop', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var fx = el.addPropertyEffect('foo', function() {
+      el.removePropertyEffect(fx);
+    });
+    el.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    el.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Adding an effect as a side-effect does not invoke it immediately',
+       function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var firstRun = true;
+    el.addPropertyEffect('foo', function() {
+      if (firstRun) {
+        el.addPropertyEffect('foo', function() {
+          called += 1;
+        });
+        firstRun = false;
+      }
+    });
+
+    el.foo = 'bar';
+    assert.equal(firstRun, false);
+    assert.equal(called, 0);
+
+    el.foo = 'quod';
+    assert.equal(called, 1);
+
+
+  });
+
+
+});
+
 </script>
 
 </body>


### PR DESCRIPTION
Based on top of #3460. Only https://github.com/Polymer/polymer/pull/3547/commits/644e290f65ccc37f7c4d52bba77037350c0c39f8 is of any interest here. 

If you open function effects to receive (deep) path notifications, you can build `linkPaths` on top of this. This implementation does not rely on dirty checking of values, and thus does not dead loop if we remove them. 
