### PR TITLE
Run each effect exactly once during config

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -351,14 +351,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // (properties) are case sensitive. Gambit is to map dash-case to
         // camel-case: `foo-bar` becomes `fooBar`.
         // Attribute bindings are excepted.
-        var propertyName = Polymer.CaseMap.dashToCamelCase(name);
         if (kind === 'property') {
-          name = propertyName;
+          name = Polymer.CaseMap.dashToCamelCase(name);
         }
         return {
           kind: kind,
           name: name,
-          propertyName: propertyName,
           parts: parts,
           literal: literal,
           isCompound: parts.length !== 1

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -68,6 +68,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // use non-notifying setters but right now that would require looking
       // up readOnly property config in the hot-path
       __setProperty: function(property, value, quiet, node) {
+        if (node && node._configValue && !node._clientsReadied) {
+          node._configValue(property, value);
+          return;
+        }
+
         node = node || this;
         var effects = node._propertyEffects && node._propertyEffects[property];
         if (effects) {

--- a/src/micro/attributes.html
+++ b/src/micro/attributes.html
@@ -162,7 +162,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // }
       node = node || this;
       if (str === undefined) {
-        node.removeAttribute(attribute);
+
+        // Invariant for config phase: Removing an attribute that is not set is
+        // a no-op and will not trigger the attributeChanged callback. To
+        // propagate this value to the property, we call _configValue manually.
+        if (node._configValue && !node._clientsReadied &&
+            !node.hasAttribute(attribute)) {
+          var property = Polymer.CaseMap.dashToCamelCase(attribute);
+          var pinfo = node._propertyInfo[property];
+          if (pinfo) {
+            value = node.deserialize(undefined, pinfo.type);
+            node._configValue(property, value);
+          }
+        } else {
+          node.removeAttribute(attribute);
+        }
+
       } else {
         node.setAttribute(attribute, str);
       }

--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -161,12 +161,10 @@ TODO(sjmiles): this module should produce either syntactic metadata
             this._discoverTemplateParentProps(note.templateContent._notes);
           var bindings = [];
           for (var prop in pp) {
-            var name = '_parent_' + prop;
             bindings.push({
               index: note.index,
               kind: 'property',
-              name: name,
-              propertyName: name,
+              name: '_parent_' + prop,
               parts: [{
                 mode: '{',
                 model: prop,

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -48,6 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // storage for configuration
     _setupConfigure: function(initialConfig) {
       this._config = {};
+      this.__effectsSkippedDuringConfig = {};
       this._handlers = [];
       this._aboveConfig = null;
       if (initialConfig) {
@@ -142,7 +143,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (var p in config) {
           var fx = fx$[p];
           if (fx) {
+            var skippedEffects = [];
             for (var i=0, l=fx.length, x; (i<l) && (x=fx[i]); i++) {
+              var effectDidRun = false;
               // TODO(kschaaf): computed annotations are excluded from top-down
               // configure for now; to be revisited
               if (x.kind === 'annotation') {
@@ -163,11 +166,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                     // bound through the attribute
                     value = node.deserialize(this.serialize(value),
                       node._propertyInfo[name].type);
+                  } else {
+                    effectDidRun = true;
                   }
                   node._configValue(name, value);
                 }
               }
+              if (!effectDidRun) {
+                skippedEffects.push(x);
+              }
             }
+            this.__effectsSkippedDuringConfig[p] = skippedEffects;
           }
         }
       }
@@ -181,17 +190,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._flushHandlers();
     },
 
-    // NOTE: values are already propagated to children via
-    // _distributeConfig so propagation triggered by effects here is
-    // redundant, but safe due to dirty checking
     _applyConfig: function(config, aboveConfig) {
       for (var n in config) {
         // Don't stomp on values that may have been set by other side effects
         if (this[n] === undefined) {
-          // Call _propertySet for any properties with accessors, which will
-          // initialize read-only properties also; set quietly if value was
-          // configured from above, as opposed to default
-          this.__setProperty(n, config[n], n in aboveConfig);
+          var effects = this.__effectsSkippedDuringConfig[n] || (
+            this._propertyEffects && this._propertyEffects[n]);
+          // Call _propertySetter for any properties with effects; set
+          // fromAbove if value was configured from above
+          if (effects) {
+            this._propertySetter(n, config[n], effects, n in aboveConfig);
+          } else {
+            this[n] = config[n];
+          }
         }
       }
     },

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -145,34 +145,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (fx) {
             var skippedEffects = [];
             for (var i=0, l=fx.length, x; (i<l) && (x=fx[i]); i++) {
-              var effectDidRun = false;
               // TODO(kschaaf): computed annotations are excluded from top-down
               // configure for now; to be revisited
               if (x.kind === 'annotation') {
-                var node = this._nodes[x.effect.index];
-                var name = x.effect.propertyName;
-                // seeding configuration only
-                var isAttr = (x.effect.kind == 'attribute');
-                var hasEffect = (node._propertyEffects &&
-                  node._propertyEffects[name]);
-                if (node._configValue && (hasEffect || !isAttr)) {
-                  var value = (p === x.effect.value) ? config[p] :
-                    this._get(x.effect.value, config);
-                  value = this._computeFinalAnnotationValue(node, name, value,
-                                                            x.effect);
-                  if (isAttr) {
-                    // For attribute bindings, flow through the same ser/deser
-                    // process to ensure the value is the same as if it were
-                    // bound through the attribute
-                    value = node.deserialize(this.serialize(value),
-                      node._propertyInfo[name].type);
-                  } else {
-                    effectDidRun = true;
-                  }
-                  node._configValue(name, value);
-                }
-              }
-              if (!effectDidRun) {
+                var path = x.effect.value;
+                var value = (path === p) ? config[p] : this._get(path, config);
+                x.fn.call(this, path, value, x.effect);
+              } else {
                 skippedEffects.push(x);
               }
             }

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -180,7 +180,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               kind: note.kind,
               index: index,
               name: note.name,
-              propertyName: note.propertyName,
               value: part.value,
               isCompound: note.isCompound,
               compoundIndex: part.compoundIndex,


### PR DESCRIPTION
Two commits here: First commit ensures that an annotation effect runs exactly once during config, so we don't need to rely on dirty-checks here. Second commit shows the readable, straightforward `distributeConfig` code path, moving the invariants around. 

Note that `serializeValueToAttribute` should be overriden, but x-styling.html already does that. 
