### PR TITLE
Ensure fromAbove in _forwardParentProp.

### DIFF
--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -169,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // notifying parent.<prop> path change on instance
     _forwardParentProp: function(prop, value) {
       if (this._instance) {
-        this._instance[prop] = value;
+        this._instance.__setProperty(prop, value, true);
       }
     },
 

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -97,7 +97,7 @@
     },
     _forwardParentProp: function(prop, value) {
       if (this.instance) {
-        this.instance[prop] = value;
+        this.instance.__setProperty(prop, value, true);
       }
     },
     _forwardParentPath: function(path, value) {
@@ -165,7 +165,7 @@
     },
     _forwardParentProp: function(prop, value) {
       if (this.instance) {
-        this.instance[prop] = value;
+        this.instance.__setProperty(prop, value, true);
       }
     },
     _forwardParentPath: function(path, value) {


### PR DESCRIPTION
The general rule here is: `_forwardParentProp/Path` must assume fromAbove
is true; for `_forwardInstanceProp/Path` assume fromAbove is false.