### PR TITLE
Exclude custom template elements from search for cssFromElement().

### DIFF
--- a/src/lib/style-util.html
+++ b/src/lib/style-util.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // chrome 49 has semi-working css vars, check if box-shadow works
       // safari 9.1 has a recalc bug: https://bugs.webkit.org/show_bug.cgi?id=155782
       NATIVE_VARIABLES: Polymer.Settings.useNativeCSSProperties,
-      MODULE_STYLES_SELECTOR: 'style, link[rel=import][type~=css], template',
+      MODULE_STYLES_SELECTOR: 'style, link[rel=import][type~=css], template:not([is])',
       INCLUDE_ATTR: 'include',
 
       toCssText: function(rules, callback) {


### PR DESCRIPTION
Fixes #4005
