### PR TITLE
Do notify once per property at most

### DIFF
--- a/src/lib/bind/accessors.html
+++ b/src/lib/bind/accessors.html
@@ -118,6 +118,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return propEffect;
     },
 
+    hasPropertyEffectOfKind: function(model, property, kind) {
+      var fx$ = model._propertyEffects && model._propertyEffects[property];
+      if (fx$) {
+        for (var i=0, l=fx$.length; i<l; i++) {
+          var fx = fx$[i];
+          if (fx.kind === kind) {
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+
     createBindings: function(model) {
       //console.group(model.is);
       // map of properties to effects

--- a/src/standard/effectBuilder.html
+++ b/src/standard/effectBuilder.html
@@ -52,6 +52,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (properties) {
         for (var p in properties) {
           var prop = properties[p];
+          // B/c of the additional `hasPropertyEffectOfKind` check, it is more
+          // efficient to check for notify effects first.
+          if (prop.notify) {
+            if (!Polymer.Bind.hasPropertyEffectOfKind(this, p, 'notify')) {
+              this._addPropertyEffect(p, 'notify', {
+                event: Polymer.CaseMap.camelToDashCase(p) + '-changed'});
+            }
+          }
           if (prop.observer) {
             this._addObserverEffect(p, prop.observer);
           }
@@ -59,10 +67,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // Computed properties are implicitly readOnly
             prop.readOnly = true;
             this._addComputedEffect(p, prop.computed);
-          }
-          if (prop.notify) {
-            this._addPropertyEffect(p, 'notify', {
-              event: Polymer.CaseMap.camelToDashCase(p) + '-changed'});
           }
           if (prop.reflectToAttribute) {
             var attr = Polymer.CaseMap.camelToDashCase(p);

--- a/test/unit/behaviors-elements.html
+++ b/test/unit/behaviors-elements.html
@@ -265,3 +265,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
 </script>
+
+<dom-module id="do-not-notify-more-than-once">
+
+  <script>
+    (function() {
+      var behaviorA = {
+        properties: {
+          value: { notify: true }
+        }
+      };
+      var behaviorB = {
+        properties: {
+          value: { notify: true }
+        }
+      };
+      Polymer({
+        is: 'do-not-notify-more-than-once',
+        behaviors: [behaviorA, behaviorB]
+      });
+    })();
+  </script>
+
+</dom-module>

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -191,6 +191,29 @@ suite('nested-behaviors element', function() {
 
 });
 
+suite('do notify more than once for a given property', function() {
+
+  var el;
+
+  setup(function() {
+    el = document.createElement('do-not-notify-more-than-once');
+    document.body.appendChild(el);
+  });
+
+  teardown(function() {
+    document.body.removeChild(el);
+  });
+
+  test('does notify exactly one time', function() {
+    var handler = sinon.spy();
+    el.addEventListener('value-changed', handler);
+
+    el.value = 'foo';
+
+    assert.equal(handler.callCount, 1);
+  });
+});
+
 </script>
 
 </body>


### PR DESCRIPTION
If you have multiple behaviors defining the same property, all setting notify
to true, Polymer just blindly added multiple effects. This resulted in multiple
DOM events sent upwards.

The fix is to just check if there is already a notify effect registered for a
given property, before we register the effect.

Reference issue #3418.
Fixes #1791.
Fixes PolymerElements/paper-input#66
