### PR TITLE
Do not parse bindings inside script tags

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -224,7 +224,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // add annotations gleaned from children of `root` to `list`, `root`'s
     // `annote` is supplied as it is the annote.parent of added annotations
     _parseChildNodesAnnotations: function(root, annote, list, stripWhiteSpace) {
-      if (root.firstChild) {
+      if (root.firstChild && root.localName !== 'script') {
         var node = root.firstChild;
         var i = 0;
         while (node) {

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -55,6 +55,15 @@
       <div id="compound2">
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literal')}} literal4
       </div>
+      <script type="text/markdown" id="markdownScript">
+        This is a markdown script which shows a Polymer {{binding}}.
+      </script>
+      <script>
+      /*exported returnStringWithBindingInScript*/
+        function returnStringWithBindingInScript() {
+          return 'Value is: {{value}}';
+        }
+      </script>
       <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
   </template>
   <script>

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -282,6 +282,12 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedWildcard, 15);
   });
 
+  test('does not process bindings in script tags', function() {
+    assert.equal(el.$.markdownScript.textContent.trim(), 'This is a markdown script which shows a Polymer {{binding}}.');
+    /*global returnStringWithBindingInScript*/
+    assert.equal(returnStringWithBindingInScript(), 'Value is: {{value}}');
+  });
+
   test('binding with dash', function() {
     el.objectWithDash = {
       'binding-with-dash': 'yes'


### PR DESCRIPTION
Scripts are now ignored when parsing bindings. This makes it impossible to craft weird functions like `returnStringWithBindingInScript`.
### Reference Issue

Fixes #3726
