### PR TITLE
Restore functionality of selectors like `:host(.foo)::after`.

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -250,7 +250,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               return SELECTOR_NO_MATCH;
             }
           } else {
-            return hostScope + paren;    
+            // make sure to do a replace here to catch selectors like:
+            // `:host(.foo)::before`
+            return selector.replace(HOST_PAREN, function(m, host, paren) {
+              return hostScope + paren;
+            });
           }
         // if no paren, do a straight :host replacement.
         // TODO(sorvell): this should not strictly be necessary but 

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -133,6 +133,11 @@
       border-width: 2px;
     }
 
+    :host(.wide)::after {
+      content: 'a';
+      border: 4px solid blue;
+    };
+
     #keyframes2.special {
       --keyframes100: 200px;
     }

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -134,8 +134,7 @@
     }
 
     :host(.wide)::after {
-      content: 'a';
-      border: 4px solid blue;
+      content: '-content-';
     };
 
     #keyframes2.special {

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -61,7 +61,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function assertComputed(element, value, property, pseudo) {
     var computed = getComputedStyle(element, pseudo);
     property = property || 'border-top-width';
-    assert.equal(computed[property], value, 'computed style incorrect for ' + property);
+    if (Array.isArray(value)) {
+      assert.oneOf(computed[property], value, 'computed style incorrect for ' + property);
+    } else {
+      assert.equal(computed[property], value, 'computed style incorrect for ' + property);
+    }
   }
 
   var styled = document.querySelector('x-styled');
@@ -73,10 +77,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test(':host, :host(...)', function() {
     assertComputed(styled, '1px');
     assertComputed(styledWide, '2px');
-    assertComputed(styled, '0px', null, '::after');
-    assertComputed(styledWide, '2px');
-    assertComputed(styledWide, '4px', null, '::after');
-
+    assertComputed(styled, ['', 'none'], 'content', '::after');
+    assertComputed(styledWide, ['"-content-"', '-content-'], 'content', '::after');
   });
 
   test(':host-context(...)', function() {

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -58,8 +58,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   suite('scoped-styling', function() {
 
-  function assertComputed(element, value, property) {
-    var computed = getComputedStyle(element);
+  function assertComputed(element, value, property, pseudo) {
+    var computed = getComputedStyle(element, pseudo);
     property = property || 'border-top-width';
     assert.equal(computed[property], value, 'computed style incorrect for ' + property);
   }
@@ -73,6 +73,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test(':host, :host(...)', function() {
     assertComputed(styled, '1px');
     assertComputed(styledWide, '2px');
+    assertComputed(styled, '0px', null, '::after');
+    assertComputed(styledWide, '2px');
+    assertComputed(styledWide, '4px', null, '::after');
 
   });
 


### PR DESCRIPTION
Fixes #3749.