### PR TITLE
Fix rootDataHost. Add templatizer tests. Rename to Templatizer.flush.

### DIFF
--- a/src/templatizer/dom-if.html
+++ b/src/templatizer/dom-if.html
@@ -96,7 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * validate application state.
      */
     render: function() {
-      Polymer.Templatizer.flushDebouncers();
+      Polymer.Templatizer.flush();
     },
 
     _render: function() {
@@ -121,14 +121,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (parentNode) {
         if (!this._ctor) {
           var template = this.querySelector('template');
+          template.__domIf = this;
           if (!template) {
             throw new Error('dom-if requires a <template> child');
           }
-          var self = this;
           this._ctor = templatizer.templatize(template, {
             fwdHostPropToInstance: function(host, prop, value) {
-              if (self._instance) {
-                self._instance.forwardProperty(prop, value, host);
+              let domif = template.__domIf;
+              if (domif._instance) {
+                domif._instance.forwardProperty(prop, value, host);
               }
             }
           });

--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -299,15 +299,15 @@ Then the `observe` property should be configured as follows:
         instanceProps[this.itemsIndexAs] = true;
         this._ctor = templatizer.templatize(template, {
           instanceProps: instanceProps,
-          fwdHostPropToInstance: function(host, prop, value) {
-            var repeater = this.__domRepeat;
+          fwdHostPropToInstance: function(template, prop, value) {
+            let repeater = template.__domRepeat;
             var i$ = repeater._instances;
             for (var i=0, inst; (i<i$.length) && (inst=i$[i]); i++) {
-              inst.forwardProperty(prop, value, host);
+              inst.forwardProperty(prop, value, template);
             }
           },
           fwdInstancePropToHost: function(inst, prop, value) {
-            var repeater = inst.template.__domRepeat;
+            let repeater = inst.__template.__domRepeat;
             if (Polymer.Path.matches(repeater.as, prop)) {
               let idx = inst[repeater.itemsIndexAs];
               if (prop == repeater.as) {
@@ -434,7 +434,7 @@ Then the `observe` property should be configured as follows:
       // Queue this repeater, then flush all in order
       this._needFullRefresh = true;
       this._debounceRender();
-      Polymer.Templatizer.flushDebouncers();
+      Polymer.Templatizer.flush();
     },
 
     _render: function() {

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._debouncerQueue.push(debouncer);
       }
 
-      static flushDebouncers() {
+      static flush() {
         if (this._debouncerQueue) {
           while (this._debouncerQueue.length) {
             this._debouncerQueue.shift().flush();
@@ -74,7 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Subclass base class to add template reference for this specific
         // template
         klass = class TemplateInstance extends baseClass {};
-        klass.prototype.template = template;
+        klass.prototype.__template = template;
         klass.instCount = 0;   
         template.__templatizerClass = klass;         
         return klass;
@@ -84,17 +84,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Anonymous class created by the templatizer
         var klass = class extends Polymer.BatchedEffects(nullClass) {
           //TODO(kschaaf): for debugging; remove?
-          get localName() { return 'template#' + this.template.id + '/TemplateInstance' }
+          get localName() { return 'template#' + this.__template.id + '/TemplateInstance' }
           constructor(host, props) {
             super();
             //TODO(kschaaf): for debugging; remove?
             this.id = this.constructor.instCount;
             this.constructor.instCount++;
-            this.__dataHost = this.template;
-            if (host) {
-              this._rootDataHost = host.__dataHost ?
-                host.__dataHost._rootDataHost || host.__dataHost : host;
-            }
+            this.__dataHost = this.__template;
+            let templateHost = this.__template.__dataHost;
+            this._rootDataHost = 
+              templateHost && templateHost._rootDataHost || templateHost;
             this._hostProps = template._content._hostProps;
             this._configureProperties(props);
             //TODO(kschaaf): id marshalling unnecessary
@@ -147,7 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               }
             }
             for (var hprop in this._hostProps) {
-              this[hprop] = this.template['_host_' + hprop];
+              this[hprop] = this.__template['_host_' + hprop];
             }
           }
           forwardProperty(prop, value, host) {
@@ -190,8 +189,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       _createHP2IEffector(hostProp, options) {
-        return function(inst, prop, value) {
-          options.fwdHostPropToInstance.call(inst, inst,
+        return function(template, prop, value) {
+          options.fwdHostPropToInstance.call(template, template,
             prop.substring('_host_'.length), value);
         }
       }
@@ -210,7 +209,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (var hprop in hostProps) {
             klass.prototype._addPropertyEffect(hprop,
               klass.prototype.PROPERTY_EFFECT_TYPES.NOTIFY,
-              {fn: this._createHP2HEffector(template)})
+              {fn: this._createHP2HEffector()})
           }
         }
       }
@@ -223,12 +222,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
-      _createHP2HEffector(template) {
+      _createHP2HEffector() {
         return function fwdHostPropToHost(inst, prop, value, old, info, fromAbove) {
           if (!fromAbove) {
             // TODO(kschaaf) This does not take advantage of the efficient
             // upward flow in batched effects
-            template._setProperty('_host_' + prop, value);
+            inst.__template._setProperty('_host_' + prop, value);
           }
         }
       }

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -91,6 +91,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.id = this.constructor.instCount;
             this.constructor.instCount++;
             this.__dataHost = this.__template;
+            // Root data host is always calculated based on the template, which
+            // is guaranteed to have a dataHost (due to being in _nodes for
+            // purposes of getting templateContent)
             let templateHost = this.__template.__dataHost;
             this._rootDataHost = 
               templateHost && templateHost._rootDataHost || templateHost;

--- a/test/runner.html
+++ b/test/runner.html
@@ -44,6 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/debounce.html',
       'unit/inheritance.html',
       'unit/path.html',
+      'unit/templatizer.html',
       'unit/dom-repeat.html',
       'unit/dom-if.html',
       'unit/polymer-dom.html',

--- a/test/smoke/style-props/test.html
+++ b/test/smoke/style-props/test.html
@@ -14,7 +14,7 @@
   </script>
   <x-app></x-app>
   <script>
-    Polymer.Templatizer.flushDebouncers();
+    Polymer.Templatizer.flush();
     document.body.offsetWidth;
     console.timeEnd('rendered');
   </script>

--- a/test/smoke/validate-properties.html
+++ b/test/smoke/validate-properties.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- <script src="../../../webcomponentsjs/webcomponents-lite.js"></script> -->
+  <script src="../../../custom-elements/src/native-shim.js"></script>
+  <link rel="import" href="../../polymer-element.html">
+</head>
+<body>
+
+  <dom-module id="x-validates">
+    <template>
+      Min: <input type="number" value-as-number="{{min::input}}">
+      Max: <input type="number" value-as-number="{{max::input}}">
+      Val: <input type="number" value-as-number="{{value::input}}">
+    </template>
+  </dom-module>
+  <script>
+    class XValidates extends Polymer.Element {
+      static get config() {
+        return {
+          properties: {
+            value: {
+              type: Number,
+              value: 5
+            },
+            min: {
+              type: Number,
+              value: 0
+            },
+            max: {
+              type: Number,
+              value: 10
+            }
+          }
+        }
+      }
+      _propertiesChanged(props, changed, old) {
+        props.value = changed.value = Math.max(Math.min(props.value, props.max), props.min);
+        super._propertiesChanged(props, changed, old);
+      }
+    }
+    window.customElements.define(XValidates.is='x-validates', XValidates);
+  </script>
+
+  <x-validates id="el"></x-validates>
+
+</body>
+</html>

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -1,0 +1,167 @@
+<dom-module id="x-host">
+  <template>
+
+    <x-templatizer obj="{{objA}}" prop="{{propA}}" id="templatizerA">
+      <template>
+        <x-child id="childA"
+          outer-prop="{{outerProp}}"
+          outer-obj="{{outerObj}}"
+          outer-obj-prop="{{outerObj.prop}}"
+          prop="{{prop}}"
+          obj="{{obj}}"
+          obj-prop="{{obj.prop}}"
+          conflict="{{outerInnerConflict.prop}}"
+          computed-from-literal="{{computeFromLiteral(33, prop)}}"
+        ></x-child>
+      </template>
+    </x-templatizer>
+
+    <x-templatizer prop="prop-a" name="templatizerB">
+      <template>
+        <x-child id="childB" computed-from-literal="{{computeFromLiteral(33, prop)}}"></x-child>
+      </template>
+    </x-templatizer>
+
+  </template>
+</dom-module>
+
+<script>
+
+  const templatizer = new Polymer.Templatizer();
+
+  Polymer({
+    is: 'x-child',
+    properties: {
+      outerProp: {
+        notify: true
+      },
+      outerObj: {
+        notify: true
+      },
+      outerObjProp: {
+        notify: true
+      },
+      prop: {
+        notify: true
+      },
+      obj: {
+        notify: true
+      },
+      objProp: {
+        notify: true
+      },
+      outerInnerConflict: {
+        notify: true
+      }
+    },
+    observers: [
+      'objChanged(obj.*)',
+      'outerObjChanged(outerObj.*)'
+    ],
+    objChanged: function() {},
+    outerObjChanged: function() {}
+  });
+
+  Polymer({
+    is: 'x-templatizer',
+    properties: {
+      obj: {
+        notify: true
+      },
+      prop: {
+        notify: true,
+        observer: 'propChanged'
+      }
+    },
+    observers: [
+      'objChanged(obj.*)'
+    ],
+    propChanged: function(value) {
+      if (this.instance) {
+        this.instance.forwardProperty('prop', value);
+        this.instance.flushProperties();
+      }
+    },
+    objChanged: function(info) {
+      if (this.instance) {
+        this.instance.forwardProperty(info.path, info.value);
+        this.instance.flushProperties();
+      }
+    },
+    go: function() {
+      var template = Polymer.dom(this).querySelector('template');
+      template.host = this;
+      var ctor = templatizer.templatize(template, {
+        instanceProps: {
+          obj: true,
+          prop: true,
+          outerInnerConflict: true
+        },
+        fwdHostPropToInstance: function(template, prop, value) {
+          if (template.host.instance) {
+            template.host.instance.forwardProperty(prop, value, template);
+          }
+        },
+        fwdInstancePropToHost: function(inst, prop, value) {
+          inst.__template.host.set(prop, value);
+        }
+      });
+      this.instance = new ctor(this, {
+        obj: this.obj,
+        prop: this.prop,
+        outerInnerConflict: {
+          prop: 'bar'
+        }
+      });
+      var parent = Polymer.dom(this).parentNode;
+      Polymer.dom(parent).appendChild(this.instance.root);
+    }
+  });
+
+
+  Polymer({
+    is: 'x-host',
+    properties: {
+      outerProp: {
+        value: 'outerProp'
+      },
+      outerObj: {
+        value: function() {
+          return { prop: 'outerObj.prop' };
+        }
+      },
+      propA: {
+        value: 'prop-a'
+      },
+      objA: {
+        value: function() {
+          return { prop: 'objA.prop' };
+        }
+      },
+      propB: {
+        value: 'prop-b'
+      },
+      objB: {
+        value: function() {
+          return { prop: 'objB.prop' };
+        }
+      },
+      outerInnerConflict: {
+        value: function() {
+          return { prop: 'conflict' };
+        }
+      }
+    },
+    observers: [
+      'outerObjChanged(outerObj.*)',
+      'objAChanged(objA.*)',
+      'objBChanged(objB.*)'
+    ],
+    outerObjChanged: function() {},
+    objAChanged: function() {},
+    objBChanged: function() {},
+    computeFromLiteral: function(literal, prop) { return literal + '-' + prop }
+  });
+
+</script>
+

--- a/test/unit/templatizer.html
+++ b/test/unit/templatizer.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+  <link rel="import" href="templatizer-elements.html">
+</head>
+<body>
+
+<script>
+
+  suite('templatizer client and template separate', function() {
+
+    let host;
+    let childA;
+
+    setup(function() {
+      host = document.createElement('x-host');
+      document.body.appendChild(host);
+      customElements.flush && customElements.flush();
+      host.$.templatizerA.go();
+      childA = host.shadowRoot.querySelector('#childA');
+      assert.ok(childA);
+    });
+
+    teardown(function() {
+      document.body.removeChild(host);
+    });
+
+    test('stamped with initial data', function() {
+      assert.equal(childA.outerProp, 'outerProp');
+      assert.equal(childA.outerObj, host.outerObj);
+      assert.equal(childA.outerObjProp, 'outerObj.prop');
+      assert.equal(childA.prop, 'prop-a');
+      assert.equal(childA.obj, host.objA);
+      assert.equal(childA.objProp, 'objA.prop');
+    });
+
+    test('host properties propagated in', function() {
+      host.outerProp = 'outerProp++';
+      assert.equal(childA.outerProp, 'outerProp++');
+      host.outerObj = { prop: 'outerObj++.prop' };
+      assert.equal(childA.outerObj, host.outerObj);
+      assert.equal(childA.outerObjProp, 'outerObj++.prop');
+    });
+
+    test('host paths propagated in', function() {
+      sinon.spy(childA, 'outerObjChanged');
+      host.set('outerObj.prop', 'outerObj.prop++');
+      assert.equal(childA.outerObjProp, 'outerObj.prop++');
+      assert.isTrue(childA.outerObjChanged.calledOnce);
+      assert.equal(childA.outerObjChanged.getCall(0).args[0].path, 'outerObj.prop');
+      assert.equal(childA.outerObjChanged.getCall(0).args[0].value, 'outerObj.prop++');
+    });
+
+    test('host properties propagated out', function() {
+      childA.outerProp = 'outerProp++';
+      assert.equal(host.outerProp, 'outerProp++');
+      childA.outerObj = { prop: 'outerObj++.prop' };
+      assert.equal(host.outerObj.prop, 'outerObj++.prop');
+    });
+
+    test('host paths propagated out', function() {
+      sinon.spy(host, 'outerObjChanged');
+      childA.set('outerObj.prop', 'outerObj.prop++');
+      assert.equal(host.outerObj.prop, 'outerObj.prop++');
+      assert.isTrue(host.outerObjChanged.calledOnce);
+      assert.equal(host.outerObjChanged.getCall(0).args[0].path, 'outerObj.prop');
+      assert.equal(host.outerObjChanged.getCall(0).args[0].value, 'outerObj.prop++');
+    });
+
+    test('instance properties propagated in', function() {
+      host.propA = 'prop-a++';
+      assert.equal(childA.prop, 'prop-a++');
+      host.objA = { prop: 'objA++.prop' };
+      assert.equal(childA.obj, host.objA);
+      assert.equal(childA.objProp, 'objA++.prop');
+    });
+
+    test('instance paths propagated in', function() {
+      sinon.spy(childA, 'objChanged');
+      host.set('objA.prop', 'objA.prop++');
+      assert.equal(childA.obj.prop, 'objA.prop++');
+      assert.isTrue(childA.objChanged.calledOnce);
+      assert.equal(childA.objChanged.getCall(0).args[0].path, 'obj.prop');
+      assert.equal(childA.objChanged.getCall(0).args[0].value, 'objA.prop++');
+    });
+
+    test('instance properties propagated out', function() {
+      childA.prop = 'prop-a++';
+      assert.equal(host.propA, 'prop-a++');
+      childA.obj = { prop: 'objA++.prop' };
+      assert.equal(host.objA.prop, 'objA++.prop');
+    });
+
+    test('instance paths propagated out', function() {
+      sinon.spy(host, 'objAChanged');
+      childA.set('obj.prop', 'objA.prop++');
+      assert.equal(host.objA.prop, 'objA.prop++');
+      assert.isTrue(host.objAChanged.calledOnce);
+      assert.equal(host.objAChanged.getCall(0).args[0].path, 'objA.prop');
+      assert.equal(host.objAChanged.getCall(0).args[0].value, 'objA.prop++');
+    });
+
+    test('outer & inner props conflict', function() {
+      assert.equal(childA.conflict, 'bar');
+      host.set('outerInnerConflict.prop', 'foo');
+      assert.equal(childA.conflict, 'bar');
+    });
+
+    test('inline computed functions', function() {
+      assert.equal(childA.computedFromLiteral, '33-prop-a');
+    });
+
+    test('ensure literals are not forwarded to templates', function() {
+      assert.notOk(host.__propertyEffects[33]);
+      assert.notOk(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(host), 33));
+    });
+
+    test('ensure undefined is not set on templatizee', function() {
+      assert.equal(host.$.templatizerA[undefined], undefined);
+    });
+
+  });
+
+  suite('templatizer client and template separate', function() {
+
+    let host;
+    let childB;
+
+    setup(function() {
+      host = document.createElement('x-host');
+      document.body.appendChild(host);
+      customElements.flush && customElements.flush();
+      host.shadowRoot.querySelector('[name=templatizerB]').go();
+      childB = host.shadowRoot.querySelector('#childB');
+      assert.ok(childB);
+    });
+
+    teardown(function() {
+      document.body.removeChild(host);
+    });
+
+    test('templatizer with no dataHost', function() {
+      assert.equal(childB.computedFromLiteral, '33-prop-a');
+    });
+
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes case where `_rootDataHost` used for context of inline computing functions in Templatizer instance could be wrong (when templatizing element has no data host).

Also renames `Templatizer.flushDebouncers` to `Templatizer.flush` to match other flush API's.

Also ports over Templatizer tests from 1.x. branch.