### PR TITLE
Add support for slot->content transformation.

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -273,7 +273,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _replaceSlotWithContent: function(slot) {
       var content = slot.ownerDocument.createElement('content');
       var attrs = slot.attributes;
-      var childNodes = slot.childNodes;
       while (slot.firstChild) {
         content.appendChild(slot.firstChild);
       }

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -272,10 +272,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _replaceSlotWithContent: function(slot) {
       var content = slot.ownerDocument.createElement('content');
-      var attrs = slot.attributes;
       while (slot.firstChild) {
         content.appendChild(slot.firstChild);
       }
+      var attrs = slot.attributes;
       for (var i=0; i<attrs.length; i++) {
         var attr = attrs[i];
         content.setAttribute(attr.name, attr.value);

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -233,6 +233,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             !node.hasAttribute('preserve-content')) {
             this._parseTemplate(node, i, list, annote);
           }
+          if (node.localName == 'slot' && node.hasAttribute('auto-content')) {
+            node = this._replaceSlotWithContent(node);
+          }
           // collapse adjacent textNodes: fixes an IE issue that can cause
           // text nodes to be inexplicably split =(
           // note that root.normalize() should work but does not so we do this
@@ -265,6 +268,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           i++;
         }
       }
+    },
+
+    _replaceSlotWithContent: function(slot) {
+      var content = slot.ownerDocument.createElement('content');
+      var attrs = slot.attributes;
+      for (var i=0; i<attrs.length; i++) {
+        var attr = attrs[i];
+        if (attr.name == 'name') {
+          content.setAttribute('select', '[slot=\'' + attr.value + '\']');
+        } else {
+          content.setAttribute(attr.name, attr.value);
+        }
+      }
+      slot.parentNode.replaceChild(content, slot);
+      return content;
     },
 
     // 1. Parse annotations from the template and memoize them on

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -275,12 +275,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var attrs = slot.attributes;
       for (var i=0; i<attrs.length; i++) {
         var attr = attrs[i];
-        if (attr.name == 'name') {
-          content.setAttribute('select', '[slot=\'' + attr.value + '\']');
-        }
-        if (attr.name !== 'select') {
-          content.setAttribute(attr.name, attr.value);
-        }
+        content.setAttribute(attr.name, attr.value);
+      }
+      var name = slot.getAttribute('name');
+      if (name) {
+        content.setAttribute('select', '[slot=\'' + attr.value + '\']');
+      } else {
+        content.setAttribute('select', ':not([slot])');
       }
       slot.parentNode.replaceChild(content, slot);
       return content;

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -233,7 +233,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             !node.hasAttribute('preserve-content')) {
             this._parseTemplate(node, i, list, annote);
           }
-          if (node.localName == 'slot' && node.hasAttribute('auto-content')) {
+          if (node.localName == 'slot') {
             node = this._replaceSlotWithContent(node);
           }
           // collapse adjacent textNodes: fixes an IE issue that can cause
@@ -277,7 +277,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var attr = attrs[i];
         if (attr.name == 'name') {
           content.setAttribute('select', '[slot=\'' + attr.value + '\']');
-        } else {
+        }
+        if (attr.name !== 'select') {
           content.setAttribute(attr.name, attr.value);
         }
       }

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -279,7 +279,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       var name = slot.getAttribute('name');
       if (name) {
-        content.setAttribute('select', '[slot=\'' + attr.value + '\']');
+        content.setAttribute('select', '[slot=\'' + name + '\']');
       } else {
         content.setAttribute('select', ':not([slot])');
       }

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -278,11 +278,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         content.setAttribute(attr.name, attr.value);
       }
       var name = slot.getAttribute('name');
