### PR TITLE
Fixes #3739: correctly shim `:host(.element-name)` as `element-name.e…

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -235,26 +235,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // :host(...) -> scopeName...
       _transformHostSelector: function(selector, hostScope) {
-        var m = HOST_PAREN.exec(selector);
-        HOST_PAREN.lastIndex = 0;
-        var paren = m && m[2].trim();
-        if (paren) {
-          var selectorKind = /[[.:#*]/;
-          if (!paren[0].match(selectorKind)) {
-            var typeSelector = paren.split(selectorKind)[0];
-            if (typeSelector === hostScope) {
-              hostScope = '';
-            } else {
-              return SELECTOR_NO_MATCH;
-            }
+        var m = selector.match(HOST_PAREN);
+        var paren = m && m[2].trim() || '';
+        if (paren && !paren[0].match(SIMPLE_SELECTOR_PREFIX)) {
+          // paren starts with a type selector
+          var typeSelector = paren.split(SIMPLE_SELECTOR_PREFIX)[0];
+          // if the type selector is our hostScope then avoid pre-pending it
+          if (typeSelector === hostScope) {
+            return paren;
+          // otherwise, this selector should not match in this scope so
+          // output a bogus selector.
+          } else {
+            return SELECTOR_NO_MATCH;
           }
-          return selector.replace(HOST_PAREN, function(m, host, paren) {
-            return hostScope + paren;
-          });
-        } else {
-          // now normal :host
-          return selector.replace(HOST, hostScope);
         }
+        return hostScope + paren;
       },
 
       documentRule: function(rule) {
@@ -286,12 +281,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ':not(.' + SCOPE_NAME + ')';
     var COMPLEX_SELECTOR_SEP = ',';
     var SIMPLE_SELECTOR_SEP = /(^|[\s>+~]+)((?:\[.+?\]|[^\s>+~=\[])+)/g;
+    var SIMPLE_SELECTOR_PREFIX = /[[.:#*]/;
     var HOST = ':host';
     var ROOT = ':root';
     // NOTE: this supports 1 nested () pair for things like
     // :host(:not([selected]), more general support requires
     // parsing which seems like overkill
-    var HOST_PAREN = /(:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
+    var HOST_PAREN = /(:host)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/;
     var HOST_CONTEXT = ':host-context';
     var HOST_CONTEXT_PAREN = /(.*)(?::host-context)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))(.*)/;
     var CONTENT = '::content';

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -206,12 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (selector.indexOf(HOST_CONTEXT) >=0) {
           hostContext = true;
         } else if (selector.indexOf(HOST) >=0) {
-          // :host(...) -> scopeName...
-          selector = selector.replace(HOST_PAREN, function(m, host, paren) {
-            return (m.indexOf(hostScope) === -1 ? hostScope : '') + paren;
-          });
-          // now normal :host
-          selector = selector.replace(HOST, hostScope);
+          selector = this._transformHostSelector(selector, hostScope);
         // replace other selectors with scoping class
         } else if (jumpIndex !== 0) {
           selector = scope ? this._transformSimpleSelector(selector, scope) :
@@ -236,6 +231,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var p$ = selector.split(PSEUDO_PREFIX);
         p$[0] += scope;
         return p$.join(PSEUDO_PREFIX);
+      },
+
+      // :host(...) -> scopeName...
+      _transformHostSelector: function(selector, hostScope) {
+        var m = HOST_PAREN.exec(selector);
+        HOST_PAREN.lastIndex = 0;
+        var paren = m && m[2].trim();
+        if (paren) {
+          var selectorKind = /[[.:#*]/;
+          if (!paren[0].match(selectorKind)) {
+            var typeSelector = paren.split(selectorKind)[0];
+            if (typeSelector === hostScope) {
+              hostScope = '';
+            } else {
+              return SELECTOR_NO_MATCH;
+            }
+          }
+          return selector.replace(HOST_PAREN, function(m, host, paren) {
+            return hostScope + paren;
+          });
+        } else {
+          // now normal :host
+          return selector.replace(HOST, hostScope);
+        }
       },
 
       documentRule: function(rule) {
@@ -283,6 +302,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var PSEUDO_PREFIX = ':';
     var CLASS = 'class';
     var CONTENT_START = new RegExp('^(' + CONTENT + ')');
+    var SELECTOR_NO_MATCH = 'should_not_match';
 
     // exports
     return api;

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -554,6 +554,10 @@
         display: block;
         border: 4px solid orange;
       }
+
+      :host(.x-shared1) {
+        padding: 8px;
+      };
     </style>
   </template>
 </dom-module>

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -556,7 +556,7 @@
       }
 
       :host(.x-shared1) {
-        padding: 8px;
+        top: 10px;
       };
     </style>
   </template>

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -423,7 +423,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       t.textContent = ':host(non-matching-type-selector)';
       document.body.appendChild(t);
       assertComputed(t, '0px');
-      var t = document.createElement('x-shared2x-shared1');
+      t = document.createElement('x-shared2x-shared1');
       t.textContent = ':host(non-matching-type-selector)';
       document.body.appendChild(t);
       assertComputed(t, '0px');

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -415,7 +415,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       t.textContent = 'host leak test';
       t.classList.add('x-shared1');
       document.body.appendChild(t);
-      assertComputed(t, '0px', 'padding');
+      assertComputed(t, 'auto', 'top');
     });
 
 });

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -418,6 +418,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assertComputed(t, 'auto', 'top');
     });
 
+    test(':host(...) with non-matching type selector does not leak', function() {
+      var t = document.createElement('x-shared1x-shared2');
+      t.textContent = ':host(non-matching-type-selector)';
+      document.body.appendChild(t);
+      assertComputed(t, '0px');
+      var t = document.createElement('x-shared2x-shared1');
+      t.textContent = ':host(non-matching-type-selector)';
+      document.body.appendChild(t);
+      assertComputed(t, '0px');
+    });
+
 });
 
 </script>

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -410,6 +410,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assertComputed(s2, '4px');
     });
 
+    test(':host with superset of element tag selector does not leak', function() {
+      var t = document.createElement('div');
+      t.textContent = 'host leak test';
+      t.classList.add('x-shared1');
+      document.body.appendChild(t);
+      assertComputed(t, '0px', 'padding');
+    });
+
 });
 
 </script>


### PR DESCRIPTION
…lement-name`.

Also converts `:host(not-element-name)` to a non-matching selector.

Fixes #3739.