### PR TITLE
Upwards notifications should not echo downwards

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -223,7 +223,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _notedListenerFactory: function(property, path, isStructured, negated) {
       return function(target, value, targetPath) {
         if (targetPath) {
-          this._notifyPath(this._fixPath(path, property, targetPath), value);
+          var newPath = this._fixPath(path, property, targetPath);
+          this._notifyPath(newPath, value, false, target, property);
         } else {
           // TODO(sorvell): even though we have a `value` argument, we *must*
           // lookup the current value of the property. Multiple listeners and

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -244,10 +244,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                                  target, property);
             }
           } else {
-            // TODO(kschaaf): dirty check avoids null references when the object has gone away
-            if (this.__data__[path] != value) {
-              this.set(path, value, undefined, false, target, property);
-            }
+            this.set(path, value, undefined, false, target, property);
           }
         }
       };

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -244,7 +244,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                                  target, property);
             }
           } else {
-            this.set(path, value, undefined, false, target, property);
+            this.set(path, value, false, target, property);
           }
         }
       };

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -42,7 +42,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Called from accessors, where effects is pre-stored
       // in the closure for the accessor for efficiency
-      _propertySetter: function(property, value, effects, fromAbove) {
+      _propertySetter: function(property, value, effects, fromAbove,
+                                origin, originalProperty) {
         var old = this.__data__[property];
         // NaN is always not equal to itself,
         // if old and value are both NaN we treat them as equal
@@ -56,7 +57,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._propertyChanged(property, value, old);
           }
           if (effects) {
-            this._effectEffects(property, value, effects, old, fromAbove);
+            this._effectEffects(property, value, effects, old, fromAbove,
+                                origin, originalProperty);
           }
         }
         return old;
@@ -67,19 +69,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // TODO(kschaaf): downward bindings (e.g. _applyEffectValue) should also
       // use non-notifying setters but right now that would require looking
       // up readOnly property config in the hot-path
