### PR TITLE
Fix nextSibling after appendChild

### DIFF
--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -51,6 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // container to container.host.
     // 3. node is <content> (host of container needs distribution)
     insertBefore: function(node, ref_node) {
+      ref_node = ref_node || null;
       if (ref_node && TreeApi.Logical.getParentNode(ref_node) !== this.node) {
         throw Error('The ref_node to be inserted before is not a child ' +
           'of this node');

--- a/test/unit/polymer-dom.js
+++ b/test/unit/polymer-dom.js
@@ -719,10 +719,12 @@ suite('Polymer.dom accessors', function() {
     var after = document.createElement('div');
     Polymer.dom(distribute).insertBefore(before, child);
     Polymer.dom(distribute).appendChild(after);
+    Polymer.dom.flush();
     assert.equal(Polymer.dom(distribute).firstChild, before, 'firstChild incorrect');
     assert.equal(Polymer.dom(distribute).lastChild, after, 'lastChild incorrect');
     assert.equal(Polymer.dom(before).nextSibling, child, 'nextSibling incorrect');
     assert.equal(Polymer.dom(child).nextSibling, after, 'nextSibling incorrect');
+    assert.equal(Polymer.dom(after).nextSibling, null, 'nextSibling incorrect');
     assert.equal(Polymer.dom(after).previousSibling, child, 'previousSibling incorrect');
     assert.equal(Polymer.dom(child).previousSibling, before, 'previousSibling incorrect');
   });


### PR DESCRIPTION
If `ref_node` is undefined instead of `null`, [node.__dom.nextSibling](https://github.com/Polymer/polymer/blob/3bd83871564770551b90926e746c5d651d60942e/src/lib/dom-tree-api.html#L218) is
`undefined` instead of `null` too. Because of this, [Polymer.dom(node).nextSibling](https://github.com/Polymer/polymer/blob/3bd83871564770551b90926e746c5d651d60942e/src/lib/dom-tree-api.html#L107) is the
nextSibling in the browser DOM when it should be `null`.