-      if (name) {
-        content.setAttribute('select', '[slot=\'' + name + '\']');
-      } else {
-        content.setAttribute('select', ':not([slot])');
-      }
+      var select = name ? '[slot=\'' + name + '\']' : ':not([slot])'; 
+      content.setAttribute('select', select);
       slot.parentNode.replaceChild(content, slot);
       return content;
     },

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -273,6 +273,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _replaceSlotWithContent: function(slot) {
       var content = slot.ownerDocument.createElement('content');
       var attrs = slot.attributes;
+      var childNodes = slot.childNodes;
+      while (slot.firstChild) {
+        content.appendChild(slot.firstChild);
+      }
       for (var i=0; i<attrs.length; i++) {
         var attr = attrs[i];
         content.setAttribute(attr.name, attr.value);

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="x-dist-slot">
   <template>
     x-dist
-    <div id="distWrapper"><slot id="content" name="foo" auto-content></slot></div>
+    <div id="distWrapper"><slot id="content" name="foo"></slot></div>
   </template>
   <script>
   HTMLImports.whenReady(function() {

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -32,7 +32,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="x-dist-slot">
   <template>
     x-dist
-    <div id="distWrapper"><slot id="content" name="foo"></slot></div>
+    <div id="default"><slot id="defaultIP"></slot></div>
+    <div id="foo"><slot id="fooIP" name="foo"></slot></div>
   </template>
   <script>
   HTMLImports.whenReady(function() {
@@ -352,27 +353,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('append div to distributing element (auto <slot> to <content>)', function() {
       var dist = document.createElement('x-dist-slot');
       document.body.appendChild(dist);
+      assert.equal(dist.$.fooIP.localName, 'content');
+      assert.equal(dist.$.fooIP.getAttribute('select'), '[slot=\'foo\']');
+      assert.equal(dist.$.defaultIP.localName, 'content');
+      assert.equal(dist.$.defaultIP.getAttribute('select'), ':not([slot])');
       // Distribute div
-      var div = document.createElement('div');
-      div.setAttribute('slot', 'foo');
-      Polymer.dom(dist).appendChild(div);
+      var frag = document.createDocumentFragment();
+      var foo1 = frag.appendChild(document.createElement('div'));
+      var default1 = frag.appendChild(document.createElement('div'));
+      var foo2 = frag.appendChild(document.createElement('div'));
+      var default2 = frag.appendChild(document.createElement('div'));
+      foo1.setAttribute('slot', 'foo');
+      foo2.setAttribute('slot', 'foo');
+      Polymer.dom(dist).appendChild(frag);
       Polymer.dom.flush();
       if (usingShady) {
-        assert.equal(dist.$.distWrapper.firstElementChild, div);
-      }
-      // Append to distributed div
-      var div2 = document.createElement('div');
-      Polymer.dom(div).appendChild(div2);
-      Polymer.dom.flush();
-      if (usingShady) {
-        assert.equal(dist.$.distWrapper.firstElementChild, div);
-        assert.equal(div.firstElementChild, div2);
+        assert.equal(dist.$.foo.children[0], foo1);
+        assert.equal(dist.$.foo.children[1], foo2);
+        assert.equal(dist.$.default.children[0], default1);
+        assert.equal(dist.$.default.children[1], default2);
       }
       // Remove
-      Polymer.dom(dist).removeChild(div);
+      Polymer.dom(dist).removeChild(foo1);
+      Polymer.dom(dist).removeChild(foo2);
+      Polymer.dom(dist).removeChild(default1);
+      Polymer.dom(dist).removeChild(default2);
       Polymer.dom.flush();
       if (usingShady) {
-        assert.equal(dist.$.distWrapper.firstElementChild, null);
+        assert.equal(dist.$.foo.children[0], null);
+        assert.equal(dist.$.foo.children[1], null);
+        assert.equal(dist.$.default.children[0], null);
+        assert.equal(dist.$.default.children[1], null);
       }
       document.body.removeChild(dist);
     });

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -29,6 +29,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-dist-slot">
+  <template>
+    x-dist
+    <div id="distWrapper"><slot id="content" name="foo" auto-content></slot></div>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-dist-slot'});
+  });
+  </script>
+</dom-module>
+
 <dom-module id="x-dist-simple">
   <template>
     <content id="content"></content>
@@ -315,6 +327,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       document.body.appendChild(dist);
       // Distribute div
       var div = document.createElement('div');
+      Polymer.dom(dist).appendChild(div);
+      Polymer.dom.flush();
+      if (usingShady) {
+        assert.equal(dist.$.distWrapper.firstElementChild, div);
+      }
+      // Append to distributed div
+      var div2 = document.createElement('div');
+      Polymer.dom(div).appendChild(div2);
+      Polymer.dom.flush();
+      if (usingShady) {
+        assert.equal(dist.$.distWrapper.firstElementChild, div);
+        assert.equal(div.firstElementChild, div2);
+      }
+      // Remove
+      Polymer.dom(dist).removeChild(div);
+      Polymer.dom.flush();
+      if (usingShady) {
+        assert.equal(dist.$.distWrapper.firstElementChild, null);
+      }
+      document.body.removeChild(dist);
+    });
+
+    test('append div to distributing element (auto <slot> to <content>)', function() {
+      var dist = document.createElement('x-dist-slot');
+      document.body.appendChild(dist);
+      // Distribute div
+      var div = document.createElement('div');
+      div.setAttribute('slot', 'foo');
       Polymer.dom(dist).appendChild(div);
       Polymer.dom.flush();
       if (usingShady) {

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -32,8 +32,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="x-dist-slot">
   <template>
     x-dist
-    <div id="default"><slot id="defaultIP"></slot></div>
-    <div id="foo"><slot id="fooIP" name="foo"></slot></div>
+    <div id="default"><slot id="defaultIP"><div>fallback for default</div></slot></div>
+    <div id="foo"><slot id="fooIP" name="foo"><div>fallback for foo</div></slot></div>
   </template>
   <script>
   HTMLImports.whenReady(function() {
@@ -357,6 +357,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(dist.$.fooIP.getAttribute('select'), '[slot=\'foo\']');
       assert.equal(dist.$.defaultIP.localName, 'content');
       assert.equal(dist.$.defaultIP.getAttribute('select'), ':not([slot])');
+      if (usingShady) {
+        assert.equal(dist.$.foo.firstElementChild.textContent, 'fallback for foo');
+        assert.equal(dist.$.default.firstElementChild.textContent, 'fallback for default');
+      }
       // Distribute div
       var frag = document.createDocumentFragment();
       var foo1 = frag.appendChild(document.createElement('div'));
@@ -380,9 +384,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.dom(dist).removeChild(default2);
       Polymer.dom.flush();
       if (usingShady) {
-        assert.equal(dist.$.foo.children[0], null);
+        assert.equal(dist.$.foo.children[0].textContent, 'fallback for foo');
         assert.equal(dist.$.foo.children[1], null);
-        assert.equal(dist.$.default.children[0], null);
+        assert.equal(dist.$.default.children[0].textContent, 'fallback for default');
         assert.equal(dist.$.default.children[1], null);
       }
       document.body.removeChild(dist);

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -357,10 +357,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(dist.$.fooIP.getAttribute('select'), '[slot=\'foo\']');
       assert.equal(dist.$.defaultIP.localName, 'content');
       assert.equal(dist.$.defaultIP.getAttribute('select'), ':not([slot])');
-      if (usingShady) {
-        assert.equal(dist.$.foo.firstElementChild.textContent, 'fallback for foo');
-        assert.equal(dist.$.default.firstElementChild.textContent, 'fallback for default');
-      }
+      assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[0].textContent, 'fallback for foo');
+      assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[0].textContent, 'fallback for default');
       // Distribute div
       var frag = document.createDocumentFragment();
       var foo1 = frag.appendChild(document.createElement('div'));
@@ -371,24 +369,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       foo2.setAttribute('slot', 'foo');
       Polymer.dom(dist).appendChild(frag);
       Polymer.dom.flush();
-      if (usingShady) {
-        assert.equal(dist.$.foo.children[0], foo1);
-        assert.equal(dist.$.foo.children[1], foo2);
-        assert.equal(dist.$.default.children[0], default1);
-        assert.equal(dist.$.default.children[1], default2);
-      }
+      assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[0], foo1);
+      assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[1], foo2);
+      assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[0], default1);
+      assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[1], default2);
       // Remove
       Polymer.dom(dist).removeChild(foo1);
       Polymer.dom(dist).removeChild(foo2);
       Polymer.dom(dist).removeChild(default1);
       Polymer.dom(dist).removeChild(default2);
       Polymer.dom.flush();
-      if (usingShady) {
-        assert.equal(dist.$.foo.children[0].textContent, 'fallback for foo');
-        assert.equal(dist.$.foo.children[1], null);
-        assert.equal(dist.$.default.children[0].textContent, 'fallback for default');
-        assert.equal(dist.$.default.children[1], null);
-      }
+      assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[0].textContent, 'fallback for foo');
+      assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[1], null);
+      assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[0].textContent, 'fallback for default');
+      assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[1], null);
       document.body.removeChild(dist);
     });
 


### PR DESCRIPTION
This PR is (a start) to enable writing 1.0 compatible elements that also target the 2.x compatibility layer.  Specifically, it transforms `<slot name="foo">` to `<content select="[slot=foo]">`, enabling users to write to slot and fallback to content in 1.0.

Need to bikeshed opt-in attribute (currently "auto-content")