### PR TITLE
Let read-only properties participate in upwards flowing data.

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -193,8 +193,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!model._bindListeners) {
         model._bindListeners = [];
       }
-      var fn = this._notedListenerFactory(property, path,
-        this._isStructured(path), negated);
+      var fn = this._notedListenerFactory(property, path, negated);
       var eventName = event ||
         (Polymer.CaseMap.camelToDashCase(property) + '-changed');
       model._bindListeners.push({
@@ -206,19 +205,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     },
 
-    _isStructured: function(path) {
-      return path.indexOf('.') > 0;
+    // Returns the `head` or root for a path. E.g. 'foo.bar.quux' => 'foo'
+    _rootForPath: function(path) {
+      var idx = path.indexOf('.');
+      if (idx === -1) {
+        return path;
+      } else {
+        return path.slice(0, idx);
+      }
     },
 
     _isEventBogus: function(e, target) {
       return e.path && e.path[0] !== target;
     },
 
-    _notedListenerFactory: function(property, path, isStructured, negated) {
+    _notedListenerFactory: function(property, path, negated) {
+      var root = this._rootForPath(path);
+      var isStructured = root !== path;
+
       return function(target, value, targetPath) {
         if (targetPath) {
           this._notifyPath(this._fixPath(path, property, targetPath), value);
         } else {
+          var pinfo = this._propertyInfo[root];
+          if (pinfo && pinfo.computed) {
+            return;
+          }
+
           // TODO(sorvell): even though we have a `value` argument, we *must*
           // lookup the current value of the property. Multiple listeners and
           // queued events during configuration can theoretically lead to
@@ -231,7 +244,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
 
           if (!isStructured) {
-            this[path] = value;
+            this.__setProperty(path, value, false);
           } else {
             // TODO(kschaaf): dirty check avoids null references when the object has gone away
             if (this.__data__[path] != value) {

--- a/src/micro/properties.html
+++ b/src/micro/properties.html
@@ -154,7 +154,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           s = source[i];
           // optimization: avoid info'ing properties that are protected and
           // not read only since they are not needed for attributes or
-          // configuration.
+          // configuration. Note that all computeds are read only, but not
+          // vice-versa.
           if (i[0] === '_' && !s.readOnly) {
             continue;
           }
@@ -162,6 +163,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             target[i] = {
               type: typeof(s) === 'function' ? s : s.type,
               readOnly: s.readOnly,
+              computed: s.computed,
               attribute: Polymer.CaseMap.camelToDashCase(i)
             }
           } else {
@@ -170,6 +172,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
             if (!t.readOnly) {
               t.readOnly = s.readOnly;
+            }
+            if (!t.computed) {
+              t.computed = s.computed;
             }
           }
         }

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -300,6 +300,13 @@
     <x-basic id="basic4"
       notifyingvalue="{{!negatedValue}}">
     </x-basic>
+    <x-basic id="basic5"
+      notifyingvalue="{{readonlyvalue}}">
+    </x-basic>
+    <x-basic id="basic6"
+      notifyingvalue="{{readonlyobject.foo}}">
+    </x-basic>
+
   </template>
   <script>
     Polymer({
@@ -323,6 +330,12 @@
         },
         negatedValue: {
           value: false
+        },
+        readonlyvalue: {
+          readOnly: true
+        },
+        readonlyobject: {
+          readOnly: true
         }
       },
       created: function() {

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -505,6 +505,17 @@ suite('2-way binding effects between elements', function() {
     assert.equal(el.boundreadonlyvalue, 46, 'property bound to read-only property should change from change to bound value');
   });
 
+  test('propagate upwards into read-only property (assignment)', function() {
+    el.$.basic5.notifyingvalue = 'Hi';
+    assert.equal(el.readonlyvalue, 'Hi');
+  });
+
+  test('propagate upwards into read-only property (deep binding)', function() {
+    el._setReadonlyobject({foo: 'bar'});
+    el.$.basic6.notifyingvalue = 'quod';
+    assert.equal(el.readonlyobject.foo, 'quod');
+  });
+
   test('listener for value-changed fires when value changed from host', function() {
     var listener = sinon.spy();
     el.$.basic1.addEventListener('notifyingvalue-changed', listener);


### PR DESCRIPTION
Fixes #3551, fixes #2632

Note that from the two possible variants 

```
+    <x-basic id="basic5"
+      notifyingvalue="{{readonlyvalue}}">
+    </x-basic>
+    <x-basic id="basic6"
+      notifyingvalue="{{readonlyobject.foo}}">
+    </x-basic>
```

`basic6` actually was working before, but `basic5` did not. This inconsistency-bug is reported here https://github.com/Polymer/polymer/issues/2632#issuecomment-199011930
