### PR TITLE
Support array path format for linkPaths() and unlinkPaths()

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -332,13 +332,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * are routed to the other.
        *
        * @method linkPaths
-       * @param {string} to Target path to link.
-       * @param {string} from Source path to link.
+       * @param {(string|Array<(string|number)>)} to Target path to link.  The
+       *   path may be specified as a string (e.g. `foo.bar.baz`) or an array of
+       *   path parts (e.g. `['foo.bar', 'baz']`).
+       * @param {(string|Array<(string|number)>)} from Source path to link.  The
+       *   path may be specified as a string (e.g. `foo.bar.baz`) or an array of
+       *   path parts (e.g. `['foo.bar', 'baz']`).
        */
       linkPaths: function(to, from) {
         this._boundPaths = this._boundPaths || {};
         if (from) {
-          this._boundPaths[to] = from;
+          var toInfo = {};
+          var fromInfo = {};
+          this._get(to, this, toInfo);
+          this._get(from, this, fromInfo);
+          this._boundPaths[toInfo.path] = fromInfo.path;
           // this.set(to, this._get(from));
         } else {
           this.unlinkPaths(to);
@@ -353,11 +361,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * linking the paths.
        *
        * @method unlinkPaths
-       * @param {string} path Target path to unlink.
+       * @param {(string|Array<(string|number)>)} path Target path to unlink.
+       *   The path may be specified as a string (e.g. `foo.bar.baz`) or an
+       *   array of path parts (e.g. `['foo.bar', 'baz']`).
        */
       unlinkPaths: function(path) {
         if (this._boundPaths) {
-          delete this._boundPaths[path];
+          var info = {};
+          this._get(path, this, info);
+          delete this._boundPaths[info.path];
         }
       },
 

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -909,6 +909,41 @@ suite('path API', function() {
     assert.equal(cChanged, 4);
   });
 
+  test('link nested paths', function() {
+    var aChanged = 0;
+    var bChanged = 0;
+    el.a = el.b = { arr: [{ nested: 'no-change' }] };
+    el.linkPaths(['b', 'arr', 0], ['a', 'arr', 0]);
+    el.aChanged = function() { aChanged++; };
+    el.bChanged = function() { bChanged++; };
+    // All array-paths (for link/unlink)
+    el.set(['a', 'arr', 0, 'nested'], 'changed-first');
+    assert.equal(aChanged, 1);
+    assert.equal(bChanged, 1);
+    el.unlinkPaths(['b', 'arr', 0]);
+    el.set(['a', 'arr', 0, 'nested'], 'changed-second');
+    assert.equal(aChanged, 2);
+    assert.equal(bChanged, 1);
+    // All string-paths
+    el.linkPaths('b.arr.0', 'a.arr.0');
+    el.set(['a', 'arr', 0, 'nested'], 'changed-third');
+    assert.equal(aChanged, 3);
+    assert.equal(bChanged, 2);
+    el.unlinkPaths('b.arr.0');
+    el.set(['a', 'arr', 0, 'nested'], 'changed-fourth');
+    assert.equal(aChanged, 4);
+    assert.equal(bChanged, 2);
+    // Mixed array- and string-paths
+    el.linkPaths(['b', 'arr', 0], ['a', 'arr', 0]);
+    el.set(['a', 'arr', 0, 'nested'], 'changed-fifth');
+    assert.equal(aChanged, 5);
+    assert.equal(bChanged, 3);
+    el.unlinkPaths('b.arr.0');
+    el.set(['a', 'arr', 0, 'nested'], 'changed-sixth');
+    assert.equal(aChanged, 6);
+    assert.equal(bChanged, 3);
+  });
+
   test('get from path in deep observer', function() {
     el.arrayChanged = nop;
     var array = [1, 2, 3];


### PR DESCRIPTION
Fixes #3090

Now `linkPaths()` and `unlinkPaths()` support array-formatted paths in addition to string-formatted paths.  Docs and tests have been updated to reflect this.
