### PR TITLE
Fix _patchMatchesEffect.

### DIFF
--- a/src/standard/notify-path.html
+++ b/src/standard/notify-path.html
@@ -324,7 +324,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var effectArg = effect.trigger.name;
         return (effectArg == path) ||
           (effectArg.indexOf(path + '.') === 0) ||
-          (effect.trigger.wildcard && path.indexOf(effectArg) === 0);
+          (effect.trigger.wildcard && path.indexOf(effectArg + '.') === 0);
       },
 
       /**

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -950,6 +950,38 @@ suite('path API', function() {
     arraysEqual(el.array, [-1, 99, 2, 3]);
   });
 
+  test('patch matches effect', function() {
+    var effect = {
+      trigger: {
+        name: 'foo.bar'
+      }
+    };
+
+    assert.isTrue(el._pathMatchesEffect('foo', effect));
+    assert.isTrue(el._pathMatchesEffect('foo.bar', effect));
+
+    assert.notOk(el._pathMatchesEffect('bar', effect));
+    assert.notOk(el._pathMatchesEffect('foobar', effect));
+    assert.notOk(el._pathMatchesEffect('foo.bar.baz', effect));
+    assert.notOk(el._pathMatchesEffect('foo.baz', effect));
+
+    effect = {
+      trigger: {
+        name: 'foo.bar',
+        wildcard: true
+      }
+    };
+
+    assert.isTrue(el._pathMatchesEffect('foo', effect));
+    assert.isTrue(el._pathMatchesEffect('foo.bar', effect));
+    assert.isTrue(el._pathMatchesEffect('foo.bar.baz', effect));
+
+    assert.notOk(el._pathMatchesEffect('foobar', effect));
+    assert.notOk(el._pathMatchesEffect('foo.bars', effect));
+    assert.notOk(el._pathMatchesEffect('foo.baz', effect));
+
+  });
+
 });
 
 suite('malformed observers', function() {


### PR DESCRIPTION
Listening for `foo.bar.*` should not trigger for `foo.bars`.