### PR TITLE
Fix binding to field in object with slash in key name

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -90,7 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _bindingRegex: (function() {
-      var IDENT  = '(?:' + '[a-zA-Z_$][\\w.:$\\-*]*' + ')';
+      var IDENT  = '(?:' + '[a-zA-Z_$][\\w.:$\\-\\/*]*' + ')';
       var NUMBER = '(?:' + '[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?' + ')';
       var SQUOTE_STRING = '(?:' + '\'(?:[^\'\\\\]|\\\\.)*\'' + ')';
       var DQUOTE_STRING = '(?:' + '"(?:[^"\\\\]|\\\\.)*"' + ')';

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -56,6 +56,7 @@
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4
       </div>
       <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
+      <span id="boundWithSlash">{{objectWithSlash.binding/with/slash}}</span>
   </template>
   <script>
     Polymer({
@@ -137,6 +138,9 @@
           computed: 'foobared(noComputed)'
         },
         objectWithDash: {
+          type: Object
+        },
+        objectWithSlash: {
           type: Object
         }
       },

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -289,6 +289,13 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundWithDash.textContent, 'yes');
   });
 
+  test('binding with slash', function() {
+    el.objectWithSlash = {
+      'binding/with/slash': 'yes'
+    };
+    assert.equal(el.$.boundWithSlash.textContent, 'yes');
+  });
+
   test('class attribute without template scope not erased', function() {
     var el = document.querySelector('.class1');
     assert.notEqual(el, null, 'class without template scope is undefined');


### PR DESCRIPTION
Added the slash character to the variable binding regex.
### Reference Issue

Fixes #3870
