### PR TITLE
TypeScript decorators for defining Polymer elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "web-component-tester": "*",
-    "test-fixture": "PolymerElements/test-fixture#ce-v1"
+    "test-fixture": "PolymerElements/test-fixture#ce-v1",
+    "imd": "PolymerLabs/imd#^1.0.0"
   },
   "private": true,
   "resolutions": {

--- a/custom_typings/dom.d.ts
+++ b/custom_typings/dom.d.ts
@@ -1,0 +1,11 @@
+declare interface Window {
+  customElements: CustomElementRegistry;
+}
+
+declare class CustomElementRegistry {
+  define(name: string, definition: {prototype: any}): void;
+}
+
+declare interface HTMLElement {
+  shadowRoot: DocumentFragment;
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test": "test"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.32",
+    "@types/mocha": "^2.2.31",
     "del": "^2.2.0",
     "dom5": "^1.3.1",
     "eslint-plugin-html": "^1.3.0",
@@ -21,10 +23,11 @@
     "polyclean": "^1.2.0",
     "run-sequence": "^1.1.0",
     "through2": "^2.0.0",
+    "typescript": "^2.0.2",
     "web-component-tester": "^4"
   },
   "scripts": {
-    "build": "gulp",
+    "build": "tsc",
     "test": "gulp lint && wct",
     "test-build": "gulp switch && wct && gulp restore"
   },
@@ -37,5 +40,8 @@
   "bugs": {
     "url": "https://github.com/Polymer/polymer/issues"
   },
-  "homepage": "https://github.com/Polymer/polymer"
+  "homepage": "https://github.com/Polymer/polymer",
+  "dependencies": {
+    "reflect-metadata": "^0.1.8"
+  }
 }

--- a/src/typescript/decorators.d.ts
+++ b/src/typescript/decorators.d.ts
@@ -1,0 +1,54 @@
+/// <reference path="../../node_modules/reflect-metadata/Reflect.d.ts" />
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * A TypeScript class decorator that defines a custom element with name
+ * `tagname` and the decorated class.
+ */
+export declare function customElement(tagname: string): (clazz: any) => void;
+export interface PropertyOptions {
+    notify?: boolean;
+}
+/**
+ * A TypeScript property decorator factory that defines this as a Polymer
+ * property.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export declare function property<T>(options?: PropertyOptions): (proto: any, propName: string) => any;
+/**
+ * A TypeScript property decorator factory that causes the decorated method to
+ * be called when a property changes. `targets` is either a single property
+ * name, or a list of property names.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export declare function observe(targets: string | string[]): (proto: any, propName: string) => any;
+/**
+ * A TypeScript property decorator factory that converts a class property into a
+ * getter that executes a querySelector on the element's shadow root.
+ *
+ * By annotating the property with the correct type, element's can have
+ * type-checked access to internal elements.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export declare const query: (selector: string) => (proto: any, propName: string) => any;
+/**
+ * A TypeScript property decorator that converts a class property into a getter
+ * that executes a querySelectorAll on the element's shadow root.
+ *
+ * By annotating the property with the correct type, element's can have
+ * type-checked access to internal elements. The type should be NodeList
+ * with the correct type argument.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export declare const queryAll: (selector: string) => (proto: any, propName: string) => any;

--- a/src/typescript/decorators.js
+++ b/src/typescript/decorators.js
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    // This file requires the reflect-metadata package to be loaded.
+    /// <reference path="../../node_modules/reflect-metadata/Reflect.d.ts" />
+    /**
+     * A TypeScript class decorator that defines a custom element with name
+     * `tagname` and the decorated class.
+     */
+    function customElement(tagname) {
+        return (clazz) => {
+            clazz.is = tagname;
+            window.customElements.define(tagname, clazz);
+        };
+    }
+    exports.customElement = customElement;
+    ;
+    /**
+     * A TypeScript property decorator factory that defines this as a Polymer
+     * property.
+     *
+     * This function must be invoked to return a decorator.
+     */
+    function property(options) {
+        return (proto, propName) => {
+            const notify = options && options.notify;
+            const type = Reflect.getMetadata("design:type", proto, propName);
+            const config = _ensureConfig(proto);
+            config.properties[propName] = {
+                type,
+                notify,
+            };
+        };
+    }
+    exports.property = property;
+    /**
+     * A TypeScript property decorator factory that causes the decorated method to
+     * be called when a property changes. `targets` is either a single property
+     * name, or a list of property names.
+     *
+     * This function must be invoked to return a decorator.
+     */
+    function observe(targets) {
+        return (proto, propName) => {
+            const targetString = typeof targets === 'string' ? targets : targets.join(',');
+            const config = _ensureConfig(proto);
+            config.observers.push(`${propName}(${targetString})`);
+        };
+    }
+    exports.observe = observe;
+    /**
+     * A TypeScript property decorator factory that converts a class property into a
+     * getter that executes a querySelector on the element's shadow root.
+     *
+     * By annotating the property with the correct type, element's can have
+     * type-checked access to internal elements.
+     *
+     * This function must be invoked to return a decorator.
+     */
+    exports.query = _query((target, selector) => target.querySelector(selector));
+    /**
+     * A TypeScript property decorator that converts a class property into a getter
+     * that executes a querySelectorAll on the element's shadow root.
+     *
+     * By annotating the property with the correct type, element's can have
+     * type-checked access to internal elements. The type should be NodeList
+     * with the correct type argument.
+     *
+     * This function must be invoked to return a decorator.
+     */
+    exports.queryAll = _query((target, selector) => target.querySelectorAll(selector));
+    function _ensureConfig(proto) {
+        const ctor = proto.constructor;
+        if (ctor.hasOwnProperty('__polymer_ts_config')) {
+            return ctor.__polymer_ts_config;
+        }
+        Object.defineProperty(ctor, 'config', {
+            get() { return ctor.__polymer_ts_config; }
+        });
+        const config = ctor.__polymer_ts_config = ctor.__polymer_ts_config || {};
+        config.properties = config.properties || {};
+        config.observers = config.observers || [];
+        return config;
+    }
+    function _query(queryFn) {
+        return (selector) => (proto, propName) => {
+            Object.defineProperty(proto, propName, {
+                get() {
+                    return queryFn(this.shadowRoot, selector);
+                },
+                enumerable: true,
+                configurable: true,
+            });
+        };
+    }
+});

