### PR TITLE
Support more expressive `:root` and `html` selectors

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -285,8 +285,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
+      _rootSelector: /(?:^:root)|(?::host\s*>\s*\*)/,
+
       _checkRoot: function(hostScope, selector) {
-        return selector.indexOf(':root') === 0 ||
+        return Boolean(selector.match(this._rootSelector)) ||
           (hostScope === 'html' && selector.indexOf('html') === 0);
       },
 
@@ -302,7 +304,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'html';
         var parsedSelector = rule.parsedSelector;
         var isRoot = this._checkRoot(hostScope, parsedSelector);
-        var isHost = parsedSelector.indexOf(':host') === 0;
+        var isHost = !isRoot && parsedSelector.indexOf(':host') === 0;
         // build info is either in scope (when scope is an element) or in the style
         // when scope is the default scope; note: this allows default scope to have
         // mixed mode built and unbuilt styles.
@@ -312,10 +314,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           isRoot = parsedSelector === (hostScope + ' > *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
           // :host -> x-foo for elements, but sub-rules have .x-foo in them
           isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
-        }
-        if (cssBuild === 'shadow') {
-          isRoot = parsedSelector === ':host > *' || this._checkRoot(hostScope, parsedSelector);
-          isHost = isHost && !isRoot;
         }
         if (!isRoot && !isHost) {
           return;

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -285,6 +285,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
+      _checkRoot: function(hostScope, selector) {
+        return selector.indexOf(':root') === 0 ||
+          (hostScope === 'html' && selector.indexOf('html') === 0);
+      },
+
       whenHostOrRootRule: function(scope, rule, style, callback) {
         if (!rule.propertyInfo) {
           self.decorateRule(rule);
@@ -292,14 +297,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!rule.propertyInfo.properties) {
           return;
         }
-        var checkRoot = function(hostScope, selector) {
-          return selector.indexOf(':root') === 0 || (hostScope === 'html' && selector.indexOf('html') === 0);
-        };
         var hostScope = scope.is ?
         styleTransformer._calcHostScope(scope.is, scope.extends) :
         'html';
         var parsedSelector = rule.parsedSelector;
-        var isRoot = checkRoot(hostScope, parsedSelector);
+        var isRoot = this._checkRoot(hostScope, parsedSelector);
         var isHost = parsedSelector.indexOf(':host') === 0;
         // build info is either in scope (when scope is an element) or in the style
         // when scope is the default scope; note: this allows default scope to have
@@ -312,7 +314,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
         }
         if (cssBuild === 'shadow') {
-          isRoot = parsedSelector === ':host > *' || checkRoot(hostScope, parsedSelector);
+          isRoot = parsedSelector === ':host > *' || this._checkRoot(hostScope, parsedSelector);
           isHost = isHost && !isRoot;
         }
         if (!isRoot && !isHost) {

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           self.decorateRule(rule);
           // mark in-order position of ast rule in styles block, used for cache key
           rule.index = ruleIndex++;
-          self.whenHostOrRootRule(scope, rule, style, false, function(info) {
+          self.whenHostOrRootRule(scope, rule, style, function(info) {
             // we can't cache styles with :host and :root props in @media rules
             if (rule.parent.type === styleUtil.ruleTypes.MEDIA_RULE) {
               scope.__notStyleScopeCacheable = true;
@@ -285,7 +285,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
-      whenHostOrRootRule: function(scope, rule, style, runtime, callback) {
+      whenHostOrRootRule: function(scope, rule, style, callback) {
         if (!rule.propertyInfo) {
           self.decorateRule(rule);
         }
@@ -293,11 +293,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return;
         }
         var checkRoot = function(hostScope, selector) {
-          if (runtime) {
-            return selector.indexOf(':root') === 0 || (hostScope === 'html' && parsedSelector.indexOf('html') === 0);
-          } else {
-            return selector === ':root' || selector === 'html';
-          }
+          return selector.indexOf(':root') === 0 || (hostScope === 'html' && selector.indexOf('html') === 0);
         };
         var hostScope = scope.is ?
         styleTransformer._calcHostScope(scope.is, scope.extends) :
@@ -338,7 +334,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // parsedSelector fallback for 'shady' css build
           selectorToMatch = rule.transformedSelector || rule.parsedSelector;
         }
-        if (isRoot && runtime && hostScope === 'html') {
+        if (isRoot && hostScope === 'html') {
           selectorToMatch = rule.transformedSelector || rule.parsedSelector;
         }
         callback({
@@ -353,7 +349,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // note: active rules excludes non-matching @media rules
         styleUtil.forActiveRulesInStyles(scope._styles, function(rule, style) {
           // if scope is StyleDefaults, use _element for matchesSelector
-          self.whenHostOrRootRule(scope, rule, style, true, function(info) {
+          self.whenHostOrRootRule(scope, rule, style, function(info) {
             var element = scope._element || scope;
             if (matchesSelector.call(element, info.selector)) {
               if (info.isHost) {

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -285,11 +285,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
-      _rootSelector: /(?:^:root)|(?::host\s*>\s*\*)/,
+      _rootSelector: /:root|:host\s*>\s*\*/,
 
       _checkRoot: function(hostScope, selector) {
         return Boolean(selector.match(this._rootSelector)) ||
-          (hostScope === 'html' && selector.indexOf('html') === 0);
+          (hostScope === 'html' && selector.indexOf('html') > -1);
       },
 
       whenHostOrRootRule: function(scope, rule, style, callback) {
@@ -311,7 +311,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var cssBuild = scope.__cssBuild || style.__cssBuild;
         if (cssBuild === 'shady') {
           // :root -> x-foo > *.x-foo for elements and html for custom-style
-          isRoot = parsedSelector === (hostScope + ' > *.' + hostScope) || parsedSelector.indexOf('html') !== -1;
+          isRoot = parsedSelector === (hostScope + ' > *.' + hostScope) || parsedSelector.indexOf('html') > -1;
           // :host -> x-foo for elements, but sub-rules have .x-foo in them
           isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
         }

--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           self.decorateRule(rule);
           // mark in-order position of ast rule in styles block, used for cache key
           rule.index = ruleIndex++;
-          self.whenHostOrRootRule(scope, rule, style, function(info) {
+          self.whenHostOrRootRule(scope, rule, style, false, function(info) {
             // we can't cache styles with :host and :root props in @media rules
             if (rule.parent.type === styleUtil.ruleTypes.MEDIA_RULE) {
               scope.__notStyleScopeCacheable = true;
@@ -285,18 +285,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return {properties: props, key: o};
       },
 
-      whenHostOrRootRule: function(scope, rule, style, callback) {
+      whenHostOrRootRule: function(scope, rule, style, runtime, callback) {
         if (!rule.propertyInfo) {
           self.decorateRule(rule);
         }
         if (!rule.propertyInfo.properties) {
           return;
         }
+        var checkRoot = function(hostScope, selector) {
+          if (runtime) {
+            return selector.indexOf(':root') === 0 || (hostScope === 'html' && parsedSelector.indexOf('html') === 0);
+          } else {
+            return selector === ':root' || selector === 'html';
+          }
+        };
         var hostScope = scope.is ?
         styleTransformer._calcHostScope(scope.is, scope.extends) :
         'html';
         var parsedSelector = rule.parsedSelector;
-        var isRoot = parsedSelector === ':root';
+        var isRoot = checkRoot(hostScope, parsedSelector);
         var isHost = parsedSelector.indexOf(':host') === 0;
         // build info is either in scope (when scope is an element) or in the style
         // when scope is the default scope; note: this allows default scope to have
@@ -309,7 +316,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           isHost = !isRoot && parsedSelector.indexOf(hostScope) === 0;
         }
         if (cssBuild === 'shadow') {
-          isRoot = parsedSelector === ':host > *' || parsedSelector === 'html';
+          isRoot = parsedSelector === ':host > *' || checkRoot(hostScope, parsedSelector);
           isHost = isHost && !isRoot;
         }
         if (!isRoot && !isHost) {
@@ -331,6 +338,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // parsedSelector fallback for 'shady' css build
           selectorToMatch = rule.transformedSelector || rule.parsedSelector;
         }
+        if (isRoot && runtime && hostScope === 'html') {
+          selectorToMatch = rule.transformedSelector || rule.parsedSelector;
+        }
         callback({
           selector: selectorToMatch,
           isHost: isHost,
@@ -343,7 +353,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // note: active rules excludes non-matching @media rules
         styleUtil.forActiveRulesInStyles(scope._styles, function(rule, style) {
           // if scope is StyleDefaults, use _element for matchesSelector
-          self.whenHostOrRootRule(scope, rule, style, function(info) {
+          self.whenHostOrRootRule(scope, rule, style, true, function(info) {
             var element = scope._element || scope;
             if (matchesSelector.call(element, info.selector)) {
               if (info.isHost) {

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -104,6 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var self = this;
           cb = function(rule) {
             rule.selector = self._slottedToContent(rule.selector);
+            rule.selector = rule.selector.replace(ROOT, ':host > *');
             if (callback) {
               callback(rule);
             }
@@ -189,6 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var self = this;
         selector = selector.trim();
         selector = this._slottedToContent(selector);
+        selector = selector.replace(ROOT, ':host > *');
         selector = selector.replace(CONTENT_START, HOST + ' $1');
         selector = selector.replace(SIMPLE_SELECTOR_SEP, function(m, c, s) {
           if (!stop) {

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -289,9 +289,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       normalizeRootSelector: function(rule) {
-        if (rule.selector === ROOT) {
-          rule.selector = 'html';
-        }
+        rule.selector = rule.selector.replace(ROOT, 'html');
       },
 
       _transformDocumentSelector: function(selector) {

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -571,6 +571,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var el;
         function activateSelectors() {
           document.documentElement.setAttribute('foo', 'bar');
+          CustomElements.takeRecords();
           Polymer.updateStyles();
         }
         suiteSetup(function() {
@@ -579,6 +580,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         teardown(function() {
           document.documentElement.removeAttribute('foo');
+          CustomElements.takeRecords();
           Polymer.updateStyles();
         });
         test(':root...', function() {

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -129,6 +129,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
   </style>
+
+  <style is="custom-style">
+  :root[foo="bar"] {
+    --foo: 10px dotted red;
+  }
+  html {
+    --html: 10px dotted yellow;
+  }
+  html[foo="bar"] {
+    --html-foo: 10px dotted green;
+  }
+  </style>
 </head>
 <body>
   <div class="italic">italic</div>
@@ -283,6 +295,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </dom-module>
 
+  <dom-module id="x-top-selectors">
+    <template>
+      <style>
+      #foo {
+        border: var(--foo);
+      }
+      #html {
+        border: var(--html);
+      }
+      #htmlFoo {
+        border: var(--html-foo);
+      }
+      </style>
+      <div id="foo"></div>
+      <div id="html"></div>
+      <div id="htmlFoo"></div>
+    </template>
+  </dom-module>
+
   <script>
   HTMLImports.whenReady(function() {
     Polymer({
@@ -303,6 +334,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     Polymer({
       is: 'x-blue-bold-text'
+    });
+    Polymer({
+      is: 'x-top-selectors'
     });
   })
   </script>
@@ -532,6 +566,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertComputed(el, '2px');
         }
       );
+
+      suite('top-level selectors', function() {
+        var el;
+        function activateSelectors() {
+          document.documentElement.setAttribute('foo', 'bar');
+          Polymer.updateStyles();
+        }
+        suiteSetup(function() {
+          el = document.createElement('x-top-selectors');
+          document.body.appendChild(el);
+        });
+        teardown(function() {
+          document.documentElement.removeAttribute('foo');
+          Polymer.updateStyles();
+        });
+        test(':root...', function() {
+          assertComputed(el.$.foo, '0px');
+          activateSelectors();
+          assertComputed(el.$.foo, '10px');
+        });
+        test('html', function() {
+          assertComputed(el.$.html, '10px');
+        });
+        test('html...', function() {
+          assertComputed(el.$.htmlFoo, '0px');
+          activateSelectors();
+          assertComputed(el.$.htmlFoo, '10px');
+        });
+      });
     });
 
 

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -831,6 +831,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="root-styles">
+  <template>
+    <style>
+    :root {
+      --root-border: 2px solid black;
+    }
+    :host > * {
+      --host-star-border: 10px solid orange;
+    }
+    #root {
+      border: var(--root-border);
+    }
+    #host {
+      border: var(--host-star-border);
+    }
+    </style>
+    <div id="root"></div>
+    <div id="host"></div>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'root-styles'});
+  });
+  </script>
+</dom-module>
+
 <script>
   suite('scoped-styling-var', function() {
 
@@ -1073,8 +1099,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assertComputed(x.$.child, '6px');
   });
 
-
-
   test('styles update based on root customStyle changes', function() {
     assertComputed(styled.$.dynamic, '0px');
     Polymer.StyleDefaults.customStyle['--dynamic'] = '4px solid navy';
@@ -1234,6 +1258,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     e.updateStyles();
     assertComputed(e, 'rgb(255, 0, 0)', null, 'background-color');
   });
+
   test('updateStyles removes the correct number of style properties', function() {
     if (!Polymer.Settings.useNativeCSSProperties) {
       this.skip();
@@ -1273,6 +1298,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     document.body.appendChild(e);
     CustomElements.takeRecords();
     assertComputed(e.$.child, '5px');
+  });
+
+  test(':root and :host > * rules apply to all shadowroot children', function() {
+    var e = document.createElement('root-styles');
+    document.body.appendChild(e);
+    CustomElements.takeRecords();
+    assertComputed(e.$.root, '2px');
+    assertComputed(e.$.host, '10px');
   });
 });
 

--- a/test/unit/styling-scoped-elements.html
+++ b/test/unit/styling-scoped-elements.html
@@ -630,3 +630,26 @@
     Polymer({is: 'x-slotted'});
   </script>
 </dom-module>
+
+<dom-module id="root-styles">
+  <template>
+    <style>
+    :root {
+      color: rgb(123, 123, 123);
+      --root-padding: 10px;
+    }
+    :host > * {
+      border: 2px solid black;
+      --host-margin: 10px;
+    }
+    #child {
+      padding: var(--root-padding);
+      margin: var(--host-margin);
+    }
+    </style>
+    <div id="child">Child</div>
+  </template>
+  <script>
+  Polymer({is: 'root-styles'});
+  </script>
+</dom-module>

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -329,6 +329,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assertComputed(e.$.bar3, '6px');
   });
 
+  test('ShadowRoot-wide selectors', function() {
+    var e = document.createElement('root-styles');
+    document.body.appendChild(e);
+    // :root
+    assertComputed(e.$.child, 'rgb(123, 123, 123)', 'color');
+    // :host > *
+    assertComputed(e.$.child, '2px');
+  });
+
     suite('scoped-styling-shady-only', function() {
 
       suiteSetup(function() {

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -332,6 +332,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('ShadowRoot-wide selectors', function() {
     var e = document.createElement('root-styles');
     document.body.appendChild(e);
+    CustomElements.takeRecords();
     // :root
     assertComputed(e.$.child, 'rgb(123, 123, 123)', 'color');
     // :host > *


### PR DESCRIPTION
Selectors like `:root[dir="rtl"]` and `html.foo` are now supported

Support `html` selector for `custom-style`

Fixes #3902
Fixes #3924
Fixes #3991 