### PR TITLE
Check value not ownProperty to save accessor value. Fixes #3972 and #…

### DIFF
--- a/src/properties/property-accessors.html
+++ b/src/properties/property-accessors.html
@@ -17,13 +17,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   'use strict';
 
   function saveAccessorValue(model, property) {
-    if (model.hasOwnProperty(property)) {
+    let value = model[property];
+    if (value !== undefined) {
       if (!model.__dataProto) {
         model.__dataProto = {};
       } else if (!model.hasOwnProperty('__dataProto')) {
         model.__dataProto = Object.create(model.__dataProto);
       }
-      model.__dataProto[property] = model[property];
+      model.__dataProto[property] = value;
     }
   }
 

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -34,6 +34,7 @@
       compoundAttr1$="{{cpnd1}}{{ cpnd2 }}{{cpnd3.prop}}{{ computeCompound(cpnd4, cpnd5, 'literalComputed')}}"
       compoundAttr2$="literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literalComputed')}} literal4"
       compoundAttr3$="[yes/no]: {{cpnd1}}, {{computeCompound('world', 'username ', 'Hello {0} ')}}"
+      computed-from-behavior="{{computeFromBehavior(value)}}"
       >
       Test
       <!-- Malformed bindings to be ignored -->
@@ -58,8 +59,14 @@
       <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
   </template>
   <script>
+    let ComputingBehavior = {
+      computeFromBehavior: function(value) {
+        return 'computed:' + value;
+      }
+    }
     Polymer({
       is: 'x-basic',
+      behaviors: [ComputingBehavior],
       properties: {
         value: {
           type: Number,

--- a/test/unit/bind.html
+++ b/test/unit/bind.html
@@ -117,6 +117,15 @@ suite('single-element binding effects', function() {
     assert.equal(el.$.boundChild.computedvalue, 45, 'Computed value not propagated to bound child');
   });
 
+  test('computed value using computing fn from behavior', function() {
+    el.value = 44;
+    assert.equal(el.$.boundChild.computedFromBehavior, 'computed:44');
+    el.computeFromBehavior = function(value) {
+      return 'new:' + value;
+    };
+    assert.equal(el.$.boundChild.computedFromBehavior, 'new:44');
+  });
+
   test('notification sent', function() {
     var notified = 0;
     el.addEventListener('notifyingvalue-changed', function(e) {


### PR DESCRIPTION
### Reference Issue
Fixes #3972 and #3972

The `hasOwnProperty` check was not robust against mixins/behaviors adding methods further down the prototype chain.