### PR TITLE
Remove dirty checks for objects

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -351,14 +351,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // (properties) are case sensitive. Gambit is to map dash-case to
         // camel-case: `foo-bar` becomes `fooBar`.
         // Attribute bindings are excepted.
-        var propertyName = Polymer.CaseMap.dashToCamelCase(name);
         if (kind === 'property') {
-          name = propertyName;
+          name = Polymer.CaseMap.dashToCamelCase(name);
         }
         return {
           kind: kind,
           name: name,
-          propertyName: propertyName,
           parts: parts,
           literal: literal,
           isCompound: parts.length !== 1

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -42,7 +42,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Called from accessors, where effects is pre-stored
       // in the closure for the accessor for efficiency
-      _propertySetter: function(property, value, effects, fromAbove) {
+      _propertySetter: function(property, value, effects, fromAbove,
+                                origin, originalProperty) {
         var old = this.__data__[property];
         // NaN is always not equal to itself,
         // if old and value are both NaN we treat them as equal
@@ -56,7 +57,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._propertyChanged(property, value, old);
           }
           if (effects) {
-            this._effectEffects(property, value, effects, old, fromAbove);
+            this._effectEffects(property, value, effects, old, fromAbove,
+                                origin, originalProperty);
           }
         }
         return old;
@@ -67,19 +69,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // TODO(kschaaf): downward bindings (e.g. _applyEffectValue) should also
       // use non-notifying setters but right now that would require looking
       // up readOnly property config in the hot-path
-      __setProperty: function(property, value, quiet, node) {
+      __setProperty: function(property, value, quiet, node,
+                              origin, originalProperty) {
         node = node || this;
         var effects = node._propertyEffects && node._propertyEffects[property];
         if (effects) {
-          node._propertySetter(property, value, effects, quiet);
+          node._propertySetter(property, value, effects, quiet,
+                               origin, originalProperty);
         } else {
           node[property] = value;
         }
       },
 
-      _effectEffects: function(property, value, effects, old, fromAbove) {
+      _effectEffects: function(property, value, effects, old, fromAbove,
+                               origin, originalProperty) {
         for (var i=0, l=effects.length, fx; (i<l) && (fx=effects[i]); i++) {
-          fx.fn.call(this, property, value, fx.effect, old, fromAbove);
+          fx.fn.call(this, property, value, fx.effect, old, fromAbove,
+                     origin, originalProperty);
         }
       },
 
@@ -193,8 +199,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!model._bindListeners) {
         model._bindListeners = [];
       }
-      var fn = this._notedListenerFactory(property, path,
-        this._isStructured(path), negated);
+      var fn = this._notedListenerFactory(property, path, negated);
       var eventName = event ||
         (Polymer.CaseMap.camelToDashCase(property) + '-changed');
       model._bindListeners.push({
@@ -214,10 +219,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return e.path && e.path[0] !== target;
     },
 
-    _notedListenerFactory: function(property, path, isStructured, negated) {
+    _notedListenerFactory: function(property, path, negated) {
+      var isStructured = this._isStructured(path);
       return function(target, value, targetPath) {
         if (targetPath) {
-          this._notifyPath(this._fixPath(path, property, targetPath), value);
+          var newPath = this._fixPath(path, property, targetPath);
+          this._notifyPath(newPath, value, false, target, property);
         } else {
           // TODO(sorvell): even though we have a `value` argument, we *must*
           // lookup the current value of the property. Multiple listeners and
@@ -231,12 +238,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
 
           if (!isStructured) {
-            this[path] = value;
-          } else {
-            // TODO(kschaaf): dirty check avoids null references when the object has gone away
-            if (this.__data__[path] != value) {
-              this.set(path, value);
+            var pinfo = this._propertyInfo && this._propertyInfo[path];
+            if (!pinfo || !pinfo.readOnly) {
+              this.__setProperty(path, value, false, undefined,
+                                 target, property);
             }
+          } else {
+            this.set(path, value, false, target, property);
           }
         }
       };

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -89,8 +89,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _effectEffects: function(property, value, effects, old, fromAbove,
                                origin, originalProperty) {
         for (var i=0, l=effects.length, fx; (i<l) && (fx=effects[i]); i++) {
-          fx.fn.call(this, property, value, fx.effect, old, fromAbove,
-                     origin, originalProperty);
+          if (!fx.disabled) {
+            fx.fn.call(this, property, value, fx.effect, old, fromAbove,
+                       origin, originalProperty);
+          }
         }
       },
 
@@ -122,7 +124,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var propEffect = {
         kind: kind,
         effect: effect,
-        fn: Polymer.Bind['_' + kind + 'Effect']
+        fn: Polymer.Bind['_' + kind + 'Effect'],
+        trigger: property
       };
       fx.push(propEffect);
       return propEffect;
@@ -140,7 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // effects have priority
           fx.sort(this._sortPropertyEffects);
           // create accessors
-          this._createAccessors(model, n, fx);
+          this._createAccessors(model, n);
         }
       }
       //console.groupEnd();
@@ -168,7 +171,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // create accessors that implement effects
 
-    _createAccessors: function(model, property, effects) {
+    _createAccessors: function(model, property) {
       var defun = {
         get: function() {
           // TODO(sjmiles): elide delegation for performance, good ROI?
@@ -176,6 +179,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       };
       var setter = function(value) {
+        var effects = this._propertyEffects && this._propertyEffects[property];
         this._propertySetter(property, value, effects);
       };
       // ReadOnly properties have a private setter only
@@ -236,7 +240,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // queued events during configuration can theoretically lead to
           // divergence of the passed value from the current value, but we
           // really need to track down a specific case where this happens.
-          value = target[property];
+          value = target.__data__ ? target.__data__[property] : target[property];
 
           if (negated) {
             value = !value;

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -45,10 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _propertySetter: function(property, value, effects, fromAbove,
                                 origin, originalProperty) {
         var old = this.__data__[property];
-        // NaN is always not equal to itself,
-        // if old and value are both NaN we treat them as equal
-        // x === x is 10x faster, and equivalent to !isNaN(x)
-        if (old !== value && (old === old || value === value)) {
+        if (this._isPropertyDirty(property, value, old) !== false) {
           this.__data__[property] = value;
           if (typeof value == 'object') {
             this._clearPath(property);
@@ -62,6 +59,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         }
         return old;
+      },
+
+      _isPropertyDirty: function(property, value, old) {
+        // NaN is always not equal to itself,
+        // if old and value are both NaN we treat them as equal
+        // x === x is 10x faster, and equivalent to !isNaN(x)
+        return (old !== value && (old === old || value === value)) ||
+               typeof value == 'object';
       },
 
       // Called during _applyConfig (well-known downward data-flow hot path)

--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -71,6 +71,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // up readOnly property config in the hot-path
       __setProperty: function(property, value, quiet, node,
                               origin, originalProperty) {
+        if (node && node._configValue && !node._clientsReadied) {
+          node._configValue(property, value);
+          return;
+        }
+
         node = node || this;
         var effects = node._propertyEffects && node._propertyEffects[property];
         if (effects) {

--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -20,12 +20,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
              effect.parts[0].mode === '{';
     },
 
-    _annotationEffect: function(source, value, effect) {
-      if (source != effect.value) {
-        value = this._get(effect.value);
-        this.__data__[effect.value] = value;
+
+    _annotationEffect: function(source, value, effect, old, fromAbove,
+                                origin, originalProperty) {
+
+      // Consider:
+      // <that-node that-property="{{ thisPath }}" />
+      var thatNode = this._nodes[effect.index];
+      var thatProperty = effect.name;
+      var thisPath = effect.value;
+
+      // Do not propagate downwards if the origin of this change is this exact
+      // binding
+      if (origin && originalProperty &&
+          origin === thatNode &&
+          originalProperty === thatProperty) {
+        return;
       }
-      this._applyEffectValue(effect, value);
+
+      if (source != thisPath) {
+        value = this._get(thisPath);
+        this.__data__[thisPath] = value;
+      }
+      this._applyEffectValue(thatNode, thatProperty, value, effect);
     },
 
     _reflectEffect: function(source, value, effect) {
@@ -94,8 +111,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (fn) {
         var args = Polymer.Bind._marshalArgs(this.__data__, effect, source, value);
         if (args) {
+          var node = this._nodes[effect.index];
+          var property = effect.name;
           var computedvalue = fn.apply(computedHost, args);
-          this._applyEffectValue(effect, computedvalue);
+          this._applyEffectValue(node, property, computedvalue, effect);
         }
       } else if (effect.dynamicFn) {
         // dynamic functions can be just like every other property `undefined`

--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -169,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // notifying parent.<prop> path change on instance
     _forwardParentProp: function(prop, value) {
       if (this._instance) {
-        this._instance[prop] = value;
+        this._instance.__setProperty(prop, value, true);
       }
     },
 

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -120,7 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       archetype._prepBindings();
 
       // boilerplate code
-      archetype._notifyPathUp = this._notifyPathUpImpl;
+      archetype._notifyPathUp = function() {};
       archetype._scopeElementClass = this._scopeElementClassImpl;
       archetype.listen = this._listenImpl;
       archetype._showHideChildren = this._showHideChildrenImpl;
@@ -193,7 +193,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       for (prop in this._instanceProps) {
         archetype._addPropertyEffect(prop, 'function',
-          this._createInstancePropEffector(prop));
+          this._createInstancePropEffector());
       }
     },
 
@@ -215,13 +215,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       archetype._parentProps = c._parentProps;
     },
 
-    // Sets up accessors on the template to call abstract _forwardParentProp
-    // API that should be implemented by Templatizer users to get parent
-    // properties to their template instances.  These accessors are memoized
-    // on the archetype and copied to instances.
+    // Sets up accessors on the template to call abstract
+    // _forwardParentProp/Path API that should be implemented by Templatizer
+    // users to get parent properties to their template instances.  These
+    // accessors are memoized on the archetype and copied to instances.
     _prepParentProperties: function(archetype, template) {
       var parentProps = this._parentProps = archetype._parentProps;
-      if (this._forwardParentProp && parentProps) {
+      if ((this._forwardParentProp || this._forwardParentPath) &&
+          parentProps) {
         // Prototype setup (memoized on archetype)
         var proto = archetype._parentPropProto;
         var prop;
@@ -229,17 +230,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (prop in this._instanceProps) {
             delete parentProps[prop];
           }
-          proto = archetype._parentPropProto = Object.create(null);
-          if (template != this) {
-            // Assumption: if `this` isn't the template being templatized,
-            // assume that the template is not a Poylmer.Base, so prep it
-            // for binding
-            Polymer.Bind.prepareModel(proto);
-            Polymer.Base.prepareModelNotifyPath(proto);
-          }
-          // Create accessors for each parent prop that forward the property
-          // to template instances through abstract _forwardParentProp API
-          // that should be implemented by Templatizer users
+          // Create accessors for each parent prop that forward the property to
+          // template instances through abstract _forwardParentProp/Path API
+          // that should be implemented by Templatizer users.
+          var propertyEffects = this.mixin({}, this._propertyEffects);
+          var propertyInfo = this.mixin({}, this._propertyInfo);
+          var prefixedParentProps = {};
           for (prop in parentProps) {
             var parentProp = this._parentPropPrefix + prop;
             // TODO(sorvell): remove reference Bind library functions here.
@@ -247,69 +243,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var effects = [{
               kind: 'function',
               effect: this._createForwardPropEffector(prop),
-              fn: Polymer.Bind._functionEffect
+              fn: Polymer.Bind._functionEffect,
+              pathFn: this._functionPathEffect
             }, {
               kind: 'notify',
               fn: Polymer.Bind._notifyEffect,
               effect: {event:
                 Polymer.CaseMap.camelToDashCase(parentProp) + '-changed'}
             }];
-            Polymer.Bind._createAccessors(proto, parentProp, effects);
+            propertyEffects[parentProp] = effects;
+            propertyInfo[parentProp] = {};
+            prefixedParentProps[parentProp] = true;
           }
+          proto = archetype._parentPropProto = {
+            _propertyEffects: propertyEffects,
+            _propertyInfo: propertyInfo,
+            prefixedParentProps: prefixedParentProps
+          };
         }
         // capture this reference for use below
         var self = this;
         // Instance setup
         if (template != this) {
+          Polymer.Bind.prepareModel(template);
+          Polymer.Base.prepareModelNotifyPath(template);
           Polymer.Bind.prepareInstance(template);
-          template._forwardParentProp = function(source, value) {
-            self._forwardParentProp(source, value);
+          if (self._forwardParentProp) {
+            template._forwardParentProp = function(prop, value) {
+              self._forwardParentProp(prop, value);
+            }
+          }
+          if (self._forwardParentPath) {
+            template._forwardParentPath = function(path, value) {
+              self._forwardParentPath(path, value);
+            }
           }
         }
         this._extendTemplate(template, proto);
-        template._pathEffector = function(path, value, fromAbove) {
-          return self._pathEffectorImpl(path, value, fromAbove);
-        }
       }
     },
 
+
     _createForwardPropEffector: function(prop) {
-      return function(source, value) {
-        this._forwardParentProp(prop, value);
+      var prefixLength = this._parentPropPrefix.length;
+      return function(path, value) {
+        if (path.indexOf('.') !== -1) {
+          if (this._forwardParentPath) {
+            var newPath = path.slice(prefixLength);
+            this._forwardParentPath(newPath, value);
+          }
+        } else if (this._forwardParentProp) {
+          this._forwardParentProp(prop, value);
+        }
       };
     },
 
     _createHostPropEffector: function(prop) {
       var prefix = this._parentPropPrefix;
-      return function(source, value) {
-        this.dataHost._templatized[prefix + prop] = value;
-      };
-    },
-
-    _createInstancePropEffector: function(prop) {
-      return function(source, value, old, fromAbove) {
+      var prefixedProp = prefix + prop;
+      return function(path, value, old, fromAbove) {
         if (!fromAbove) {
-          this.dataHost._forwardInstanceProp(this, prop, value);
+          var dataHost = this.dataHost;
+          if (path.indexOf('.') !== -1) {
+            dataHost._templatized._notifyPath(prefix + path, value, false);
+          } else {
+            dataHost._templatized.__setProperty(prefixedProp, value, false);
+          }
         }
       };
     },
 
-    // Similar to Polymer.Base.extend, but retains any previously set instance
-    // values (_propertySetter back on instance once accessor is installed)
-    _extendTemplate: function(template, proto) {
-      var n$ = Object.getOwnPropertyNames(proto);
-      if (proto._propertySetter) {
-        // _propertySetter API may need to be copied onto the template,
-        // and it needs to come first to allow the property swizzle below
-        template._propertySetter = proto._propertySetter;
-      }
-      for (var i=0, n; (i<n$.length) && (n=n$[i]); i++) {
-        var val = template[n];
-        var pd = Object.getOwnPropertyDescriptor(proto, n);
-        Object.defineProperty(template, n, pd);
-        if (val !== undefined) {
-          template._propertySetter(n, val);
+    _createInstancePropEffector: function() {
+      return function(path, value, old, fromAbove) {
+        if (!fromAbove) {
+          if (path.indexOf('.') !== -1) {
+            this.dataHost._forwardInstancePath(this, path, value);
+          } else {
+            this.dataHost._forwardInstanceProp(this, path, value);
+          }
         }
+      };
+    },
+
+    // Extends template with parent property info & effects and seed pre-bound data
+    _extendTemplate: function(template, proto) {
+      template._propertyEffects = proto._propertyEffects;
+      template._propertyInfo = proto._propertyInfo;
+      var prefixedParentProps = proto.prefixedParentProps;
+      for (var p in prefixedParentProps) {
+        var val = template[p];
+        template.__data__[p] = val;
       }
     },
 
@@ -322,31 +345,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // _forwardParentPath: function(path, value) { },
     // _forwardParentProp: function(prop, value) { },
     /* eslint-enable no-unused-vars */
-
-    _notifyPathUpImpl: function(path, value) {
-      var dataHost = this.dataHost;
-      var dot = path.indexOf('.');
-      var root = dot < 0 ? path : path.slice(0, dot);
-      // Call extension point for Templatizer sub-classes
-      dataHost._forwardInstancePath.call(dataHost, this, path, value);
-      if (root in dataHost._parentProps) {
-        dataHost._templatized._notifyPath(dataHost._parentPropPrefix + path, value);
-      }
-    },
-
-    // Overrides Base notify-path module
-    _pathEffectorImpl: function(path, value, fromAbove) {
-      if (this._forwardParentPath) {
-        if (path.indexOf(this._parentPropPrefix) === 0) {
-          var subPath = path.substring(this._parentPropPrefix.length);
-          var model = this._modelForPath(subPath);
-          if (model in this._parentProps) {
-            this._forwardParentPath(subPath, value);
-          }
-        }
-      }
-      Polymer.Base._pathEffector.call(this._templatized, path, value, fromAbove);
-    },
 
     _constructorImpl: function(model, host) {
       this._rootDataHost = host._getRootDataHost();
@@ -425,7 +423,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var templatized = this._templatized;
         for (var prop in this._parentProps) {
           if (model[prop] === undefined) {
-            model[prop] = templatized[this._parentPropPrefix + prop];
+            model[prop] = templatized.__data__[this._parentPropPrefix + prop];
           }
         }
       }

--- a/src/micro/attributes.html
+++ b/src/micro/attributes.html
@@ -114,7 +114,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         info = info || (this._propertyInfo && this._propertyInfo[property]);
         if (info && !info.readOnly) {
           var v = this.getAttribute(attribute);
-          model[property] = this.deserialize(v, info.type);
+          v = this.deserialize(v, info.type);
+          if (model.__setProperty) {
+            model.__setProperty(property, v, true);
+          } else {
+            model[property] = v;
+          }
         }
       }
     },

--- a/src/micro/attributes.html
+++ b/src/micro/attributes.html
@@ -167,7 +167,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // }
       node = node || this;
       if (str === undefined) {
-        node.removeAttribute(attribute);
+
+        // Invariant for config phase: Removing an attribute that is not set is
+        // a no-op and will not trigger the attributeChanged callback. To
+        // propagate this value to the property, we call _configValue manually.
+        if (node._configValue && !node._clientsReadied &&
+            !node.hasAttribute(attribute)) {
+          var property = Polymer.CaseMap.dashToCamelCase(attribute);
+          var pinfo = node._propertyInfo[property];
+          if (pinfo) {
+            value = node.deserialize(undefined, pinfo.type);
+            node._configValue(property, value);
+          }
+        } else {
+          node.removeAttribute(attribute);
+        }
+
       } else {
         node.setAttribute(attribute, str);
       }

--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -161,12 +161,10 @@ TODO(sjmiles): this module should produce either syntactic metadata
             this._discoverTemplateParentProps(note.templateContent._notes);
           var bindings = [];
           for (var prop in pp) {
-            var name = '_parent_' + prop;
             bindings.push({
               index: note.index,
               kind: 'property',
-              name: name,
-              propertyName: name,
+              name: '_parent_' + prop,
               parts: [{
                 mode: '{',
                 model: prop,

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -48,6 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // storage for configuration
     _setupConfigure: function(initialConfig) {
       this._config = {};
+      this.__effectsSkippedDuringConfig = {};
       this._handlers = [];
       this._aboveConfig = null;
       if (initialConfig) {
@@ -142,32 +143,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (var p in config) {
           var fx = fx$[p];
           if (fx) {
+            var skippedEffects = [];
             for (var i=0, l=fx.length, x; (i<l) && (x=fx[i]); i++) {
               // TODO(kschaaf): computed annotations are excluded from top-down
               // configure for now; to be revisited
               if (x.kind === 'annotation') {
-                var node = this._nodes[x.effect.index];
-                var name = x.effect.propertyName;
-                // seeding configuration only
-                var isAttr = (x.effect.kind == 'attribute');
-                var hasEffect = (node._propertyEffects &&
-                  node._propertyEffects[name]);
-                if (node._configValue && (hasEffect || !isAttr)) {
-                  var value = (p === x.effect.value) ? config[p] :
-                    this._get(x.effect.value, config);
-                  value = this._computeFinalAnnotationValue(node, name, value,
-                                                            x.effect);
-                  if (isAttr) {
-                    // For attribute bindings, flow through the same ser/deser
-                    // process to ensure the value is the same as if it were
-                    // bound through the attribute
-                    value = node.deserialize(this.serialize(value),
-                      node._propertyInfo[name].type);
-                  }
-                  node._configValue(name, value);
-                }
+                var path = x.effect.value;
+                var value = (path === p) ? config[p] : this._get(path, config);
+                x.fn.call(this, path, value, x.effect);
+              } else {
+                skippedEffects.push(x);
               }
             }
+            this.__effectsSkippedDuringConfig[p] = skippedEffects;
           }
         }
       }
@@ -181,17 +169,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._flushHandlers();
     },
 
-    // NOTE: values are already propagated to children via
-    // _distributeConfig so propagation triggered by effects here is
-    // redundant, but safe due to dirty checking
     _applyConfig: function(config, aboveConfig) {
       for (var n in config) {
         // Don't stomp on values that may have been set by other side effects
         if (this[n] === undefined) {
-          // Call _propertySet for any properties with accessors, which will
-          // initialize read-only properties also; set quietly if value was
-          // configured from above, as opposed to default
-          this.__setProperty(n, config[n], n in aboveConfig);
+          var effects = this.__effectsSkippedDuringConfig[n] || (
+            this._propertyEffects && this._propertyEffects[n]);
+          // Call _propertySetter for any properties with effects; set
+          // fromAbove if value was configured from above
+          if (effects) {
+            this._propertySetter(n, config[n], effects, n in aboveConfig);
+          } else {
+            this[n] = config[n];
+          }
         }
       }
     },

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -180,7 +180,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               kind: note.kind,
               index: index,
               name: note.name,
-              propertyName: note.propertyName,
               value: part.value,
               isCompound: note.isCompound,
               compoundIndex: part.compoundIndex,

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -338,10 +338,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (pinfo && pinfo.readOnly) {
           return;
         }
-        // Ideally we would call setProperty using fromAbove: true to avoid
-        // spinning the wheel needlessly, but we found that users were listening
-        // for change events outside of bindings
-        this.__setProperty(property, value, false, node);
+        this.__setProperty(property, value, true, node);
       }
     },
 

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -319,10 +319,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _applyEffectValue: function(info, value) {
-      var node = this._nodes[info.index];
-      var property = info.name;
-
+    _applyEffectValue: function(node, property, value, info) {
       value = this._computeFinalAnnotationValue(node, property, value, info);
 
       // For better interop, dirty check before setting when custom events

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -35,6 +35,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var prop = Polymer.Bind.addPropertyEffect(this, property, kind, effect);
       // memoize path function for faster lookup.
       prop.pathFn = this['_' + prop.kind + 'PathEffect'];
+      return prop;
+    },
+
+    _ensureOwnEffects: function(property) {
+      // Move the property effects from the prototype to the instance, so
+      // we can mutate them. We use prototypal inheritance here to go cheap.
+      var pE = this._propertyEffects;
+      if (pE) {
+        if (!this.hasOwnProperty('_propertyEffects')) {
+          pE = this._propertyEffects = Polymer.Base.chainObject({}, pE);
+        }
+
+        // Shallow-copy the effects array for this property, to the instance.
+        if (pE[property] && !pE.hasOwnProperty(property)) {
+          pE[property] = pE[property].slice();
+        }
+      }
+    },
+
+    addPropertyEffect: function(property, fn) {
+      this._ensureOwnEffects(property);
+
+      // We have to create the underlying trigger machinery here, if this is
+      // the first effect of the property.
+      var effects = Polymer.Bind.ensurePropertyEffects(this, property);
+      if (effects.length === 0) {
+        // The current value will be masked by the descriptor, read it ...
+        var val = this[property];
+        Polymer.Bind._createAccessors(this, property);
+        // ... and put it in our data store
+        this.__data__[property] = val;
+      }
+
+      // Theoretically the effects must be sorted again, but `function`-effects
+      // are executed last anyway, so we can skip this for now. NOTE that, if
+      // you add a custom effect inside another effect, t.i. the notification-
+      // loop is already running, mutating the effects in place like we do here
+      // would be usually catastrophic. This 'just' works b/c we prestore the
+      // loop-length in our for-loops (see `effectEffects`). Note as well that
+      // the  newly added effect will not be executed before the next
+      // notification we have to propagate. This is intended and a bonus point
+      // for appending only.
+      return this._addPropertyEffect(property, 'function', fn);
+    },
+
+    removePropertyEffect: function(fx) {
+      // Since effects can be removed as a side-effect, t.i. within a running
+      // effects-loop, we must ensure not to shorten the effects-array in
+      // place, otherwise the for-loop would break. On the other side removing
+      // an effect must be immediate, so we use a flag here to indicate that
+      // this effect should be skipped.
+      fx.disabled = true;
+
+      // We then slice and splice and reassign the effects-array. This new
+      // array will be used not before the next notification we have to
+      // propagate.
+      var property = fx.trigger;
+      var effects = property && this._propertyEffects &&
+                    this._propertyEffects[property];
+      if (effects) {
+        var index = effects.indexOf(fx);
+        if (index !== -1) {
+          effects = effects.slice();
+          effects.splice(index, 1);
+          this._propertyEffects[property] = effects;
+        }
+      }
     },
 
     // prototyping

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -87,15 +87,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      // Note: this implemetation only accepts key-based array paths
+      // Note: this implementation only accepts key-based array paths
       _notifyPath: function(path, value, fromAbove, origin, originalProperty) {
         // All path/value pairs are cached on `this.__data__`
         var old = this.__data__[path];
-        // manual dirty checking for now...
-        // NaN is always not equal to itself,
-        // if old and value are both NaN we treat them as equal
-        // x === x is 10x faster, and equivalent to !isNaN(x)
-        if (old !== value && (old === old || value === value)) {
+        if (this._isPropertyDirty(path, value, old) !== false) {
           this.__data__[path] = value;
           if (typeof value == 'object') {
             this._clearPath(path);

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -89,12 +89,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Note: this implemetation only accepts key-based array paths
       _notifyPath: function(path, value, fromAbove) {
-        var old = this._propertySetter(path, value);
+        // All path/value pairs are cached on `this.__data__`
+        var old = this.__data__[path];
         // manual dirty checking for now...
         // NaN is always not equal to itself,
         // if old and value are both NaN we treat them as equal
         // x === x is 10x faster, and equivalent to !isNaN(x)
         if (old !== value && (old === old || value === value)) {
+          this.__data__[path] = value;
+          if (typeof value == 'object') {
+            this._clearPath(path);
+          }
           // console.group((this.localName || this.dataHost.id + '-' + this.dataHost.dataHost.index) + '#' + (this.id || this.index) + ' ' + path, value);
           // Take path effects at this level for exact path matches,
           // and notify down for any bindings to a subset of this path

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -288,10 +288,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
         }
-        // notify runtime-bound paths
-        if (this._boundPaths) {
-          this._notifyBoundPaths(path, value);
-        }
       },
 
       _annotationPathEffect: function(path, value, effect, fromAbove,
@@ -363,14 +359,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       linkPaths: function(to, from) {
         this._boundPaths = this._boundPaths || {};
+
         if (from) {
-          this._boundPaths[to] = from;
+          this._boundPaths[to] = this._addLinkPathEffect(to, from);
           // this.set(to, this._get(from));
         } else {
           this.unlinkPaths(to);
           // this.set(to, from);
         }
       },
+
+      _addLinkPathEffect: function(to, from) {
+        var locked = false;
+        var makeLinkPathEffect = function(thisPath, thatPath) {
+          return function(path, value) {
+            if (locked) return;
+            // We only forward deep property changes, deeper than `thisPath`.
+            // Shouldn't we open this up?
+            if (path.indexOf(thisPath + '.') !== 0) return;
+
+            locked = true;
+            var newPath = this._fixPath(thatPath, thisPath, path)
+            try {
+              // Don't pass fromAbove et.al., we forward a notification as if
+              // it came from `this`, not from above or down under.
+              this._notifyPath(newPath, value);
+            } finally {
+              locked = false;
+            }
+          };
+        };
+
+        return [
+          this.addPropertyEffect(this._modelForPath(to),
+                                 makeLinkPathEffect(to, from)),
+          this.addPropertyEffect(this._modelForPath(from),
+                                 makeLinkPathEffect(from, to))
+        ];
+      },
+
 
       /**
        * Removes a data path alias previously established with `linkPaths`.
@@ -382,19 +409,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} path Target path to unlink.
        */
       unlinkPaths: function(path) {
-        if (this._boundPaths) {
-          delete this._boundPaths[path];
-        }
-      },
-
-      _notifyBoundPaths: function(path, value) {
-        for (var a in this._boundPaths) {
-          var b = this._boundPaths[a];
-          if (path.indexOf(a + '.') == 0) {
-            this._notifyPath(this._fixPath(b, a, path), value);
-          } else if (path.indexOf(b + '.') == 0) {
-            this._notifyPath(this._fixPath(a, b, path), value);
+        var fx = this._boundPaths && this._boundPaths[path];
+        if (fx) {
+          for (var i=0, l=fx.length; i<l; i++) {
+            this.removePropertyEffect(fx[i]);
           }
+          this._boundPaths[path] = undefined;
         }
       },
 

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -278,11 +278,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var fx$ = this._propertyEffects && this._propertyEffects[model];
         if (fx$) {
           for (var i=0, fx; (i<fx$.length) && (fx=fx$[i]); i++) {
-            // use memoized path functions
-            var fxFn = fx.pathFn;
-            if (fxFn) {
-              fxFn.call(this, path, value, fx.effect, fromAbove,
-                        origin, originalProperty);
+            if (!fx.disabled) {
+              // use memoized path functions
+              var fxFn = fx.pathFn;
+              if (fxFn) {
+                fxFn.call(this, path, value, fx.effect, fromAbove,
+                          origin, originalProperty);
+              }
             }
           }
         }
@@ -337,6 +339,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this._pathMatchesEffect(path, effect)) {
           Polymer.Bind._annotatedComputationEffect.call(this, path, value, effect);
         }
+      },
+
+      _functionPathEffect: function(path, value, effect, fromAbove) {
+        Polymer.Bind._functionEffect.call(this, path, value, effect,
+                                          undefined, fromAbove);
       },
 
       _pathMatchesEffect: function(path, effect) {

--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       // Note: this implemetation only accepts key-based array paths
-      _notifyPath: function(path, value, fromAbove) {
+      _notifyPath: function(path, value, fromAbove, origin, originalProperty) {
         // All path/value pairs are cached on `this.__data__`
         var old = this.__data__[path];
         // manual dirty checking for now...
@@ -103,7 +103,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // console.group((this.localName || this.dataHost.id + '-' + this.dataHost.dataHost.index) + '#' + (this.id || this.index) + ' ' + path, value);
           // Take path effects at this level for exact path matches,
           // and notify down for any bindings to a subset of this path
-          this._pathEffector(path, value);
+          this._pathEffector(path, value, fromAbove, origin, originalProperty);
           // Send event to notify the path change upwards
           // Optimization: don't notify up if we know the notification
           // is coming from above already (avoid wasted event dispatch)
@@ -155,12 +155,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {*} value Value to set at the specified path.
        * @param {Object=} root Root object from which the path is evaluated.
       */
-      set: function(path, value, root) {
-        var prop = root || this;
+      set: function(path, value, fromAbove, origin, originalProperty) {
         var parts = this._getPathParts(path);
-        var array;
-        var last = parts[parts.length-1];
         if (parts.length > 1) {
+          var prop = this;
+          var array;
+          var last = parts[parts.length-1];
           // Loop over path parts[0..n-2] and dereference
           for (var i=0; i<parts.length-1; i++) {
             var part = parts[i];
@@ -207,12 +207,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Set value to object at end of path
           prop[last] = value;
           // Notify observers of path change
-          if (!root) {
-            this._notifyPath(parts.join('.'), value);
-          }
+          this._notifyPath(parts.join('.'), value, fromAbove,
+                           origin, originalProperty);
         } else {
-          // Simple property set
-          prop[path] = value;
+          this.__setProperty(path, value, undefined, fromAbove,
+                             origin, originalProperty)
         }
       },
 
@@ -272,7 +271,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return prop;
       },
 
-      _pathEffector: function(path, value) {
+      _pathEffector: function(path, value, fromAbove, origin, originalProperty) {
         // get root property
         var model = this._modelForPath(path);
         // search property effects of the root property for 'annotation' effects
@@ -282,7 +281,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // use memoized path functions
             var fxFn = fx.pathFn;
             if (fxFn) {
-              fxFn.call(this, path, value, fx.effect);
+              fxFn.call(this, path, value, fx.effect, fromAbove,
+                        origin, originalProperty);
             }
           }
         }
@@ -292,17 +292,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      _annotationPathEffect: function(path, value, effect) {
-        if (effect.value === path || effect.value.indexOf(path + '.') === 0) {
+      _annotationPathEffect: function(path, value, effect, fromAbove,
+                                      origin, originalProperty) {
+
+        // Consider:
+        // <that-node that-property="{{ thisPath }}" />
+        var thatNode = this._nodes[effect.index];
+        var thatProperty = effect.name;
+        var thisPath = effect.value;
+
+        // Do not propagate downwards if the origin of this change is this
+        // exact binding
+        if (origin && originalProperty &&
+            origin === thatNode &&
+            originalProperty === thatProperty) {
+          return;
+        }
+
+        if (thisPath === path || thisPath.indexOf(path + '.') === 0) {
           // TODO(sorvell): ideally the effect function is on this prototype
           // so we don't have to call it like this.
           Polymer.Bind._annotationEffect.call(this, path, value, effect);
-        } else if ((path.indexOf(effect.value + '.') === 0) && !effect.negate) {
-          // locate the bound node
-          var node = this._nodes[effect.index];
-          if (node && node._notifyPath) {
-            var p = this._fixPath(effect.name , effect.value, path);
-            node._notifyPath(p, value, true);
+        } else if ((path.indexOf(thisPath + '.') === 0) && !effect.negate) {
+          if (thatNode && thatNode._notifyPath) {
+            var newPath = this._fixPath(thatProperty, thisPath, path);
+            thatNode._notifyPath(newPath, value, true);
           }
         }
       },

--- a/test/unit/attributes-elements.html
+++ b/test/unit/attributes-elements.html
@@ -26,7 +26,8 @@
       },
       string: {
         type: String,
-        value: 'none'
+        value: 'none',
+        notify: true
       },
       bool: {
         type: Boolean,

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -189,6 +189,17 @@ suite('imperative attribute change (no-reflect)', function() {
     assert.strictEqual(el.dashCase, 'Changed');
   });
 
+  test('setting an attribute does not echo upwards', function() {
+    var listener = sinon.spy();
+    el.addEventListener('string-changed', listener);
+
+    el.setAttribute('string', 'howdy');
+    assert.isFalse(listener.called);
+
+    el.removeAttribute('string');
+    assert.isFalse(listener.called);
+  });
+
 });
 
 suite('imperative attribute change (reflect)', function() {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -739,3 +739,6 @@
     });
   </script>
 </dom-module>
+<script>
+  Polymer({is: 'x-custom-effect'});
+</script>

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -713,3 +713,29 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-downwards-notification-does-not-echo">
+  <template>
+    <x-sender id="sender1" binding="{{foo}}"></x-sender>
+    <x-sender id="sender2" binding="{{foo.bar}}"></x-sender>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'x-downwards-notification-does-not-echo',
+      properties: {
+        foo: String
+      }
+    });
+
+    Polymer({
+      is: 'x-sender',
+      properties: {
+        binding: {
+          type: String,
+          notify: true
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -510,8 +510,7 @@ suite('2-way binding effects between elements', function() {
     el.$.basic1.addEventListener('notifyingvalue-changed', listener);
     el.boundnotifyingvalue = 678;
     assert.equal(el.$.basic1.notifyingvalue, 678);
-    assert.isTrue(listener.calledOnce);
-    assert.equal(listener.getCalls()[0].args[0].detail.value, 678);
+    assert.isFalse(listener.called);
   });
 
   test('negated binding update negates value for parent', function() {

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -1098,7 +1098,147 @@ suite('notifications do not echo', function() {
     assert.deepEqual(el.foo, {bar: {baz: 'anil'}});
     assert.equal(called, 1);
   });
+});
 
+suite('custom user effects', function() {
+
+  test('Add custom effect', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(path, 'foo');
+      assert.equal(value, 'bar');
+      assert.equal(old, undefined);
+    });
+
+    el.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Remove custom effect', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var fx = el.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    el.removePropertyEffect(fx);
+
+    el.foo = 'bar';
+    assert.equal(called, 0);
+  });
+
+  test('Ensure old values are sent', function() {
+    var el = document.createElement('x-custom-effect');
+    el.foo = 'bar';
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(old, 'bar');
+    });
+
+    el.foo = 'quux';
+    assert.equal(called, 1);
+  });
+
+  test('Ensure path effects can be seen', function() {
+    var el = document.createElement('x-custom-effect');
+    el.foo = {bar: 'quux'};
+
+    var called = 0;
+    el.addPropertyEffect('foo', function(path, value, old) {
+      called += 1;
+      assert.equal(path, 'foo.bar');
+      assert.equal(value, 'quod');
+      assert.equal(old, undefined);  // always undefined for structured paths!
+    });
+
+    el.set('foo.bar', 'quod');
+    assert.equal(called, 1);
+  });
+
+  test('Ensure independence', function() {
+    var el1 = document.createElement('x-custom-effect');
+    var called = 0;
+    el1.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    var el2 = document.createElement('x-custom-effect');
+
+    el2.foo = 'bar';
+    assert.equal(called, 0);
+  });
+
+  test('Ensure independence (property effects already created on prototype)',
+       function() {
+    Polymer({
+      is: 'x-custom-effect2',
+      properties: {
+        foo: {
+          observer: '_foo'
+        }
+      },
+      _foo: function(){}
+    });
+    var el1 = document.createElement('x-custom-effect2');
+
+    var called = 0;
+    el1.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+    el1.foo = 'bar';
+    assert.equal(called, 1);
+
+    var el2 = document.createElement('x-custom-effect2');
+    el2.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Removing an effect as a side-effect does not break the running ' +
+       'effect loop', function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var fx = el.addPropertyEffect('foo', function() {
+      el.removePropertyEffect(fx);
+    });
+    el.addPropertyEffect('foo', function() {
+      called += 1;
+    });
+
+    el.foo = 'bar';
+    assert.equal(called, 1);
+  });
+
+  test('Adding an effect as a side-effect does not invoke it immediately',
+       function() {
+    var el = document.createElement('x-custom-effect');
+
+    var called = 0;
+    var firstRun = true;
+    el.addPropertyEffect('foo', function() {
+      if (firstRun) {
+        el.addPropertyEffect('foo', function() {
+          called += 1;
+        });
+        firstRun = false;
+      }
+    });
+
+    el.foo = 'bar';
+    assert.equal(firstRun, false);
+    assert.equal(called, 0);
+
+    el.foo = 'quod';
+    assert.equal(called, 1);
+
+
+  });
 });
 
 </script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -1022,6 +1022,85 @@ suite('order of effects', function() {
   });
 });
 
+suite('notifications do not echo', function() {
+
+  test('upwards notification does not echo downwards (simple binding)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender1;
+
+    var called = 0;
+    sender._propertySetter = function() {
+      called += 1;
+    };
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.foo = 'quux';
+    assert.equal(called, 1);
+
+    // We can't use simple property assignment b/c we mocked that method
+    // above, so we do it manually
+    sender.__data__['binding'] = 'bar';
+    sender._notifyChange('binding');
+
+    assert.equal(el.foo, 'bar');
+    assert.equal(called, 1);
+  });
+
+  test('upwards notification does not echo downwards (deep binding)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender2;
+
+    var called = 0;
+    sender._propertySetter = function() {
+      called += 1;
+    };
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.foo = {bar: 'quux'};
+    assert.equal(called, 1);
+
+    // We can't use simple property assignment b/c we mocked that method
+    // above, so we do it manually
+    sender.__data__['binding'] = 'quod';
+    sender._notifyChange('binding');
+
+    assert.deepEqual(el.foo, {bar: 'quod'});
+    assert.equal(called, 1);
+  });
+
+  test('upwards notification does not echo downwards (path notification)',
+       function() {
+    var el = document.createElement('x-downwards-notification-does-not-echo');
+    var sender = el.$.sender2;
+
+    var called = 0;
+    sender._notifyPath = function() {
+      called += 1;
+    };
+
+    // Ensure that the object at foo is completely shared between both
+    // instances
+    sender.__data__['binding'] = {baz: 'quux'};
+    el.foo = {bar: sender.__data__['binding']};
+
+    // ensure 'private' API is actually used, in case we refactor
+    el.set('foo.bar.baz', 'quod');
+    assert.equal(called, 1);
+    // Ensure object is shared data
+    assert.equal(sender.binding.baz, 'quod');
+
+    // We can't use set b/c we mocked _notifyPath
+    sender.binding.baz = 'anil';
+    sender._notifyPathUp('binding.baz', 'anil');
+
+    assert.deepEqual(el.foo, {bar: {baz: 'anil'}});
+    assert.equal(called, 1);
+  });
+
+});
+
 </script>
 
 </body>

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -97,7 +97,7 @@
     },
     _forwardParentProp: function(prop, value) {
       if (this.instance) {
-        this.instance[prop] = value;
+        this.instance.__setProperty(prop, value, true);
       }
     },
     _forwardParentPath: function(path, value) {
@@ -165,7 +165,7 @@
     },
     _forwardParentProp: function(prop, value) {
       if (this.instance) {
-        this.instance[prop] = value;
+        this.instance.__setProperty(prop, value, true);
       }
     },
     _forwardParentPath: function(path, value) {


### PR DESCRIPTION
To come to an end here. Assembles the following PRs:
- Ensure fromAbove in _forwardParentProp. #3592
- Ensure fromAbove for downwards bindings. #3593
- Upwards notifications should not echo downwards #3550
- Run each effect exactly once during config #3590
- Bare minimum for custom effects (take 2) #3573
- Implement linkPath as (custom) property effect. #3547

Then we can just remove the dirty check for object values https://github.com/Polymer/polymer/pull/3596/commits/6d24b87dca8f1dc8da868b83038852b7d29dde10.

Related #3343.
