### PR TITLE
Fix css shady build mistakenly matching root rules as host rules

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -290,7 +290,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var cssBuild = scope.__cssBuild || style.__cssBuild;
         if (cssBuild === 'shady') {
           // :root -> x-foo > *.x-foo for elements and html for custom-style
-          isRoot = parsedSelector === (hostScope + '> *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
+          isRoot = parsedSelector === (hostScope + ' > *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
           // :host -> x-foo for elements, but sub-rules have .x-foo in them
           isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
         }
@@ -314,7 +314,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               hostScope
             );
           }
-          selectorToMatch = rule.transformedSelector || hostScope;
+          // parsedSelector fallback for 'shady' css build
+          selectorToMatch = rule.transformedSelector || rule.parsedSelector;
         }
         callback({
           selector: selectorToMatch,


### PR DESCRIPTION
Fallback to parsedSelector when matching host rules to catch host-function and host-context rules corectly

Fixes tests in polymer-css-build