### PR TITLE
Use this instead of self.

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -287,14 +287,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       whenHostOrRootRule: function(scope, rule, style, callback) {
         if (!rule.propertyInfo) {
-          self.decorateRule(rule);
+          this.decorateRule(rule);
         }
         if (!rule.propertyInfo.properties) {
           return;
         }
         var hostScope = scope.is ?
-        styleTransformer._calcHostScope(scope.is, scope.extends) :
-        'html';
+          styleTransformer._calcHostScope(scope.is, scope.extends) :
+          'html';
         var parsedSelector = rule.parsedSelector;
         var isRoot = parsedSelector === ':root';
         var isHost = parsedSelector.indexOf(':host') === 0;


### PR DESCRIPTION
`self` refers the global window object here. 

Fixes #3840 

Notes:
1. This code branch is not covered by tests, otherwise it would have thrown early.
2. If we set `browser: false` in eslintrc, eslint would have thrown early as well.