-      __setProperty: function(property, value, quiet, node) {
+      __setProperty: function(property, value, quiet, node,
+                              origin, originalProperty) {
         node = node || this;
         var effects = node._propertyEffects && node._propertyEffects[property];
         if (effects) {
-          node._propertySetter(property, value, effects, quiet);
+          node._propertySetter(property, value, effects, quiet,
+                               origin, originalProperty);
         } else {
           node[property] = value;
         }
       },
 
-      _effectEffects: function(property, value, effects, old, fromAbove) {
+      _effectEffects: function(property, value, effects, old, fromAbove,
+                               origin, originalProperty) {
         for (var i=0, l=effects.length, fx; (i<l) && (fx=effects[i]); i++) {
-          fx.fn.call(this, property, value, fx.effect, old, fromAbove);
+          fx.fn.call(this, property, value, fx.effect, old, fromAbove,
+                     origin, originalProperty);
         }
       },
 
@@ -231,7 +237,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
 
           if (!isStructured) {
-            this[path] = value;
+            var pinfo = this._propertyInfo && this._propertyInfo[path];
+            if (!pinfo || !pinfo.readOnly) {
+              this.__setProperty(path, value, false, undefined,
+                                 target, property);
+            }
           } else {
             // TODO(kschaaf): dirty check avoids null references when the object has gone away
             if (this.__data__[path] != value) {

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -199,8 +199,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!model._bindListeners) {
         model._bindListeners = [];
       }
-      var fn = this._notedListenerFactory(property, path,
-        this._isStructured(path), negated);
+      var fn = this._notedListenerFactory(property, path, negated);
       var eventName = event ||
         (Polymer.CaseMap.camelToDashCase(property) + '-changed');
       model._bindListeners.push({
@@ -220,7 +219,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return e.path && e.path[0] !== target;
     },
 
-    _notedListenerFactory: function(property, path, isStructured, negated) {
+    _notedListenerFactory: function(property, path, negated) {
+      var isStructured = this._isStructured(path);
       return function(target, value, targetPath) {
         if (targetPath) {
           var newPath = this._fixPath(path, property, targetPath);

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -245,7 +245,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } else {
             // TODO(kschaaf): dirty check avoids null references when the object has gone away
             if (this.__data__[path] != value) {
-              this.set(path, value);
+              this.set(path, value, undefined, false, target, property);
             }
           }
         }

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -20,10 +20,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
              effect.parts[0].mode === '{';
     },
 
-    _annotationEffect: function(source, value, effect) {
-      if (source != effect.value) {
-        value = this._get(effect.value);
-        this.__data__[effect.value] = value;
+
+    _annotationEffect: function(source, value, effect, old, fromAbove,
+                                origin, originalProperty) {
+
+      // Consider:
+      // <that-node that-property="{{ thisPath }}" />
+      var thatNode = this._nodes[effect.index];
+      var thatProperty = effect.name;
+      var thisPath = effect.value;
+
+      // Do not propagate downwards if the origin of this change is this exact
+      // binding
+      if (origin && originalProperty &&
+          origin === thatNode &&
+          originalProperty === thatProperty) {
+        return;
+      }
+
+      if (source != thisPath) {
+        value = this._get(thisPath);
+        this.__data__[thisPath] = value;
       }
       this._applyEffectValue(effect, value);
     },

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value = this._get(thisPath);
         this.__data__[thisPath] = value;
       }
-      this._applyEffectValue(effect, value);
+      this._applyEffectValue(thatNode, thatProperty, value, effect);
     },
 
     _reflectEffect: function(source, value, effect) {
@@ -111,8 +111,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (fn) {
         var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
         if (args) {
+          var node = this._nodes[effect.index];
+          var property = effect.name;
           var computedvalue = fn.apply(computedHost, args);
-          this._applyEffectValue(effect, computedvalue);
+          this._applyEffectValue(node, property, computedvalue, effect);
         }
       } else if (effect.dynamicFn) {
         // dynamic functions can be just like every other property `undefined`

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -319,10 +319,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _applyEffectValue: function(info, value) {
-      var node = this._nodes[info.index];
-      var property = info.name;
-
+    _applyEffectValue: function(node, property, value, info) {
       value = this._computeFinalAnnotationValue(node, property, value, info);
 
       // For better interop, dirty check before setting when custom events

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -150,12 +150,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {*} value Value to set at the specified path.
        * @param {Object=} root Root object from which the path is evaluated.
       */
-      set: function(path, value, root, fromAbove, origin, originalProperty) {
-        var prop = root || this;
+      set: function(path, value, fromAbove, origin, originalProperty) {
         var parts = this._getPathParts(path);
-        var array;
-        var last = parts[parts.length-1];
         if (parts.length > 1) {
+          var prop = this;
+          var array;
+          var last = parts[parts.length-1];
           // Loop over path parts[0..n-2] and dereference
           for (var i=0; i<parts.length-1; i++) {
             var part = parts[i];
@@ -202,10 +202,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Set value to object at end of path
           prop[last] = value;
           // Notify observers of path change
-          if (!root) {
-            this._notifyPath(parts.join('.'), value, fromAbove,
-                             origin, originalProperty);
-          }
+          this._notifyPath(parts.join('.'), value, fromAbove,
+                           origin, originalProperty);
         } else {
           this.__setProperty(path, value, undefined, fromAbove,
                              origin, originalProperty)

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       // Note: this implemetation only accepts key-based array paths
-      _notifyPath: function(path, value, fromAbove) {
+      _notifyPath: function(path, value, fromAbove, origin, originalProperty) {
         var old = this._propertySetter(path, value);
         // manual dirty checking for now...
         // NaN is always not equal to itself,
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // console.group((this.localName || this.dataHost.id + '-' + this.dataHost.dataHost.index) + '#' + (this.id || this.index) + ' ' + path, value);
           // Take path effects at this level for exact path matches,
           // and notify down for any bindings to a subset of this path
-          this._pathEffector(path, value);
+          this._pathEffector(path, value, fromAbove, origin, originalProperty);
           // Send event to notify the path change upwards
           // Optimization: don't notify up if we know the notification
           // is coming from above already (avoid wasted event dispatch)
@@ -150,7 +150,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {*} value Value to set at the specified path.
        * @param {Object=} root Root object from which the path is evaluated.
       */
-      set: function(path, value, root) {
+      set: function(path, value, root, fromAbove, origin, originalProperty) {
         var prop = root || this;
         var parts = this._getPathParts(path);
         var array;
@@ -203,7 +203,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           prop[last] = value;
           // Notify observers of path change
           if (!root) {
-            this._notifyPath(parts.join('.'), value);
+            this._notifyPath(parts.join('.'), value, fromAbove,
+                             origin, originalProperty);
           }
         } else {
           // Simple property set
@@ -267,7 +268,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return prop;
       },
 
-      _pathEffector: function(path, value) {
+      _pathEffector: function(path, value, fromAbove, origin, originalProperty) {
         // get root property
         var model = this._modelForPath(path);
         // search property effects of the root property for 'annotation' effects
@@ -277,7 +278,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // use memoized path functions
             var fxFn = fx.pathFn;
             if (fxFn) {
-              fxFn.call(this, path, value, fx.effect);
+              fxFn.call(this, path, value, fx.effect, fromAbove,
+                        origin, originalProperty);
             }
           }
         }
@@ -287,17 +289,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      _annotationPathEffect: function(path, value, effect) {
-        if (effect.value === path || effect.value.indexOf(path + '.') === 0) {
+      _annotationPathEffect: function(path, value, effect, fromAbove,
+                                      origin, originalProperty) {
+
+        // Consider:
+        // <that-node that-property="{{ thisPath }}" />
+        var thatNode = this._nodes[effect.index];
+        var thatProperty = effect.name;
+        var thisPath = effect.value;
+
+        // Do not propagate downwards if the origin of this change is this
+        // exact binding
+        if (origin && originalProperty &&
+            origin === thatNode &&
+            originalProperty === thatProperty) {
+          return;
+        }
+
+        if (thisPath === path || thisPath.indexOf(path + '.') === 0) {
           // TODO(sorvell): ideally the effect function is on this prototype
           // so we don't have to call it like this.
           Polymer.Bind._annotationEffect.call(this, path, value, effect);
-        } else if ((path.indexOf(effect.value + '.') === 0) && !effect.negate) {
-          // locate the bound node
-          var node = this._nodes[effect.index];
-          if (node && node._notifyPath) {
-            var p = this._fixPath(effect.name , effect.value, path);
-            node._notifyPath(p, value, true);
+        } else if ((path.indexOf(thisPath + '.') === 0) && !effect.negate) {
+          if (thatNode && thatNode._notifyPath) {
+            var newPath = this._fixPath(thatProperty, thisPath, path);
+            thatNode._notifyPath(newPath, value, true);
           }
         }
       },

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -207,8 +207,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                              origin, originalProperty);
           }
         } else {
-          // Simple property set
-          prop[path] = value;
+          this.__setProperty(path, value, undefined, fromAbove,
+                             origin, originalProperty)
         }
       },
 

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -713,3 +713,29 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-downwards-notification-does-not-echo">
+  <template>
+    <x-sender id="sender1" binding="{{foo}}"></x-sender>
+    <x-sender id="sender2" binding="{{foo.bar}}"></x-sender>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'x-downwards-notification-does-not-echo',
+      properties: {
+        foo: String
+      }
+    });
+
+    Polymer({
+      is: 'x-sender',
+      properties: {
+        binding: {
+          type: String,
+          notify: true
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -1023,6 +1023,85 @@ suite('order of effects', function() {
   });
 });
 
+suite('notifications do not echo', function() {
+
+  test('upwards notification does not echo downwards (simple binding)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender1;
+
+    var called = 0;
+    sender._propertySetter = function() {
+      called += 1;
+    };
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.foo = 'quux';
+    assert.equal(called, 1);
+
+    // We can't use simple property assignment b/c we mocked that method
+    // above, so we do it manually
+    sender.__data__['binding'] = 'bar';
+    sender._notifyChange('binding');
+
+    assert.equal(el.foo, 'bar');
+    assert.equal(called, 1);
+  });
+
+  test('upwards notification does not echo downwards (deep binding)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender2;
+
+    var called = 0;
+    sender._propertySetter = function() {
+      called += 1;
+    };
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.foo = {bar: 'quux'};
+    assert.equal(called, 1);
+
+    // We can't use simple property assignment b/c we mocked that method
+    // above, so we do it manually
+    sender.__data__['binding'] = 'quod';
+    sender._notifyChange('binding');
+
+    assert.deepEqual(el.foo, {bar: 'quod'});
+    assert.equal(called, 1);
+  });
+
+  test('upwards notification does not echo downwards (path notification)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender2;
+
+    var called = 0;
+    sender._notifyPath = function() {
+      called += 1;
+    };
+
+    // Ensure that the object at foo is completely shared between both
+    // instances
+    sender.__data__['binding'] = {baz: 'quux'};
+    el.foo = {bar: sender.__data__['binding']};
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.set('foo.bar.baz', 'quod');
+    assert.equal(called, 1);
+    // Ensure object is shared data
+    assert.equal(sender.binding.baz, 'quod');
+
+    // We can't use set b/c we mocked _notifyPath
+    sender.binding.baz = 'anil';
+    sender._notifyPathUp('binding.baz', 'anil');
+
+    assert.deepEqual(el.foo, {bar: {baz: 'anil'}});
+    assert.equal(called, 1);
+  });
+
+});
+
 </script>
 
 </body>


### PR DESCRIPTION
Pretty much what `fromAbove` is during downwards data flow, for upwards data propagation. 

Ensures that data that flows up (via DOM events) doesn't come back through the same binding (triggered by annotation effects). 

Should be read commit by commit b/c there is a lot of noise passing the target/origin from the event listener through the whole system down to the annotation effect. The essential code excerpt is: 

```
+
+    _annotationEffect: function(source, value, effect, old, fromAbove,
+                                origin, originalProperty) {
+
+      // Consider:
+      // <that-node that-property="{{ thisPath }}" />
+      var thatNode = this._nodes[effect.index];
+      var thatProperty = effect.name;
+      var thisPath = effect.value;
+
+      // Do not propagate downwards if the origin of this change is this exact
+      // binding
+      if (origin && originalProperty &&
+          origin === thatNode &&
+          originalProperty === thatProperty) {
+        return;
+      }
+
```

:cake: 
