### PR TITLE
Clear paths upon object invalidation. Fixes #3998.

### DIFF
--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -629,6 +629,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this.__dataPending && (prop in this.__dataPending);
       }
 
+      _setPendingProperty(prop, value) {
+        // clear cached paths
+        if (typeof value == 'object') {
+          for (var p in this.__data) {
+            if (Polymer.Path.isDescendant(prop, p)) {
+              this.__data[p] = undefined;
+            }
+          }
+        }
+        return super._setPendingProperty(prop, value);
+      }
+
       // Prototype setup ----------------------------------------
 
       _addPropertyEffect(path, type, effect) {

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -279,6 +279,17 @@ suite('basic path bindings', function() {
     verifyObserverOutput(1, el.nested);
   });
 
+  test('cached paths get invalidated by object sets', function() {
+    el.nested = {obj: { value: 'initial' }};
+    assert.equal(el.$.forward.$.compose.$.basic1.notifyingValue, 'initial');
+    el.$.forward.$.compose.$.basic1.notifyingValue = 'correct';
+    assert.equal(el.$.forward.$.compose.$.basic1.notifyingValue, 'correct');
+    el.nested = {obj: { value: 'wrong' }};
+    assert.equal(el.$.forward.$.compose.$.basic1.notifyingValue, 'wrong');
+    el.set('nested.obj.value', 'correct');
+    assert.equal(el.$.forward.$.compose.$.basic1.notifyingValue, 'correct');
+  });
+
   test('similarly named properties', function() {
     var nested = {
       obj: {


### PR DESCRIPTION
This re-institutes the 1.x [`clearPath`](https://github.com/Polymer/polymer/blob/master/src/lib/bind/accessors.html#L87-L93) behavior, which clears cached path values from `__data` when an object root is set.

This is a more correct fix than the one previously discussed (unconditionally read `Polymer.path.get` for all `arg.structured` [in marshalArgs](https://github.com/Polymer/polymer/blob/2.0-preview/src/properties/property-effects.html#L489-L490), since that would still leave invalid cached paths lying around.  I believe it is safe to keep the current optimization in `marshalArgs` that was causing the problem (only read from the object if no path is cached) as long as paths are being cleared when the object is invalidated, but it may be safer to also add that change to make the code less brittle -- to be discussed.

That said, needing to add the `clearPath` code back to the fast path is unfortunate.  Since the entire path notification system is now unified with the property system via `_setProperty`, it would be a significant change to remove all path caching, since queueing a path in `__dataPending` is the unified way to introduce a change into the system.  To be investigated further, but recommending unblocking the issue with this change first.