### PR TITLE
Implement initialization guard for computed expressions

### DIFF
--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -125,12 +125,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var values = [];
       var args = effect.args;
 
-      var bailoutEarly;
-      if (Polymer.Bind.expressionDidEvaluateOnce(this, effect)) {
-        bailoutEarly = false;
-      } else {
-        bailoutEarly = (args.length > 1 || effect.dynamicFn);
-      }
+      var bailoutEarly = !Polymer.Bind.expressionDidEvaluateOnce(this, effect);
 
       for (var i=0, l=args.length; i<l; i++) {
         var arg = args[i];

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -62,7 +62,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _complexObserverEffect: function(source, value, effect) {
       var fn = this[effect.method];
       if (fn) {
-        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
+        var args = Polymer.Bind._marshalArgs.call(this, this.__data__,
+                                                  effect, source, value);
         if (args) {
           fn.apply(this, args);
         }
@@ -79,7 +80,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _computeEffect: function(source, value, effect) {
       var fn = this[effect.method];
       if (fn) {
-        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
+        var args = Polymer.Bind._marshalArgs.call(this, this.__data__,
+                                                  effect, source, value);
         if (args) {
           var computedvalue = fn.apply(this, args);
           this.__setProperty(effect.name, computedvalue);
@@ -98,7 +100,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var computedHost = this._rootDataHost || this;
       var fn = computedHost[effect.method];
       if (fn) {
-        var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
+        var args = Polymer.Bind._marshalArgs.call(computedHost, this.__data__,
+                                                  effect, source, value);
         if (args) {
           var computedvalue = fn.apply(computedHost, args);
           if (effect.negate) {
@@ -121,9 +124,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _marshalArgs: function(model, effect, path, value) {
       var values = [];
       var args = effect.args;
-      // Actually we should return early as soon as we see an `undefined`,
-      // but dom-repeat relies on this behavior.
-      var bailoutEarly = (args.length > 1 || effect.dynamicFn);
+
+      var bailoutEarly;
+      if (Polymer.Bind.expressionDidEvaluateOnce(this, effect)) {
+        bailoutEarly = false;
+      } else {
+        bailoutEarly = (args.length > 1 || effect.dynamicFn);
+      }
+
       for (var i=0, l=args.length; i<l; i++) {
         var arg = args[i];
         var name = arg.name;
@@ -152,7 +160,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           values[i] = v;
         }
       }
+      if (bailoutEarly) {
+        Polymer.Bind.markExpressionAsDidRun(this, effect);
+      }
       return values;
+    },
+
+    expressionDidEvaluateOnce: function(model, effect) {
+      return (model.__readyExpressions &&
+              model.__readyExpressions[effect.expression]);
+    },
+
+    markExpressionAsDidRun: function(model, effect) {
+      var store = model.__readyExpressions;
+      if (!store) {
+        store = model.__readyExpressions = {};
+      }
+      var expression = effect.expression;
+      if (!store[expression]) {
+        store[expression] = true;
+      }
     }
 
   });

--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -151,6 +151,7 @@ TODO(sjmiles): this module should produce either syntactic metadata
               } else {
                 p.model = this._modelForPath(p.value);
               }
+              p.expression = p.value;
             }
           }
         }

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -93,7 +93,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           args: sig.args,
           trigger: arg,
           name: name,
-          dynamicFn: dynamicFn
+          dynamicFn: dynamicFn,
+          expression: expression
         });
       }
       if (dynamicFn) {
@@ -102,7 +103,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           args: sig.args,
           trigger: null,
           name: name,
-          dynamicFn: dynamicFn
+          dynamicFn: dynamicFn,
+          expression: expression
         });
       }
     },
@@ -136,7 +138,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           method: sig.method,
           args: sig.args,
           trigger: arg,
-          dynamicFn: dynamicFn
+          dynamicFn: dynamicFn,
+          expression: observer
         });
       }
       if (dynamicFn) {
@@ -144,7 +147,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           method: sig.method,
           args: sig.args,
           trigger: null,
-          dynamicFn: dynamicFn
+          dynamicFn: dynamicFn,
+          expression: observer
         });
       }
     },
@@ -226,7 +230,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         method: part.signature.method,
         args: part.signature.args,
         trigger: trigger,
