### PR TITLE
Assume attribute changes as coming from above.

### DIFF
--- a/src/micro/attributes.html
+++ b/src/micro/attributes.html
@@ -114,7 +114,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         info = info || (this._propertyInfo && this._propertyInfo[property]);
         if (info && !info.readOnly) {
           var v = this.getAttribute(attribute);
-          model[property] = this.deserialize(v, info.type);
+          v = this.deserialize(v, info.type);
+          if (model.__setProperty) {
+            model.__setProperty(property, v, true);
+          } else {
+            model[property] = v;
+          }
         }
       }
     },

--- a/test/unit/attributes-elements.html
+++ b/test/unit/attributes-elements.html
@@ -26,7 +26,8 @@
       },
       string: {
         type: String,
-        value: 'none'
+        value: 'none',
+        notify: true
       },
       bool: {
         type: Boolean,

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -189,6 +189,17 @@ suite('imperative attribute change (no-reflect)', function() {
     assert.strictEqual(el.dashCase, 'Changed');
   });
 
+  test('setting an attribute does not echo upwards', function() {
+    var listener = sinon.spy();
+    el.addEventListener('string-changed', listener);
+
+    el.setAttribute('string', 'howdy');
+    assert.isFalse(listener.called);
+
+    el.removeAttribute('string');
+    assert.isFalse(listener.called);
+  });
+
 });
 
 suite('imperative attribute change (reflect)', function() {


### PR DESCRIPTION
When using the public API `node.set/removeAttribute` assume that these changes are coming from above, t.i. do not notify upwards. 
