### PR TITLE
Allow more whitespace in style include attribute

### DIFF
--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -163,10 +163,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       cssFromModules: function(moduleIds, warnIfNotFound) {
-        var modules = moduleIds.trim().split(' ');
+        var modules = moduleIds.trim().split(/\s/);
         var cssText = '';
         for (var i=0; i < modules.length; i++) {
-          cssText += this.cssFromModule(modules[i], warnIfNotFound);
+          if (modules[i]) {
+            cssText += this.cssFromModule(modules[i], warnIfNotFound);
+          }
         }
         return cssText;
       },


### PR DESCRIPTION
Style tags can grow beyond 80 characters:

```
<style include="my-custom-element-shared-styles iron-flex iron-flex-reverse
    iron-flex-alignment iron-positioning">
```

which leads to a bunch of warnings (the first one because the supposed module ID includes a newline):

> Could not find style data in module named iron-flex-reverse
> 
> Could not find style data in module named
> Could not find style data in module named
> Could not find style data in module named
> Could not find style data in module named

So split on _any_ whitespace, and ignore empty strings after splitting.
