### PR TITLE
Ensure properties override attributes at upgrade time. Fixes #3779.

### DIFF
--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -71,9 +71,9 @@ elements to the template itself as the binding scope.
       Polymer.RenderStatus.whenReady(function() {
         if (document.readyState == 'loading') {
           document.addEventListener('DOMContentLoaded', function() {
-            self._markImportsReady(); 
+            self._markImportsReady();
           });
-        } else {  
+        } else {
           self._markImportsReady();
         }
       });
@@ -121,6 +121,11 @@ elements to the template itself as the binding scope.
       } else {
         return selector;
       }
+    },
+
+    _configureInstanceProperties: function() {
+      // We use the _prepConfigure code below to read instance values before
+      // creating instance accessors, rather than the standard method here
     },
 
     _prepConfigure: function() {

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -92,6 +92,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._configureAnnotationReferences();
       // save copy of configuration that came from above
       this._aboveConfig = this.mixin({}, this._config);
+      // save instance properties that may have been bound prior to upgrade
+      this._configureInstanceProperties(this._aboveConfig);
       // get individual default values from property configs
       var config = {};
       // mixed-in behaviors
@@ -113,18 +115,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _configureProperties: function(properties, config) {
-      for (var i in properties) {
-        var c = properties[i];
+    _configureInstanceProperties: function(config) {
+      for (var i in this._propertyEffects) {
         // Allow properties set before upgrade on the instance
         // to override default values. This allows late upgrade + an early set
         // to not b0rk accessors on the prototype.
         // Perf testing has shown `hasOwnProperty` to be ok here.
-        if (!usePolyfillProto && this.hasOwnProperty(i) &&
-            this._propertyEffects && this._propertyEffects[i]) {
+        if (!usePolyfillProto && this.hasOwnProperty(i)) {
           config[i] = this[i];
           delete this[i];
-        } else if (c.value !== undefined) {
+        }
+      }
+    },
+
+    _configureProperties: function(properties, config) {
+      for (var i in properties) {
+        var c = properties[i];
+        if (c.value !== undefined) {
           var value = c.value;
           if (typeof value == 'function') {
             // pass existing config values (this._config) to value function

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -115,7 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _configureInstanceProperties: function(config) {
+    _configureInstanceProperties: function() {
       for (var i in this._propertyEffects) {
         // Allow properties set before upgrade on the instance
         // to override default values. This allows late upgrade + an early set

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -90,10 +90,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // e.g. hand template content stored in notes to children as part of
       // configure flow so templates have their content at ready time
       this._configureAnnotationReferences();
+      // configure instance properties that may have been bound prior to upgrade
+      this._configureInstanceProperties();
       // save copy of configuration that came from above
       this._aboveConfig = this.mixin({}, this._config);
-      // save instance properties that may have been bound prior to upgrade
-      this._configureInstanceProperties(this._aboveConfig);
       // get individual default values from property configs
       var config = {};
       // mixed-in behaviors
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // to not b0rk accessors on the prototype.
         // Perf testing has shown `hasOwnProperty` to be ok here.
         if (!usePolyfillProto && this.hasOwnProperty(i)) {
-          config[i] = this[i];
+          this._configValue(i, this[i]);
           delete this[i];
         }
       }

--- a/test/unit/configure-elements.html
+++ b/test/unit/configure-elements.html
@@ -234,3 +234,53 @@
     });
   </script>
 </dom-module>
+
+<script>
+  window.XConfigLazy = {
+    is: 'x-config-lazy',
+    properties: {
+      noEffectProp: Number,
+      defaultUsesNoEffectProp: {
+        value: function() {
+          return this.noEffectProp * 2;
+        }
+      },
+      prop: {
+        observer: 'propChanged'
+      },
+      readOnlyProp: {
+        readOnly: true,
+        value: 'readOnly'
+      },
+      hadAttrProp: {
+        value: 'hadAttrProp',
+        observer: 'hadAttrPropChanged'
+      }
+    },
+    created: function() {
+      this.noEffectProp = 1;
+      this.propChanged = sinon.spy();
+      this.hadAttrPropChanged = sinon.spy();
+    }
+  };
+</script>
+
+<dom-module id="x-config-lazy-host">
+  <template>
+    <x-config-lazy id="lazy" prop="{{foo}}" read-only-prop="{{foo}}" had-attr-prop="attrValue"></x-config-lazy>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-config-lazy-host',
+      properties: {
+        foo: {
+          value: 'foo',
+          observer: 'fooChanged'
+        }
+      },
+      fooChanged: function(foo) {
+        this.$.lazy.hadAttrProp = foo;
+      }
+    })
+  </script>
+</dom-module>

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -186,6 +186,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(x.b, 2);
       document.body.removeChild(x);
     });
+
+    test('lazy upgrade binding use cases', function() {
+      // don't test if __proto__ is polyfilled (IE10); cannot be fixed in this case.
+      if (Polymer.Settings.usePolyfillProto) {
+        return;
+      }
+      var el = document.createElement('x-config-lazy-host');
+      document.body.appendChild(el);
+      Polymer(window.XConfigLazy);
+      assert.equal(el.$.lazy.noEffectProp, 1);
+      assert.equal(el.$.lazy.defaultUsesNoEffectProp, 2);
+      assert.equal(el.$.lazy.prop, 'foo');
+      assert.isTrue(el.$.lazy.propChanged.calledOnce);
+      assert.equal(el.$.lazy.readOnlyProp, 'readOnly');
+      assert.equal(el.$.lazy.hadAttrProp, 'foo');
+      assert.isTrue(el.$.lazy.hadAttrPropChanged.calledOnce);
+      document.body.removeChild(el);
+    });
+
   });
 
 </script>


### PR DESCRIPTION
### Reference Issue
Read instance values into `_aboveConfig` rather than `config`, so that they override attribute values.  Requires handling instance values & defaults as separate loops, and required stubbing the new `_configureInstanceProperties` in `dom-bind` since the `hasOwnProperty` check would pass for `dom-bind`'s instance-time accessors, causing `undefined` from the getter to be configured into `_aboveConfig`.  `dom-bind` has its own early instance property handling.

Fixes #3779

