### PR TITLE
Fix IE style cache performance

### DIFF
--- a/src/lib/style-properties.html
+++ b/src/lib/style-properties.html
@@ -494,9 +494,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           // shady and cache hit but not in document
           } else if (!style.parentNode) {
+            if (IS_IE && cssText.indexOf('@media') > -1) {
+              // @media rules may be stale in IE 10 and 11
+              // refresh the text content of the style to revalidate them.
+              style.textContent = cssText;
+            }
             styleUtil.applyStyle(style, null, element._scopeStyle);
           }
-
         }
         // ensure this style is our custom style and increment its use count.
         if (style) {
@@ -506,10 +510,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             style._useCount++;
           }
           element._customStyle = style;
-        }
-        // @media rules may be stale in IE 10 and 11
-        if (IS_IE) {
-          style.textContent = style.textContent;
         }
         return style;
       },


### PR DESCRIPTION
Continue workaround from 80be0df for `@media` staleness, but only refresh
the stylesheet if it came from the cache and has `@media` queries.

Fixes #3965