### PR TITLE
Fixes #4019

### DIFF
--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -629,12 +629,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var self = this;
         if (onload) {
           l.onload = function(e) {
-            return onload.call(self, e);
+            // NOTE: Push load handler until after `HTMLImports.whenReady`,
+            // if available, to better coordinate with use of customElements
+            // polyfill's document upgrade ordering guarantees (ensures,
+            // for example, a dom-module for an element in an async import
+            // customizes before any elements matching a define call).
+            if (window.HTMLImports) {
+              // wait until any other pending imports are ready
+              HTMLImports.whenReady(function() {
+                // wait until the CustomElements polyfill has upgraded elements.
+                // (needed because CE's whenReady is installed afer this one)
+                setTimeout(function() {
+                  onload.call(self, e);
+                });
+              });
+            } else {
+              onload.call(self, e);
+            }
           }
         }
         if (onerror) {
           l.onerror = function(e) {
-            return onerror.call(self, e);
+            onerror.call(self, e);
           }
         }
         document.head.appendChild(l);

--- a/test/runner.html
+++ b/test/runner.html
@@ -47,7 +47,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dom-repeat.html',
       'unit/dom-if.html',
       'unit/polymer-dom.html',
-      'unit/polymer-dom-observeNodes.html'
+      'unit/polymer-dom-observeNodes.html',
+      'unit/importHref-element.html'
     ];
 
     // http://eddmann.com/posts/cartesian-product-in-javascript/

--- a/test/unit/importHref-element.html
+++ b/test/unit/importHref-element.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+<body>
+
+<x-test></x-test>
+
+<script>
+
+suite('importHref element', function() {
+
+  test('element loaded with importHref upgrades properly', function(done) {
+    Polymer.Base.importHref('sub/x-test.html', function() {
+      var parsedEl = document.querySelector('x-test');
+      if (customElements.flush) {
+        customElements.flush();
+      }
+      assert.ok(parsedEl.$.test, 'parsed element not upgraded with template when import loaded');
+      var el = document.createElement('x-test');
+      document.body.appendChild(el);
+      if (customElements.flush) {
+        customElements.flush();
+      }
+      assert.ok(el.$.test, 'imperatively created element not upgraded with template when import loaded');
+      done();
+    });
+  })
+});
+
+</script>
+
+</body>
+</html>

--- a/test/unit/sub/x-test.html
+++ b/test/unit/sub/x-test.html
@@ -1,0 +1,10 @@
+<dom-module id="x-test">
+  <template>
+    <div id="test">test</div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-test'
+    })
+  </script>
+</dom-module>


### PR DESCRIPTION
Fixes #4019: : make sure importHref never calls its callback before the custom elements polyfill has finished processing imports.