### PR TITLE
Ensure fromAbove for downwards bindings.

### DIFF
--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -338,10 +338,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (pinfo && pinfo.readOnly) {
           return;
         }
-        // Ideally we would call setProperty using fromAbove: true to avoid
-        // spinning the wheel needlessly, but we found that users were listening
-        // for change events outside of bindings
-        this.__setProperty(property, value, false, node);
+        this.__setProperty(property, value, true, node);
       }
     },
 

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -510,8 +510,7 @@ suite('2-way binding effects between elements', function() {
     el.$.basic1.addEventListener('notifyingvalue-changed', listener);
     el.boundnotifyingvalue = 678;
     assert.equal(el.$.basic1.notifyingvalue, 678);
-    assert.isTrue(listener.calledOnce);
-    assert.equal(listener.getCalls()[0].args[0].detail.value, 678);
+    assert.isFalse(listener.called);
   });
 
   test('negated binding update negates value for parent', function() {


### PR DESCRIPTION
Essentially downwards flowing data change events shouldn't echo upwards.

This is a breaking change since you actually had a test (!) that ensures the opposite. 

