### PR TITLE
re-support selectors like `:host[inline]` since this was previously s…

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -237,19 +237,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _transformHostSelector: function(selector, hostScope) {
         var m = selector.match(HOST_PAREN);
         var paren = m && m[2].trim() || '';
-        if (paren && !paren[0].match(SIMPLE_SELECTOR_PREFIX)) {
-          // paren starts with a type selector
-          var typeSelector = paren.split(SIMPLE_SELECTOR_PREFIX)[0];
-          // if the type selector is our hostScope then avoid pre-pending it
-          if (typeSelector === hostScope) {
-            return paren;
-          // otherwise, this selector should not match in this scope so
-          // output a bogus selector.
+        if (paren) { 
+          if (!paren[0].match(SIMPLE_SELECTOR_PREFIX)) {
+            // paren starts with a type selector
+            var typeSelector = paren.split(SIMPLE_SELECTOR_PREFIX)[0];
+            // if the type selector is our hostScope then avoid pre-pending it
+            if (typeSelector === hostScope) {
+              return paren;
+            // otherwise, this selector should not match in this scope so
+            // output a bogus selector.
+            } else {
+              return SELECTOR_NO_MATCH;
+            }
           } else {
-            return SELECTOR_NO_MATCH;
+            return hostScope + paren;    
           }
+        } else {
+          return selector.replace(HOST, hostScope);
         }
-        return hostScope + paren;
       },
 
       documentRule: function(rule) {

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -252,6 +252,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } else {
             return hostScope + paren;    
           }
+        // if no paren, do a straight :host replacement.
+        // TODO(sorvell): this should not strictly be necessary but 
+        // it's needed to maintain support for `:host[foo]` type selectors
+        // which have been improperly used under Shady DOM. This should be
+        // deprecated.
         } else {
           return selector.replace(HOST, hostScope);
         }


### PR DESCRIPTION
…upported under shady-dom.