### PR TITLE
Allow setting read-only properties using `set`

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -206,8 +206,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._notifyPath(parts.join('.'), value);
           }
         } else {
-          // Simple property set
-          prop[path] = value;
+          // `prop` is root or this, so we need to duck type here.
+          // Consider removing the `root`-argument.
+          if (prop.__setProperty) {
+            this.__setProperty(path, value);
+          } else {
+            prop[path] = value;
+          }
         }
       },
 

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -505,6 +505,11 @@ suite('2-way binding effects between elements', function() {
     assert.equal(el.boundreadonlyvalue, 46, 'property bound to read-only property should change from change to bound value');
   });
 
+  test('allow setting read-only property via `set`', function() {
+    el.$.basic1.set('readonlyvalue', 46);
+    assert.equal(el.$.basic1.readonlyvalue, 46);
+  });
+
   test('listener for value-changed fires when value changed from host', function() {
     var listener = sinon.spy();
     el.$.basic1.addEventListener('notifyingvalue-changed', listener);


### PR DESCRIPTION
Fixes #3552

Note: computed properties could be set as well. Nobody should do this.

Can I remove the third argument `root` from `set()`? It is unused within the framework. Since `set` is public API I would like the following signature:

Before `set: function(path, value, root) {`
After `set: function(path, value, fromAbove) {` 