--- a/src/typescript/decorators.ts
+++ b/src/typescript/decorators.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+// This file requires the reflect-metadata package to be loaded.
+/// <reference path="../../node_modules/reflect-metadata/Reflect.d.ts" />
+
+/**
+ * A TypeScript class decorator that defines a custom element with name
+ * `tagname` and the decorated class.
+ */
+export function customElement(tagname: string) {
+  return (clazz: any) => {
+    clazz.is = tagname;
+    window.customElements.define(tagname, clazz);
+  }
+}
+
+export interface PropertyOptions {
+  notify?: boolean;
+};
+
+/**
+ * A TypeScript property decorator factory that defines this as a Polymer
+ * property.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export function property<T>(options?: PropertyOptions) {
+  return (proto: any, propName: string) : any => {
+    const notify : boolean = options && options.notify;
+    const type = Reflect.getMetadata("design:type", proto, propName);
+    const config = _ensureConfig(proto);
+    config.properties[propName] = {
+      type,
+      notify,
+    };
+  }
+}
+
+/**
+ * A TypeScript property decorator factory that causes the decorated method to
+ * be called when a property changes. `targets` is either a single property
+ * name, or a list of property names.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export function observe(targets: string|string[]) {
+  return (proto: any, propName: string) : any => {
+    const targetString = typeof targets === 'string' ? targets : targets.join(',');
+    const config = _ensureConfig(proto);
+    config.observers.push(`${propName}(${targetString})`);
+  }
+}
+
+
+/**
+ * A TypeScript property decorator factory that converts a class property into a
+ * getter that executes a querySelector on the element's shadow root.
+ *
+ * By annotating the property with the correct type, element's can have
+ * type-checked access to internal elements.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export const query = _query(
+    (target: NodeSelector, selector: string) => target.querySelector(selector));
+
+/**
+ * A TypeScript property decorator that converts a class property into a getter
+ * that executes a querySelectorAll on the element's shadow root.
+ *
+ * By annotating the property with the correct type, element's can have
+ * type-checked access to internal elements. The type should be NodeList
+ * with the correct type argument.
+ *
+ * This function must be invoked to return a decorator.
+ */
+export const queryAll = _query(
+    (target: NodeSelector, selector: string) => target.querySelectorAll(selector));
+
+
+interface Config {
+  properties: {[name: string]: PropertyDefinition};
+  observers: string[];
+}
+
+interface PropertyDefinition {
+  notify?: boolean;
+  type: Function;
+}
+
+function _ensureConfig(proto: any): Config {
+  const ctor = proto.constructor;
+  if (ctor.hasOwnProperty('__polymer_ts_config')) {
+    return ctor.__polymer_ts_config;
+  }
+
+  Object.defineProperty(ctor, 'config', {
+    get() { return ctor.__polymer_ts_config; }
+  });
+
+  const config: Config = ctor.__polymer_ts_config = ctor.__polymer_ts_config || {};
+  config.properties = config.properties || {};
+  config.observers = config.observers || [];
+  return config;
+}
+
+function _query(queryFn: (target: NodeSelector, selector: string) => Element|NodeList) {
+  return (selector: string) => (proto: any, propName: string): any => {
+    Object.defineProperty(proto, propName, {
+      get() {
+        return queryFn(this.shadowRoot, selector);
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  };
+}

--- a/src/typescript/polymer.d.ts
+++ b/src/typescript/polymer.d.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+interface Constructor<T> {
+  new (...args: any[]): T;
+}
+
+/**
+ * An interface to match all Objects, but not primitives.
+ */
+interface Base {}
+
+/**
+ * A subclass-factory style mixin that extends `superclass` with a new subclass
+ * that implements the interface `M`.
+ */
+type Mixin<M> =
+    <C extends Base>(superclass: Constructor<C>) => Constructor<M & C>;
+
+/**
+ * The Polymer function and namespace.
+ */
+declare var Polymer: {
+
+  /**
+   * The "Polymer function" for backwards compatibility with Polymer 1.x.
+   */
+  (definition: any): void;
+
+  /**
+   * A base class for Polymer custom elements that includes the
+   * `Polymer.MetaEffects`, `Polymer.BatchedEffects`, `Polymer.PropertyEffects`,
+   * etc., mixins.
+   */
+  Element: PolymerElementConstructor;
+
+  ElementMixin:  Mixin<PolymerElement>;
+
+  PropertyEffects: Mixin<PolymerPropertyEffects>;
+
+  BatchedEffects: Mixin<PolymerBatchedEffects>;
+};
+
+declare interface PolymerElementConstructor {
+  new(): PolymerElement;
+}
+
+declare class PolymerElement extends PolymerMetaEffects {
+  static finalized: boolean;
+  static finalize(): void;
+  static readonly template: HTMLTemplateElement;
+
+  ready(): void;
+  updateStyles(properties: string[]): void;
+}
+
+declare class PolymerPropertyEffects extends HTMLElement {
+  ready(): void;
+  linkPaths(to: string, from: string): void;
+  unlinkPaths(path: string): void;
+  notifySplices(path: string, splices: any[]): void;
+  get(path: string|(string|number)[], root: any): any;
+  set(path: string|(string|number)[], value: any): void;
+  push(path: string, ...items: any[]): any;
+  pop(path: string): any;
+}
+
+declare class PolymerBatchedEffects extends PolymerPropertyEffects {
+  // _propertiesChanged(currentProps, changedProps, oldProps): void;
+  // _setPropertyToNodeFromAnnotation(node, prop, value): void;
+  // _setPropertyFromNotification(path, value, event): void;
+  // _setPropertyFromComputation(prop, value): void;
+  // _enqueueClient(client): void;
+  // _flushClients(): void;
+  setProperties(props: any): void;
+}
+
+declare class PolymerMetaEffects extends PolymerBatchedEffects {
+  // _clearPropagateEffects(): void;
+  // _createPropertyFromInfo(name: string, info): void;
+  // _setPropertyDefaults(properties): void;
+}

--- a/test/runner.html
+++ b/test/runner.html
@@ -43,7 +43,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/inheritance.html',
       'unit/path.html',
       'unit/dom-repeat.html',
-      'unit/dom-if.html'
+      'unit/dom-if.html',
+      'unit/typescript/decorators.html'
     ];
 
     // http://eddmann.com/posts/cartesian-product-in-javascript/

--- a/test/unit/typescript/decorators.html
+++ b/test/unit/typescript/decorators.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <!--
+      This test uses IMD for simplicity and less tools, but browserify,
+      webpack, or rollup could probably be used relatively easily to build a
+      single JS bundle
+    -->
+    <script src="../../../../imd/imd.js"></script>
+    <script src="../../../../chai/chai.js" as="chai"></script>
+    <script
+      src="../../../node_modules/reflect-metadata/Reflect.js">
+    </script>
+    <script>
+      define('reflect-metadata', () => {
+        // TODO(justinfagnani): figure out how to keep decorators.ts from
+        // generating an import for 'reflect-metadata' so this hack isn't
+        // necessary
+      });
+    </script>
+    <link rel="import" href="../../../polymer-element.html">
+    <script src="../../../src/typescript/decorators.js"></script>
+    <link rel="import" href="./test-element.html">
+  </head>
+  <body>
+
+    <test-fixture id="test-element">
+      <template>
+        <test-element></test-element>
+      </template>
+    </test-fixture>
+
+    <script src="decorators.js"></script>
+
+  </body>
+</html>

--- a/test/unit/typescript/decorators.js
+++ b/test/unit/typescript/decorators.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+define(["require", "exports", 'chai', './test-element.js'], function (require, exports, chai_1, test_element_js_1) {
+    "use strict";
+    suite('TypeScript Decorators', function () {
+        suite('@customElement', function () {
+            test('defines an element', function () {
+                var testElement = fixture('test-element');
+                chai_1.assert.instanceOf(testElement, test_element_js_1.TestElement);
+            });
+        });
+        suite('@property', function () {
+            test('defines a property', function () {
+                var testElement = fixture('test-element');
+                testElement.aNum = 999;
+                var numDiv = testElement.shadowRoot.querySelector('#num');
+                var numText = numDiv.textContent;
+                chai_1.assert.equal(numText, '999');
+            });
+        });
+        suite('@observe', function () {
+            test('calls a method when a single observed property changes', function () {
+                var testElement = fixture('test-element');
+                testElement.aNum = 999;
+                chai_1.assert.equal(testElement.lastNumChange, 999);
+            });
+            test('calls a method when multiple observed properties change', function () {
+                var testElement = fixture('test-element');
+                testElement.aNum = 999;
+                chai_1.assert.equal(testElement.lastMultiChange[0], 999);
+                testElement.aString = 'yahoo';
+                chai_1.assert.equal(testElement.lastMultiChange[1], 'yahoo');
+            });
+        });
+        suite('@query', function () {
+            test('queries the shadow root', function () {
+                var testElement = fixture('test-element');
+                var numDiv = testElement.numDiv;
+                chai_1.assert.equal(numDiv.id, 'num');
+            });
+        });
+        suite('@queryAll', function () {
+            test('queries the shadow root', function () {
+                var testElement = fixture('test-element');
+                var divs = testElement.divs;
+                chai_1.assert.equal(divs.length, 2);
+            });
+        });
+    });
+});

--- a/test/unit/typescript/decorators.ts
+++ b/test/unit/typescript/decorators.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import {TestElement} from './test-element.js';
+
+declare function fixture(id: string): HTMLElement;
+
+suite('TypeScript Decorators', function() {
+
+  suite('@customElement', function() {
+
+    test('defines an element', function() {
+      var testElement = fixture('test-element');
+      assert.instanceOf(testElement, TestElement);
+    });
+
+  });
+
+  suite('@property', function() {
+
+    test('defines a property', function() {
+      var testElement = fixture('test-element') as TestElement;
+      testElement.aNum = 999;
+      var numDiv = testElement.shadowRoot.querySelector('#num');
+      var numText = numDiv.textContent;
+      assert.equal(numText, '999');
+    });
+
+  });
+
+  suite('@observe', function() {
+
+    test('calls a method when a single observed property changes', function() {
+      var testElement = fixture('test-element') as TestElement;
+      testElement.aNum = 999;
+      assert.equal(testElement.lastNumChange, 999);
+    });
+
+    test('calls a method when multiple observed properties change', function() {
+      var testElement = fixture('test-element') as TestElement;
+      testElement.aNum = 999;
+      assert.equal(testElement.lastMultiChange[0], 999);
+      testElement.aString = 'yahoo';
+      assert.equal(testElement.lastMultiChange[1], 'yahoo');
+    });
+
+
+  });
+
+  suite('@query', function() {
+
+    test('queries the shadow root', function() {
+      var testElement = fixture('test-element') as TestElement;
+      var numDiv = testElement.numDiv;
+      assert.equal(numDiv.id, 'num');
+    });
+
+  });
+
+  suite('@queryAll', function() {
+
+    test('queries the shadow root', function() {
+      var testElement = fixture('test-element') as TestElement;
+      var divs = testElement.divs;
+      assert.equal(divs.length, 2);
+    });
+
+  });
+
+});

--- a/test/unit/typescript/test-element.d.ts
+++ b/test/unit/typescript/test-element.d.ts
@@ -1,0 +1,11 @@
+export declare class TestElement extends Polymer.Element {
+    aNum: number;
+    aString: string;
+    aBool: boolean;
+    lastNumChange: number;
+    lastMultiChange: any[];
+    numDiv: HTMLDivElement;
+    divs: HTMLInputElement[];
+    private _aNumChanged(newNum);
+    private _numStringChanged(newNum, newString);
+}

--- a/test/unit/typescript/test-element.html
+++ b/test/unit/typescript/test-element.html
@@ -1,0 +1,9 @@
+<link rel="import" href="../../../polymer-element.html">
+
+<dom-module id="test-element">
+  <template>
+    <div id="num">{{aNum}}</div>
+    <div id="string">{{aString}}</div>
+  </template>
+  <script src="./test-element.js"></script>
+</dom-module>

--- a/test/unit/typescript/test-element.js
+++ b/test/unit/typescript/test-element.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+define(["require", "exports", '../../../src/typescript/decorators.js'], function (require, exports, decorators_js_1) {
+    "use strict";
+    let TestElement = class TestElement extends Polymer.Element {
+        constructor() {
+            super(...arguments);
+            this.aNum = 42;
+            this.aString = 'yes';
+            this.aBool = true;
+        }
+        _aNumChanged(newNum) {
+            this.lastNumChange = newNum;
+        }
+        _numStringChanged(newNum, newString) {
+            this.lastMultiChange = [newNum, newString];
+        }
+    };
+    __decorate([
+        decorators_js_1.property({ notify: true }), 
+        __metadata('design:type', Number)
+    ], TestElement.prototype, "aNum", void 0);
+    __decorate([
+        decorators_js_1.property({ notify: true }), 
+        __metadata('design:type', String)
+    ], TestElement.prototype, "aString", void 0);
+    __decorate([
+        decorators_js_1.property(), 
+        __metadata('design:type', Boolean)
+    ], TestElement.prototype, "aBool", void 0);
+    __decorate([
+        decorators_js_1.query('#num'), 
+        __metadata('design:type', HTMLDivElement)
+    ], TestElement.prototype, "numDiv", void 0);
+    __decorate([
+        decorators_js_1.queryAll('div'), 
+        __metadata('design:type', Array)
+    ], TestElement.prototype, "divs", void 0);
+    __decorate([
+        decorators_js_1.observe('aNum'), 
+        __metadata('design:type', Function), 
+        __metadata('design:paramtypes', [Number]), 
+        __metadata('design:returntype', void 0)
+    ], TestElement.prototype, "_aNumChanged", null);
+    __decorate([
+        decorators_js_1.observe(['aNum', 'aString']), 
+        __metadata('design:type', Function), 
+        __metadata('design:paramtypes', [Number, String]), 
+        __metadata('design:returntype', void 0)
+    ], TestElement.prototype, "_numStringChanged", null);
+    TestElement = __decorate([
+        decorators_js_1.customElement('test-element'), 
+        __metadata('design:paramtypes', [])
+    ], TestElement);
+    exports.TestElement = TestElement;
+});

--- a/test/unit/typescript/test-element.ts
+++ b/test/unit/typescript/test-element.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {customElement, property, query, queryAll, observe} from '../../../src/typescript/decorators.js';
+
+@customElement('test-element')
+export class TestElement extends Polymer.Element {
+
+  @property({notify: true})
+  aNum: number = 42;
+
+  @property({notify: true})
+  aString: string = 'yes';
+
+  @property()
+  aBool: boolean = true;
+
+  lastNumChange: number;
+
+  lastMultiChange: any[];
+
+  @query('#num')
+  numDiv: HTMLDivElement;
+
+  @queryAll('div')
+  divs: HTMLInputElement[];
+
+  @observe('aNum')
+  private _aNumChanged(newNum: number) {
+    this.lastNumChange = newNum;
+  }
+
+  @observe(['aNum', 'aString'])
+  private _numStringChanged(newNum: number, newString: string) {
+    this.lastMultiChange = [newNum, newString];
+  }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "amd",
+    "moduleResolution": "node",
+    "isolatedModules": false,
+    "noImplicitAny": true,
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "lib": ["es2017", "dom"],
+    "declaration": true,
+    "sourceMap": false
+  },
+  "include": [
+    "custom_typings/dom.d.ts",
+    "src/typescript/polymer.d.ts",
+    "src/typescript/decorators.ts",
+    "test/unit/typescript/*.ts"
+  ]
+}


### PR DESCRIPTION
This adds `@customElement()`, `@property()`, `@observe()`, `@query()`, and `@queryAll()` decorator factories which let authors define elements with TypeScript classes using class properties.

`@property` and `@observe` work by writing to a private configuration property and defining a static 'config' getter that returns that property for Polymer.

`@query` and `@queryAll` are intended to replace `$` and `$$` in a way that's somewhat type-safe: by defining a field decorated with @query and with the right type annotation, TypeScript will know the return type of the query, eliminating the need for casts.

`@customElement` simply defines the class, but it also sets `is` for use by Polymer.

I added a test of a compiled TypeScript element. The dependency loading of the test isn't great, but brings relatively little tooling dependencies, it uses <script> tags to load and IMD for a module registry.
