### PR TITLE
Fixes #3938

### DIFF
--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -46,16 +46,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.created();
       }
 
-      _applyConfigMetaData() {
-        this._applyConfigMetaDataFrom(this.constructor._ownConfig);
+      _applyListeners() {
+        this._applyConfigListeners(this.constructor._ownConfig);
       }
 
-      _applyConfigMetaDataFrom(config) {
+      _applyConfigListeners(config) {
         if (config.listeners) {
           for (let l in config.listeners) {
             this._addMethodEventListenerToNode(this, l, config.listeners[l]);
           }
         }
+      }
+
+      _ensureAttributes() {
+        this._ensureConfigAttributes(this.constructor._ownConfig);
+      }
+
+      _ensureConfigAttributes(config) {
         if (config.hostAttributes) {
           for (let a in config.hostAttributes) {
             this._ensureAttribute(a, config.hostAttributes[a]);
@@ -64,7 +71,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       ready() {
-        this._applyConfigMetaData();
+        this._applyListeners();
+        this._ensureAttributes();
         super.ready();
       }
 

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -106,6 +106,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._applyConfigMetaDataFrom(behavior);
         }
 
+        _applyListeners() {
+          super._applyListeners();
+          this._applyConfigListeners(behavior);
+        }
+
+        _ensureAttributes() {
+          // ensure before calling super so that subclasses can override defaults
+          this._ensureConfigAttributes(behavior);
+          super._ensureAttributes();
+        }
+
         ready() {
           super.ready();
           this._invokeFunction(behavior.ready);

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -54,6 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       hostAttributes: {
         behavior: 'A',
+        element: 'A',
         user: 'A'
       },
 
@@ -103,6 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       hostAttributes: {
         behavior: 'B',
+        element: 'B',
         user: 'B'
       },
 
@@ -167,6 +169,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.BehaviorA,
           Polymer.BehaviorB
         ],
+
+        hostAttributes: {
+          element: 'element'
+        },
 
         properties: {
 
@@ -404,7 +410,8 @@ suite('multi-behaviors element', function() {
   });
 
   test('hostAttributes ordering', function() {
-    assert.equal(el.attributes.behavior.value, 'A', 'Behavior hostAttribute overridden by subclass');
+    assert.equal(el.attributes.behavior.value, 'B', 'Behavior hostAttribute not overridden by younger behavior');
+    assert.equal(el.attributes.element.value, 'element', 'Behavior hostAttribute overridden by behavior');
     assert.equal(el.attributes.user.value, 'user', 'Behavior hostAttribute overrode user attribute');
   });
 


### PR DESCRIPTION
Fixes #3938 

* Separate application of listeners and host attributes. 
* Adds `_applyListeners` and `_ensureAttributes` as override points. 
* Legacy `Polymer` impl ensures attributes subclass before superclass so that a subclass gets first crack as to what attribute value should exist (This matches the behavior of Polymer 1.0).