### PR TITLE
Strawman for `setMultipleProperties`

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -87,8 +87,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.__data__[prop] = undefined;
           }
         }
-      }
+      },
 
+      /**
+       * Updates a set of properties atomically, such that there is no
+       * observable time in which some but not all of the properties are
+       * updated.
+       *
+       * Takes an object mapping property names to their new values. Does not
+       * currently support updating nested properties like 'x.y'.
+       */
+      setMultipleProperties: function(propsObj) {
+        for (var prop in propsObj) {
+          this._propertySetter(prop, propsObj[prop]);
+        }
+
+        for (var prop in propsObj) {
+          var value = propsObj[prop];
+          this._pathEffector(prop, value);
+          this._notifyPathUp(prop, value);
+        }
+      }
     },
 
     // a prepared model can acquire effects

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -713,3 +713,40 @@
     });
   </script>
 </dom-module>
+
+<dom-module id="x-set-multi">
+  <script>
+    Polymer({
+      is: 'x-set-multi',
+      properties: {
+        x: {
+          type: Number,
+          value: 0,
+          observer: 'xChanged'
+        },
+        twoX: {
+          type: Number,
+          notify: true
+        },
+        threeX: {
+          type: Number,
+          notify: true
+        },
+        obj: {
+          type: Object,
+          value: function() {
+            return {}
+          },
+          notify: true
+        }
+      },
+      xChanged: function(x) {
+        this.setMultipleProperties({
+          twoX: x * 2,
+          threeX: x * 3,
+          obj: {x: x},
+        });
+      }
+    })
+  </script>
+</dom-module>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -997,6 +997,31 @@ suite('compound binding / string interpolation', function() {
 
 });
 
+suite('setting multiple properties atomically', function() {
+  var el;
+  setup(function() {
+    el = document.createElement('x-set-multi');
+  });
+
+  test('no change notifications are fired until all changes are made', function() {
+    var changesSeen = 0;
+    function testConsistency() {
+      changesSeen++;
+      assert.equal(el.twoX, 2 * el.x);
+      assert.equal(el.threeX, 3 * el.x);
+      assert.equal(el.obj.x, el.x);
+    }
+    el.addEventListener('two-x-changed', testConsistency);
+    el.addEventListener('three-x-changed', testConsistency);
+    el.addEventListener('obj-changed', testConsistency);
+
+    el.x = 1;
+    assert.equal(changesSeen, 3);
+    el.x = 5;
+    assert.equal(changesSeen, 6);
+  });
+});
+
 suite('order of effects', function() {
 
   var el;


### PR DESCRIPTION
Adds a method to Polymer.Base for setting multiple properties atomically, such
that there's no externally visible time when some but not all of the given
properties have been set.

Fixes #3640
