### PR TITLE
Prevent tap from firing after a 300ms long touch.

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -19,6 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   var GESTURE_KEY = '__polymerGestures';
   var HANDLED_OBJ = '__polymerGesturesHandled';
   var TOUCH_ACTION = '__polymerGesturesTouchAction';
+  // Disabling "tap" after 300ms long touch
+  var TAP_TIMEOUT = 300;
   // radius for tap and track
   var TAP_DISTANCE = 25;
   var TRACK_DISTANCE = 5;
@@ -648,6 +650,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     save: function(e) {
       this.info.x = e.clientX;
       this.info.y = e.clientY;
+      this.info.time = e.timeStamp;
     },
 
     mousedown: function(e) {
@@ -662,18 +665,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     touchstart: function(e) {
+      this.info.startTime = e.timeStamp;
       this.save(e.changedTouches[0]);
     },
     touchend: function(e) {
+      this.info.endTime = e.timeStamp;
       this.forward(e.changedTouches[0]);
     },
 
     forward: function(e) {
       var dx = Math.abs(e.clientX - this.info.x);
       var dy = Math.abs(e.clientY - this.info.y);
+      var dt = this.info.endTime - this.info.startTime;
       var t = Gestures.findOriginalTarget(e);
-      // dx,dy can be NaN if `click` has been simulated and there was no `down` for `start`
-      if (isNaN(dx) || isNaN(dy) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE) || isSyntheticClick(e)) {
+      // dx,dy,dt can be NaN if `click` has been simulated and there was no `down` for `start`
+      if (isNaN(dx) || isNaN(dy) || isNaN(dt) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE && dt <= TAP_TIMEOUT) || isSyntheticClick(e)) {
         // prevent taps from being generated if an event has canceled them
         if (!this.info.prevent) {
           Gestures.fire(t, 'tap', {

--- a/test/unit/gestures-elements.html
+++ b/test/unit/gestures-elements.html
@@ -205,3 +205,28 @@ var EventCaptureBehavior = {
     });
   </script>
 </dom-module>
+
+<dom-module id="x-tap-listener">
+  <template></template>
+  <script>
+    Polymer({
+      is: 'x-tap-listener',
+
+      properties: {
+        events: {
+          value: function() {
+            return [];
+          }
+        }
+      },
+
+      listeners: {
+        tap: 'handle'
+      },
+
+      handle: function(e) {
+        this.events.push(e);
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -490,6 +490,79 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
     });
+
+    suite('Touch', function() {
+      var el;
+
+      setup(function() {
+        el = document.createElement('x-tap-listener');
+        document.body.appendChild(el);
+      });
+
+      teardown(function() {
+        document.body.removeChild(el);
+      });
+
+      suite('Tap', function() {
+        test('Does not fire on Long Tap', function(done) {
+          var start = new CustomEvent('touchstart', {bubbles: true});
+          start.touches = start.changedTouches = [
+            {
+              clientX: 0,
+              clientY: 0,
+              identifier: 1,
+              target: el
+            }
+          ];
+          el.dispatchEvent(start);
+
+          Polymer.Base.async(function() {
+            var end = new CustomEvent('touchend', {bubbles: true});
+            end.touches = end.changedTouches = [
+              {
+                clientX: 0,
+                clientY: 0,
+                identifier: 1,
+                target: el
+              }
+            ];
+            el.dispatchEvent(end);
+            assert.equal(el.events.length, 0);
+
+            done();
+          }, 300);
+        });
+
+        test('Fires on quick Tap', function(done) {
+          var start = new CustomEvent('touchstart', {bubbles: true});
+          start.touches = start.changedTouches = [
+            {
+              clientX: 0,
+              clientY: 0,
+              identifier: 1,
+              target: el
+            }
+          ];
+          el.dispatchEvent(start);
+
+          Polymer.Base.async(function() {
+            var end = new CustomEvent('touchend', {bubbles: true});
+            end.touches = end.changedTouches = [
+              {
+                clientX: 0,
+                clientY: 0,
+                identifier: 1,
+                target: el
+              }
+            ];
+            el.dispatchEvent(end);
+            assert.equal(el.events.length, 1);
+
+            done();
+          }, 150);
+        });
+      });
+    });
   </script>
 
 </body>


### PR DESCRIPTION
### Reference Issue

Fixes polymer/polymer-gestures#12

Currently, unintentional taps happen easily with elements like `<iron-list>` where a user can first touch scroll down and then back up having `touchend` getting fired inside the same area where touching started.

Adding a simple timeout for the tap event, helps, alternative approach for this issue could to be track the total distance from the track events and have a threshold for that.
