### PR TITLE
Remove guard for iOS/Android in ignoreMouse

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -82,9 +82,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   function ignoreMouse() {
-    if (IS_TOUCH_ONLY) {
-      return;
-    }
     if (!POINTERSTATE.mouse.mouseIgnoreJob) {
       setupTeardownMouseCanceller(true);
     }


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue #3704 
<!-- Example: Fixes #1234 -->

`ignoreMouse` sets up cancellation of "ghost click" when handling touch
events. We want to prevent the "ghost click" on all mobile devices.