### PR TITLE
Better error message for bad listeners entry.

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -67,6 +67,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           name = eventName.split('.');
           node = this.$[name[0]];
+          if (!node) {
+            console.warn('listeners: could not find node with ID', name[0]);
+          }
           name = name[1];
         }
         this.listen(node, name, listeners[eventName]);


### PR DESCRIPTION
Currently, if you specify a bad node in the `listeners` object, the result is a cryptic message about a missing key in a weak map. This can result if you use the ID of an element that's inside a `dom-if`, for example.
### Test case

Load the following element. It should log a more useful message when  it encounters the listeners key `foo.click`.

```
<dom-module id="a-thing">
  <template>
    <template is="dom-if" if="{{test}}">
    <div id="foo">
        Foo
      </div>
  </template>
  <div id="bar">
      Bar
  </div>
  </template>

  <script>
    Polymer({
      is: 'a-thing',
      listeners: {
        'foo.click': 'clickFoo',
        'bar.click': 'clickBar'
      },
      clickFoo: function() {
        console.log('foo clicked.');
      },
      clickBar: function() {
        console.log('bar clicked.');
      }
    });
  </script>
  </dom-module>
```
### Reference Issue

Related to: https://github.com/Polymer/docs/issues/1689, https://github.com/Polymer/polymer/issues/1506#issuecomment-175850553
### Note

Adding a `continue;` after line 71 lets the other listeners register correctly and lets the element finish initializing. Currently, the error appears to break the element entirely.  Not sure which behavior is preferable, so I left the `continue` out here.
