### PR TITLE
Do not scope cache elements with media rules, :host(), or :host-context() selectors

### DIFF
--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -19,7 +19,11 @@ Polymer.CssParse = (function() {
     // given a string of css, return a simple rule tree
     parse: function(text) {
       text = this._clean(text);
-      return this._parseCss(this._lex(text), text);
+      var info = {
+        styleIndex: 0,
+        mediaIndex: 0
+      };
+      return this._parseCss(this._lex(text), text, info);
     },
 
     // remove stuff we don't care about that may hinder parsing
@@ -54,7 +58,7 @@ Polymer.CssParse = (function() {
     },
 
     // add selectors/cssText to node tree
-    _parseCss: function(node, text) {
+    _parseCss: function(node, text, info) {
       var t = text.substring(node.start, node.end-1);
       node.parsedCssText = node.cssText = t.trim();
       if (node.parent) {
@@ -71,6 +75,7 @@ Polymer.CssParse = (function() {
         if (node.atRule) {
           if (s.indexOf(this.MEDIA_START) === 0) {
             node.type = this.types.MEDIA_RULE;
+            node.index = info.mediaIndex++;
           } else if (s.match(this._rx.keyframesRule)) {
             node.type = this.types.KEYFRAMES_RULE;
             node.keyframesName =
@@ -81,13 +86,14 @@ Polymer.CssParse = (function() {
             node.type = this.types.MIXIN_RULE;
           } else {
             node.type = this.types.STYLE_RULE;
+            node.index = info.styleIndex++;
           }
         }
       }
       var r$ = node.rules;
       if (r$) {
         for (var i=0, l=r$.length, r; (i<l) && (r=r$[i]); i++) {
-          this._parseCss(r, text);
+          this._parseCss(r, text, info);
         }
       }
       return node;

--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -19,11 +19,7 @@ Polymer.CssParse = (function() {
     // given a string of css, return a simple rule tree
     parse: function(text) {
       text = this._clean(text);
-      var info = {
-        styleIndex: 0,
-        mediaIndex: 0
-      };
-      return this._parseCss(this._lex(text), text, info);
+      return this._parseCss(this._lex(text), text);
     },
 
     // remove stuff we don't care about that may hinder parsing
@@ -58,7 +54,7 @@ Polymer.CssParse = (function() {
     },
 
     // add selectors/cssText to node tree
-    _parseCss: function(node, text, info) {
+    _parseCss: function(node, text) {
       var t = text.substring(node.start, node.end-1);
       node.parsedCssText = node.cssText = t.trim();
       if (node.parent) {
@@ -75,7 +71,6 @@ Polymer.CssParse = (function() {
         if (node.atRule) {
           if (s.indexOf(this.MEDIA_START) === 0) {
             node.type = this.types.MEDIA_RULE;
-            node.index = info.mediaIndex++;
           } else if (s.match(this._rx.keyframesRule)) {
             node.type = this.types.KEYFRAMES_RULE;
             node.keyframesName =
@@ -86,14 +81,13 @@ Polymer.CssParse = (function() {
             node.type = this.types.MIXIN_RULE;
           } else {
             node.type = this.types.STYLE_RULE;
-            node.index = info.styleIndex++;
           }
         }
       }
       var r$ = node.rules;
       if (r$) {
         for (var i=0, l=r$.length, r; (i<l) && (r=r$[i]); i++) {
-          this._parseCss(r, text, info);
+          this._parseCss(r, text);
         }
       }
       return node;

--- a/src/lib/style-defaults.html
+++ b/src/lib/style-defaults.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       get _styleProperties() {
         if (!this._properties) {
           // force rules to reparse since they may be out of date
-          styleProperties.decorateStyles(this._styles, this._element);
+          styleProperties.decorateStyles(this._styles, this);
           // NOTE: reset cache for own properties; it may have been set when
           // an element in an import applied styles (e.g. custom-style)
           this._styles._scopeStyleProperties = null;

--- a/src/lib/style-defaults.html
+++ b/src/lib/style-defaults.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       get _styleProperties() {
         if (!this._properties) {
           // force rules to reparse since they may be out of date
-          styleProperties.decorateStyles(this._styles);
+          styleProperties.decorateStyles(this._styles, this._element);
           // NOTE: reset cache for own properties; it may have been set when
           // an element in an import applied styles (e.g. custom-style)
           this._styles._scopeStyleProperties = null;

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -28,17 +28,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // decorates styles with rule info and returns an array of used style
       // property names
       decorateStyles: function(styles, scope) {
-        var self = this, props = {}, keyframes = [];
-        // assume all styles are cacheable
-        for (var idx = 0; i < styles.length; i++) {
-          styles[idx]._cacheable = true;
-        }
+        var self = this, props = {}, keyframes = [], styleIndex = 0;
         styleUtil.forRulesInStyles(styles, function(rule, style) {
           self.decorateRule(rule);
+          // mark in-order position of ast rule in styles block, used for cache key
+          rule.index = styleIndex++;
           self.walkHostAndRootProperties(scope, rule, style, function(info) {
             // we can't cache styles with :host and :root props in @media rules
             if (rule.parent.type === styleUtil.ruleTypes.MEDIA_RULE) {
-              style._cacheable = false;
+              scope._notCacheable = true;
             }
             if (info.isHost) {
               // check if the selector is in the form of `:host-context()` or `:host()`
@@ -46,7 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               var hostContextOrFunction = info.selector.split(' ').some(function(s) {
                 return s.indexOf(scope.is) === 0 && s.length !== scope.is.length;
               });
-              style._cacheable = style._cacheable && !hostContextOrFunction;
+              scope._notCacheable = scope._notCacheable || hostContextOrFunction;
             }
           });
           self.collectPropertiesInCssText(rule.propertyInfo.cssText, props);

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -27,10 +27,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // decorates styles with rule info and returns an array of used style
       // property names
-      decorateStyles: function(styles) {
+      decorateStyles: function(styles, scope) {
         var self = this, props = {}, keyframes = [];
-        styleUtil.forRulesInStyles(styles, function(rule) {
+        // assume all styles are cacheable
+        for (var idx = 0; i < styles.length; i++) {
+          styles[idx]._cacheable = true;
+        }
+        styleUtil.forRulesInStyles(styles, function(rule, style) {
           self.decorateRule(rule);
+          self.walkHostAndRootProperties(scope, rule, style, function(info) {
+            // we can't cache styles with :host and :root props in @media rules
+            if (rule.parent.type === styleUtil.ruleTypes.MEDIA_RULE) {
+              style._cacheable = false;
+            }
+            if (info.isHost) {
+              // check if the selector is in the form of `:host-context()` or `:host()`
+              // if so, this style is not cacheable
+              var hostContextOrFunction = info.selector.split(' ').some(function(s) {
+                return s.indexOf(scope.is) === 0 && s.length !== scope.is.length;
+              });
+              style._cacheable = style._cacheable && !hostContextOrFunction;
+            }
+          });
           self.collectPropertiesInCssText(rule.propertyInfo.cssText, props);
         }, function onKeyframesRule(rule) {
           keyframes.push(rule);
@@ -231,7 +249,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       propertyDataFromStyles: function(styles, element) {
         var props = {}, self = this;
         // generates a unique key for these matches
-        var o = [], i = 0;
+        var o = [];
         // note: active rules excludes non-matching @media rules
         styleUtil.forActiveRulesInStyles(styles, function(rule) {
           // TODO(sorvell): we could trim the set of rules at declaration
@@ -247,71 +265,80 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             if (matchesSelector.call(element, selectorToMatch)) {
               self.collectProperties(rule, props);
               // produce numeric key for these matches for lookup
-              addToBitMask(i, o);
+              addToBitMask(rule.index, o);
             }
           }
-          i++;
         });
         return {properties: props, key: o};
+      },
+
+      walkHostAndRootProperties: function(scope, rule, style, callback) {
+        if (!rule.propertyInfo) {
+          self.decorateRule(rule);
+        }
+        if (!rule.propertyInfo.properties) {
+          return;
+        }
+        var hostScope = scope.is ?
+        styleTransformer._calcHostScope(scope.is, scope.extends) :
+        'html';
+        var parsedSelector = rule.parsedSelector;
+        var isRoot = parsedSelector === ':root';
+        var isHost = parsedSelector.indexOf(':host') === 0;
+        // build info is either in scope (when scope is an element) or in the style
+        // when scope is the default scope; note: this allows default scope to have
+        // mixed mode built and unbuilt styles.
+        var cssBuild = scope.__cssBuild || style.__cssBuild;
+        if (cssBuild === 'shady') {
+          // :root -> x-foo > *.x-foo for elements and html for custom-style
+          isRoot = parsedSelector === (hostScope + '> *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
+          // :host -> x-foo for elements, but sub-rules have .x-foo in them
+          isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
+        }
+        if (cssBuild === 'shadow') {
+          isRoot = parsedSelector === ':host > *' || parsedSelector === 'html';
+          isHost = isHost && !isRoot;
+        }
+        if (!isRoot && !isHost) {
+          return;
+        }
+        var selectorToMatch = hostScope;
+        if (isHost) {
+          // need to transform :host under ShadowDOM because `:host` does not work with `matches`
+          if (settings.useNativeShadow && !rule.transformedSelector) {
+            // transform :host into a matchable selector
+            rule.transformedSelector =
+            styleTransformer._transformRuleCss(
+              rule,
+              styleTransformer._transformComplexSelector,
+              scope.is,
+              hostScope
+            );
+          }
+          selectorToMatch = rule.transformedSelector || hostScope;
+        }
+        callback({
+          selector: selectorToMatch,
+          isHost: isHost,
+          isRoot: isRoot
+        });
       },
 
       hostAndRootPropertiesForScope: function(scope) {
         var hostProps = {}, rootProps = {}, self = this;
         // note: active rules excludes non-matching @media rules
         styleUtil.forActiveRulesInStyles(scope._styles, function(rule, style) {
-          if (!rule.propertyInfo) {
-            self.decorateRule(rule);
-          }
-          if (!rule.propertyInfo.properties) {
-            return;
-          }
-          var hostScope = scope.is ?
-            styleTransformer._calcHostScope(scope.is, scope.extends) :
-             'html';
-          var parsedSelector = rule.parsedSelector;
-          var isRoot = parsedSelector === ':root';
-          var isHost = parsedSelector.indexOf(':host') === 0;
-          // build info is either in scope (when scope is an element) or in the style
-          // when scope is the default scope; note: this allows default scope to have
-          // mixed mode built and unbuilt styles.
-          var cssBuild = scope.__cssBuild || style.__cssBuild;
-          if (cssBuild === 'shady') {
-            // :root -> x-foo > *.x-foo for elements and html for custom-style
-            isRoot = parsedSelector === (hostScope + '> *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
-            // :host -> x-foo for elements, but sub-rules have .x-foo in them
-            isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
-          }
-          if (cssBuild === 'shadow') {
-            isRoot = parsedSelector === ':host > *' || parsedSelector === 'html';
-            isHost = isHost && !isRoot;
-          }
-          if (!isRoot && !isHost) {
-            return;
-          }
-          var selectorToMatch = hostScope;
-          if (isHost) {
-            // need to transform :host under ShadowDOM because `:host` does not work with `matches`
-            if (settings.useNativeShadow && !rule.transformedSelector) {
-              // transform :host into a matchable selector
-              rule.transformedSelector =
-                styleTransformer._transformRuleCss(
-                  rule,
-                  styleTransformer._transformComplexSelector,
-                  scope.is,
-                  hostScope
-                );
-            }
-            selectorToMatch = rule.transformedSelector || hostScope;
-          }
           // if scope is StyleDefaults, use _element for matchesSelector
-          var element = scope._element || scope;
-          if (matchesSelector.call(element, selectorToMatch)) {
-            if (isHost) {
-              self.collectProperties(rule, hostProps);
-            } else {
-              self.collectProperties(rule, rootProps);
+          self.walkHostAndRootProperties(scope, rule, style, function(info) {
+            var element = scope._element || scope;
+            if (matchesSelector.call(element, info.selector)) {
+              if (info.isHost) {
+                self.collectProperties(rule, hostProps);
+              } else {
+                self.collectProperties(rule, rootProps);
+              }
             }
-          }
+          });
         });
         return {rootProps: rootProps, hostProps: hostProps};
       },

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -28,12 +28,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // decorates styles with rule info and returns an array of used style
       // property names
       decorateStyles: function(styles, scope) {
-        var self = this, props = {}, keyframes = [], styleIndex = 0;
+        var self = this, props = {}, keyframes = [], ruleIndex = 0;
         styleUtil.forRulesInStyles(styles, function(rule, style) {
           self.decorateRule(rule);
           // mark in-order position of ast rule in styles block, used for cache key
-          rule.index = styleIndex++;
-          self.walkHostAndRootProperties(scope, rule, style, function(info) {
+          rule.index = ruleIndex++;
+          self.whenHostOrRootRule(scope, rule, style, function(info) {
             // we can't cache styles with :host and :root props in @media rules
             if (rule.parent.type === styleUtil.ruleTypes.MEDIA_RULE) {
               scope._notCacheable = true;
@@ -270,7 +270,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
-      walkHostAndRootProperties: function(scope, rule, style, callback) {
+      whenHostOrRootRule: function(scope, rule, style, callback) {
         if (!rule.propertyInfo) {
           self.decorateRule(rule);
         }
@@ -327,7 +327,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // note: active rules excludes non-matching @media rules
         styleUtil.forActiveRulesInStyles(scope._styles, function(rule, style) {
           // if scope is StyleDefaults, use _element for matchesSelector
-          self.walkHostAndRootProperties(scope, rule, style, function(info) {
+          self.whenHostOrRootRule(scope, rule, style, function(info) {
             var element = scope._element || scope;
             if (matchesSelector.call(element, info.selector)) {
               if (info.isHost) {

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         } else {
           this._ownStylePropertyNames = this._styles && this._styles.length ?
-            propertyUtils.decorateStyles(this._styles) :
+            propertyUtils.decorateStyles(this._styles, this) :
             null;
         }
       },
@@ -144,9 +144,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             _scopeSelector: this._scopeSelector,
             _styleProperties: this._styleProperties
           };
-          scopeData.key.customStyle = {};
-          this.mixin(scopeData.key.customStyle, this.customStyle);
-          scope._styleCache.store(this.is, info, scopeData.key, this._styles);
+          // the scope cache does not evaluate if @media rules, :host(), or :host-context() rules defined in this element have changed
+          // therefore, if we detect those rules, we opt-out of the scope cache
+          var scopeCacheable = this._styles.every(function(s) {
+            return s._cacheable;
+          });
+          if (scopeCacheable) {
+            scopeData.key.customStyle = {};
+            this.mixin(scopeData.key.customStyle, this.customStyle);
+            scope._styleCache.store(this.is, info, scopeData.key, this._styles);
+          }
+          // global cache key is all property values consumed in this element,
+          // we _can_ use the global cache with @media, :host(), and :host-context() rules, as _computeStyleProperties will determine if those properties have changed
           if (!globalCached) {
             // save in global cache
             styleCache.store(this.is, Object.create(info), this._ownStyleProperties,

--- a/src/standard/x-styling.html
+++ b/src/standard/x-styling.html
@@ -107,9 +107,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         var scopeData = propertyUtils
           .propertyDataFromStyles(scope._styles, this);
+        // the scope cache does not evaluate if @media rules, :host(), or :host-context() rules defined in this element have changed
+        // therefore, if we detect those rules, we opt-out of the scope cache
+        var scopeCacheable = !this._notCacheable;
         // look in scope cache
-        scopeData.key.customStyle = this.customStyle;
-        info = scope._styleCache.retrieve(this.is, scopeData.key, this._styles);
+        if (scopeCacheable) {
+          scopeData.key.customStyle = this.customStyle;
+          info = scope._styleCache.retrieve(this.is, scopeData.key, this._styles);
+        }
         // compute style properties (fast path, if cache hit)
         var scopeCached = Boolean(info);
         if (scopeCached) {
@@ -144,11 +149,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             _scopeSelector: this._scopeSelector,
             _styleProperties: this._styleProperties
           };
-          // the scope cache does not evaluate if @media rules, :host(), or :host-context() rules defined in this element have changed
-          // therefore, if we detect those rules, we opt-out of the scope cache
-          var scopeCacheable = this._styles.every(function(s) {
-            return s._cacheable;
-          });
           if (scopeCacheable) {
             scopeData.key.customStyle = {};
             this.mixin(scopeData.key.customStyle, this.customStyle);

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -5,6 +5,7 @@
   "globals": {
     "assert": true,
     "sinon": true,
-    "WCT": true
+    "WCT": true,
+    "fixture": true
   }
 }

--- a/test/runner.html
+++ b/test/runner.html
@@ -64,6 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/styling-cross-scope-apply.html?dom=shadow',
       'unit/styling-cross-scope-apply.html?dom=shadow&lazyRegister=true&useNativeCSSProperties=true',
       'unit/styling-cross-scope-unknown-host.html',
+      'unit/style-cache.html',
       'unit/custom-style.html',
       'unit/custom-style.html?lazyRegister=true&useNativeCSSProperties=true',
       'unit/custom-style.html?dom=shadow',

--- a/test/smoke/media-query-cache.html
+++ b/test/smoke/media-query-cache.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Media Query and Caching</title>
+  <link rel="import" href="../../polymer.html">
+</head>
+
+<body>
+  <dom-module id="my-element">
+    <template>
+      <style>
+        :root {
+          --color: orange;
+        }
+
+        @media(max-width: 800px) {
+          :root {
+            --color: green;
+          }
+        }
+
+        div {
+          height: 50px;
+          width: 50px;
+          background: var(--color);
+          color: var(--text-color);
+        }
+
+        :host {
+          display: block;
+          background: blue;
+          height: 100px;
+          --text-color: white;
+        }
+
+        @media(max-width: 800px) {
+          :host {
+            background: red;
+          }
+        }
+
+        :host([foo]) {
+          --text-color: black;
+        }
+
+        :host-context([bar]) {
+          --text-color: lightgray;
+        }
+      </style>
+      <div>text</div>
+    </template>
+    <script>
+      Polymer({
+        is: 'my-element'
+      });
+    </script>
+  </dom-module>
+  <div bar>
+    <my-element foo></my-element>
+  </div>
+</body>
+
+</html>

--- a/test/unit/style-cache.html
+++ b/test/unit/style-cache.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+  <dom-module id="my-element">
+    <template>
+      <style>
+        div {
+          height: 50px;
+          width: 50px;
+          color: var(--text-color);
+        }
+
+        :host {
+          display: block;
+          background: blue;
+          height: 100px;
+          --text-color: white;
+        }
+
+        :host([foo]) {
+          --text-color: black;
+        }
+
+        :host-context([bar]) {
+          --text-color: lightgray;
+        }
+      </style>
+
+      <div id="inner">text</div>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'my-element'
+      });
+    });
+    </script>
+  </dom-module>
+
+  <test-fixture id="test">
+    <template>
+      <div id="owner" bar>
+        <my-element id="element" foo></my-element>
+      </div>
+    </template>
+  </test-fixture>
+
+  <script>
+  suite('Style Cache', function() {
+
+    var owner, element, inner;
+    setup(function() {
+      owner = fixture('test');
+      element = owner.querySelector('#element');
+      inner = element.$.inner;
+    });
+
+    suite('scope cache', function() {
+      test(':host-context()', function() {
+        assert.equal(getComputedStyle(inner).color, 'rgb(211, 211, 211)');
+        owner.removeAttribute('bar');
+        Polymer.updateStyles();
+        assert.equal(getComputedStyle(inner).color, 'rgb(0, 0, 0)');
+      });
+
+      test(':host()', function() {
+        owner.removeAttribute('bar');
+        Polymer.updateStyles();
+        assert.equal(getComputedStyle(inner).color, 'rgb(0, 0, 0)');
+        element.removeAttribute('foo');
+        Polymer.updateStyles();
+        assert.equal(getComputedStyle(inner).color, 'rgb(255, 255, 255)');
+      });
+    });
+
+    suite('global cache', function() {
+      test(':host-context', function() {
+        owner.removeAttribute('bar')
+        Polymer.updateStyles();
+        assert.include(element.className, 'my-element-1');
+        owner.setAttribute('bar', '');
+        Polymer.updateStyles();
+        assert.include(element.className, 'my-element-0');
+      });
+
+      test(':host()', function() {
+        assert.include(element.className, 'my-element-0');
+        owner.removeAttribute('bar');
+        element.removeAttribute('foo');
+        Polymer.updateStyles();
+        assert.include(element.className, 'my-element-2');
+        element.setAttribute('foo', '');
+        Polymer.updateStyles();
+        assert.include(element.className, 'my-element-1');
+      });
+    });
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Mark style rules in parsing rather than runtime to make sure scope'd
bitmask is consistent.

Add tests for cache coherency.

Fixes #3696