-        dynamicFn: part.signature.dynamicFn
+        dynamicFn: part.signature.dynamicFn,
+        expression: part.expression
       });
     },
 

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -713,3 +713,27 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-init-expressions">
+  <template>
+  <div annotation="[[annotation(e, f)]]"></div>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-init-expressions',
+    properties: {
+      foo: {
+        computed: 'computed(c, d)'
+      }
+    },
+
+    observers: ['observer(a, b)'],
+
+    created: function() {
+      this.observer = sinon.spy();
+      this.computed = sinon.spy();
+      this.annotation = sinon.spy();
+    }
+  });
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -1025,5 +1025,56 @@ suite('order of effects', function() {
 
 </script>
 
+<script>
+
+  suite('Initialization of computational expressions', function() {
+
+    test('observers receive undefineds after initialization', function() {
+      var el = document.createElement('x-init-expressions');
+
+      el.a = 'val1';
+      assert.equal(el.observer.callCount, 0);
+
+      el.b = 'val2';
+      assert.equal(el.observer.callCount, 1);
+      assert.isTrue(el.observer.getCall(0).calledWith('val1', 'val2'));
+
+      el.a = undefined;
+      assert.equal(el.observer.callCount, 2);
+      assert.isTrue(el.observer.getCall(1).calledWith(undefined, 'val2'));
+    });
+
+    test('computed property sees undefineds after initialization', function() {
+      var el = document.createElement('x-init-expressions');
+
+      el.c = 'val1';
+      assert.equal(el.computed.callCount, 0);
+      el.d = 'val2';
+      assert.equal(el.computed.callCount, 1);
+      assert.isTrue(el.computed.getCall(0).calledWith('val1', 'val2'));
+
+      el.c = undefined;
+      assert.equal(el.computed.callCount, 2);
+      assert.isTrue(el.computed.getCall(1).calledWith(undefined, 'val2'));
+    });
+
+    test('computed annotation sees undefineds after initialization',
+         function() {
+      var el = document.createElement('x-init-expressions');
+
+      el.e = 'val1';
+      assert.equal(el.annotation.callCount, 0);
+      el.f = 'val2';
+      assert.equal(el.annotation.callCount, 1);
+      assert.isTrue(el.annotation.getCall(0).calledWith('val1', 'val2'));
+
+      el.e = undefined;
+      assert.equal(el.annotation.callCount, 2);
+      assert.isTrue(el.annotation.getCall(1).calledWith(undefined, 'val2'));
+    });
+
+  });
+</script>
+
 </body>
 </html>

--- a/test/unit/notify-path-elements.html
+++ b/test/unit/notify-path-elements.html
@@ -198,6 +198,7 @@
         assert.equal(c, this.nested.obj.c, 'multiplePathsChanged `c` arg incorrect');
       },
       arrayChanged: function(splices) {
+        assert.notEqual(splices, undefined);
         this.observerCounts.arrayChanged++;
         if (this.array.length) {
           assert.equal(splices.indexSplices.length, 1,
@@ -212,6 +213,7 @@
       },
       arrayChangedDeep: function() { },
       arrayNoCollChanged: function(splices) {
+        assert.notEqual(splices, undefined);
         this.observerCounts.arrayNoCollChanged++;
         if (this.arrayNoColl.length) {
           assert.equal(splices.indexSplices.length, 1,

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -348,12 +348,12 @@ suite('path effects', function() {
 
   test('array.splices notified (no Collection)', function() {
     el.arrayNoColl = [];
-    assert.equal(el.observerCounts.arrayNoCollChanged, 1);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 0);
     el.push('arrayNoColl', 1, 2, 3);
-    assert.equal(el.observerCounts.arrayNoCollChanged, 2);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 1);
     assert.equal(Polymer.Collection.get(el.arrayNoColl).getKeys().length, 3);
     el.push('arrayNoColl', 4, 5, 6);
-    assert.equal(el.observerCounts.arrayNoCollChanged, 3);
+    assert.equal(el.observerCounts.arrayNoCollChanged, 2);
     assert.equal(Polymer.Collection.get(el.arrayNoColl).getKeys().length, 6);
   });
 
@@ -361,12 +361,12 @@ suite('path effects', function() {
     el.array = [];
     // Ensure keySplices are generated for test purposes
     Polymer.Collection.get(el.array);
-    assert.equal(el.observerCounts.arrayChanged, 1);
+    assert.equal(el.observerCounts.arrayChanged, 0);
     el.push('array', 1, 2, 3);
-    assert.equal(el.observerCounts.arrayChanged, 2);
+    assert.equal(el.observerCounts.arrayChanged, 1);
     assert.equal(Polymer.Collection.get(el.array).getKeys().length, 3);
     el.push('array', 4, 5, 6);
-    assert.equal(el.observerCounts.arrayChanged, 3);
+    assert.equal(el.observerCounts.arrayChanged, 2);
     assert.equal(Polymer.Collection.get(el.array).getKeys().length, 6);
   });
 


### PR DESCRIPTION
This implements the initialization guard for all computed expressions (like multi observers etc.) as stated in the docs. T.i. we ensure that observers (et.al.) don't get called with undefineds _initially_, but if they did run **once**, they will see undefined values just like any other value.

The second commit fixes the bug that `*.splices` observers did fire with undefined initially. 

Fixes #2158, fixes #3239, fixes #3401.
