### PR TITLE
fix-binding undefined value of property

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -44,8 +44,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var old = this.__data__[property];
         // NaN is always not equal to itself,
         // if old and value are both NaN we treat them as equal
-        // x === x is 10x faster, and equivalent to !isNaN(x)
-        if (old !== value && (old === old || value === value)) {
+		// x === x is 10x faster, and equivalent to !isNaN(x)
+		// !undefined === true so we have to treet also properties with undefined values.
+        if ((old !== value && (old === old || value === value)) || value === undefined) {
           this.__data__[property] = value;
           if (typeof value == 'object') {
             this._clearPath(property);


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
https://github.com/Polymer/polymer/issues/3684

the problem is that old at the beginning is undefined. If value===undefined 
then old===value. 
We have to consider the situation  that 
effect.negate===true  && value == undefined -> !undefined ===true  

but old===value so not change occur.

