### PR TITLE
Fixes 3661

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -417,8 +417,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (!style) {
             // apply css after the scope style of the element to help with
             // style precedence rules.
-            style = styleUtil.applyCss(cssText, selector, null,
-              element._scopeStyle);
+            if (cssText) {
+              style = styleUtil.applyCss(cssText, selector, null,
+                element._scopeStyle);
+            }
           // shady and cache hit but not in document
           } else if (!style.parentNode) {
             styleUtil.applyStyle(style, null, element._scopeStyle);

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -409,8 +409,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } else if (cssText) {
             // apply css after the scope style of the element to help with
             // style precedence rules.
-            style = styleUtil.applyCss(cssText, selector, element.root, 
-              element._scopeStyle);
+            style = styleUtil.applyCss(cssText, selector, element.root);
           }
         } else {
           // shady and no cache hit

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -400,18 +400,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // apply styling always under native or if we generated style
         // or the cached style is not in document(!)
-        if (nativeShadow || (!style || !style.parentNode)) {
+        if (nativeShadow) {
           // update existing style only under native
-          if (nativeShadow && element._customStyle) {
+          if (element._customStyle) {
             element._customStyle.textContent = cssText;
             style = element._customStyle;
           // otherwise, if we have css to apply, do so
           } else if (cssText) {
             // apply css after the scope style of the element to help with
             // style precedence rules.
-            style = styleUtil.applyCss(cssText, selector,
-              nativeShadow ? element.root : null, element._scopeStyle);
+            style = styleUtil.applyCss(cssText, selector, element.root, 
+              element._scopeStyle);
           }
+        } else {
+          // shady and no cache hit
+          if (!style) {
+            // apply css after the scope style of the element to help with
+            // style precedence rules.
+            style = styleUtil.applyCss(cssText, selector, null,
+              element._scopeStyle);
+          // shady and cache hit but not in document
+          } else if (!style.parentNode) {
+            styleUtil.applyStyle(style, null, element._scopeStyle);
+          }
+
         }
         // ensure this style is our custom style and increment its use count.
         if (style) {
@@ -424,7 +436,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         return style;
       },
-
+      
       // customStyle properties are applied if they are truthy or 0. Otherwise,
       // they are skipped; this allows properties previously set in customStyle
       // to be easily reset to inherited values.

--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -79,6 +79,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // add a string of cssText to the document.
       applyCss: function(cssText, moniker, target, contextNode) {
         var style = this.createScopeStyle(cssText, moniker);
+        return this.applyStyle(style, target, contextNode);
+      },
+
+      applyStyle: function(style, target, contextNode) {
         target = target || document.head;
         var after = (contextNode && contextNode.nextSibling) || 
           target.firstChild;

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -187,6 +187,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._styleProperties, this._scopeSelector, info && info.style);
         // apply scope selector
         if (!nativeShadow) {
+          // update cached style to point to new style.
+          // TODO(sorvell): under ShadyDOM, the cached style is 
+          // used to style the element and the cache must be updated to point
+          // to the 'active' style so elements can determine if updates are needed.
+          // This is not the case under Shadow DOM. Ideally the cache 
+          // would be decoupled from style application/use.
+          if (info) {
+            info.style = style;
+          }
           propertyUtils.applyElementScopeSelector(this, this._scopeSelector,
             oldScopeSelector, this._scopeCssViaAttr);
         }

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -187,15 +187,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._styleProperties, this._scopeSelector, info && info.style);
         // apply scope selector
         if (!nativeShadow) {
-          // update cached style to point to new style.
-          // TODO(sorvell): under ShadyDOM, the cached style is 
-          // used to style the element and the cache must be updated to point
-          // to the 'active' style so elements can determine if updates are needed.
-          // This is not the case under Shadow DOM. Ideally the cache 
-          // would be decoupled from style application/use.
-          if (info) {
-            info.style = style;
-          }
           propertyUtils.applyElementScopeSelector(this, this._scopeSelector,
             oldScopeSelector, this._scopeCssViaAttr);
         }

--- a/test/unit/attach-detach-timing.html
+++ b/test/unit/attach-detach-timing.html
@@ -52,22 +52,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <attach-detach id="ad"></attach-detach>
     <script>
-    var ad = document.getElementById('ad');
-    ad.remove();
-    var el = document.createElement('attach-detach');
-    document.body.appendChild(el);
-    el.remove();
-    test('attach() and detach() are correct for upgraded elements', function() {
-      checkOrder(ad);
-    });
-    test('attach() and detach() are correct for imperative elements', function() {
-      checkOrder(el);
-    });
-    test('attach() and detach() are correct for elements made after load', function() {
-      var e = document.createElement('attach-detach');
-      document.body.appendChild(e);
-      e.remove();
-      checkOrder(e);
+    suite('attached-detached timing', function() {
+
+      var ad = document.getElementById('ad');
+      ad.remove();
+      var el = document.createElement('attach-detach');
+      document.body.appendChild(el);
+      el.remove();
+      
+      test('attach() and detach() are correct for upgraded elements', function(done) {
+        Polymer.RenderStatus.whenReady(function() {
+          checkOrder(ad);
+          done();
+        });
+      });
+      test('attach() and detach() are correct for imperative elements', function(done) {
+        Polymer.RenderStatus.whenReady(function() {
+          checkOrder(el);
+          done();
+        });
+      });
+      test('attach() and detach() are correct for elements made after load', function(done) {
+        Polymer.RenderStatus.whenReady(function() {
+          var e = document.createElement('attach-detach');
+          document.body.appendChild(e);
+          e.remove();
+          checkOrder(e);
+          done();
+        });
+      });
     });
     </script>
   </body>

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -250,7 +250,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         child-of-child-with-var {
           /* in certain browsers (e.g. Safari) `top`, `bottom`, `left`, `right` don't compute
              when no explicit position is defined (`relative` / `absolute` / `fixed`) */
-          position: relative;
+          position: absolute;
           --variable-own-line: "Varela font";
           margin-top: var(--variable-property-own-line);
           margin-bottom: var(--variable-property-preceded-property);
@@ -259,6 +259,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           --variable-assignment-before-property: 7px; padding-bottom: var(--variable-property-after-assignment);
           padding-left: var(--variable-property-before-assignment);--variable-assignment-after-property: 8px;
           top: 12px;--variable-from-other-variable: var(--variable-into-first-variable);--variable-from-another-variable: var(--variable-into-second-variable); --variable-from-last-variable: var(--variable-into-third-variable);
+          height: 20px;
         }
       </style>
       <child-of-child-with-var id="child"></child-of-child-with-var>

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -250,7 +250,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         child-of-child-with-var {
           /* in certain browsers (e.g. Safari) `top`, `bottom`, `left`, `right` don't compute
              when no explicit position is defined (`relative` / `absolute` / `fixed`) */
-          position: absolute;
+          position: relative;
           --variable-own-line: "Varela font";
           margin-top: var(--variable-property-own-line);
           margin-bottom: var(--variable-property-preceded-property);

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -67,12 +67,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           padding: 8px;
           border: var(--scope-var);
         }
+
+        :host(.foo) {
+          border: var(--scope-var-foo);
+        }
       </style>
       Host property
     </template>
     <script>
     HTMLImports.whenReady(function() {
       Polymer({is: 'x-host-property'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-host-host-property">
+    <template>
+      <x-host-property id="hosted"></x-host-property>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-host-host-property'});
+    });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-produce-use-property">
+    <template>
+      <style>
+        :host {
+          --scope-var: 6px solid steelblue;
+          --scope-var-foo: 8px solid steelblue;
+        }
+      </style>
+      <x-host-host-property id="hosted"></x-host-host-property>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({is: 'x-produce-use-property'});
     });
     </script>
   </dom-module>
@@ -771,6 +803,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     assertComputed(styled.$.child.$.me, '2px');
   });
+
+  test('Nested element uses style cache when attached and updateStyles is called', function() {
+    var l = document.querySelectorAll('style').length;
+    var e1 = document.createElement('x-produce-use-property');
+    var e1t = e1.$.hosted.$.hosted;
+    var e2 = document.createElement('x-produce-use-property');
+    var e2t = e2.$.hosted.$.hosted;
+    document.body.appendChild(e1);
+    document.body.appendChild(e2);
+    CustomElements.takeRecords();
+    if (styled.shadyRoot) {
+      assert.equal(document.querySelectorAll('style').length, l+1);
+    }
+    assertComputed(e1t, '6px');
+    assertComputed(e2t, '6px');
+    e1.customStyle['--scope-var'] = '8px solid purple';
+    e2.customStyle['--scope-var'] = '8px solid purple';
+    Polymer.updateStyles();
+    assertComputed(e1t, '8px');
+    assertComputed(e2t, '8px');
+    if (styled.shadyRoot) {
+      assert.equal(document.querySelectorAll('style').length, l+1);
+    }
+    e1.customStyle['--scope-var'] = null;
+    e2.customStyle['--scope-var'] = null;
+    Polymer.updateStyles();
+    assertComputed(e1t, '6px');
+    assertComputed(e2t, '6px');
+    if (styled.shadyRoot) {
+      assert.equal(document.querySelectorAll('style').length, l+1);
+    }
+  })
 
   test('updateStyles changes own properties based on customStyle changes', function() {
     styled.$.child.customStyle['--child-scope-var'] = '30px solid orange';


### PR DESCRIPTION
Ensure cached style points to applied/active style under Shady DOM. This prevents extra unnecessary styles from spamming the document when changes are made to properties affecting nested elements.