### PR TITLE
Allow dom-repeat for array-like Objects

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -359,9 +359,17 @@ Then the `observe` property should be configured as follows:
         this.observe.replace('.*', '.').split(' ');
     },
 
+    _isArrayLike: function(o) {
+      return o instanceof Object && Number.isInteger(o.length) && o.splice instanceof Function && o.pop instanceof Function && o.unshift instanceof Function && o.shift instanceof Function && o.push instanceof Function;
+    },
+
+    _isArray: function(o) {
+      return Array.isArray(o) || this._isArrayLike(o);
+    },
+
     _itemsChanged: function(change) {
       if (change.path == 'items') {
-        if (Array.isArray(this.items)) {
+        if (this._isArray(this.items)) {
           this.collection = Polymer.Collection.get(this.items);
         } else if (!this.items) {
           this.collection = null;
@@ -842,6 +850,5 @@ Then the `observe` property should be configured as follows:
     }
 
   });
-
 
 </script>


### PR DESCRIPTION
Implement a further check on objects passed through dom-repeat to check if they have the required properties and methods (https://www.polymer-project.org/1.0/docs/devguide/properties#array-mutation) to allow stamping out of array-like objects on a template dom-repeat.
### Reference Issue

https://github.com/Polymer/polymer/issues/3811
