### PR TITLE
Add gesture support and e.model to templatizer event handling. Fixes #4016.

### DIFF
--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -18,8 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    let TemplateInstanceBase =
-      Polymer.GestureEventListeners(Polymer.BatchedEffects(class{}));
+    let TemplateInstanceBase = Polymer.BatchedEffects(class{});
 
     function PatchedHTMLTemplateElement() {
       return PatchedHTMLTemplateElement._newInstance;
@@ -164,10 +163,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           dispatchEvent() { }
           _addEventListenerToNode(node, eventName, handler) {
-            super._addEventListenerToNode(node, eventName, (e) => {
-              e.model = this;
-              handler(e);
-            });
+            if (this._rootDataHost) {
+              this._rootDataHost._addEventListenerToNode(node, eventName, (e) => {
+                e.model = this;
+                handler(e);
+              });              
+            }
           }
         }
         klass.prototype._bindTemplate(template);

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -18,7 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     'use strict';
 
-    class nullClass {}
+    let TemplateInstanceBase =
+      Polymer.GestureEventListeners(Polymer.BatchedEffects(class{}));
 
     function PatchedHTMLTemplateElement() {
       return PatchedHTMLTemplateElement._newInstance;
@@ -82,7 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _createTemplatizerClass(template, options) {
         // Anonymous class created by the templatizer
-        var klass = class extends Polymer.BatchedEffects(nullClass) {
+        var klass = class extends TemplateInstanceBase {
           //TODO(kschaaf): for debugging; remove?
           get localName() { return 'template#' + this.__template.id + '/TemplateInstance' }
           constructor(host, props) {
@@ -162,8 +163,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this._flushProperties(true);
           }
           dispatchEvent() { }
+          _addEventListenerToNode(node, eventName, handler) {
+            super._addEventListenerToNode(node, eventName, (e) => {
+              e.model = this;
+              handler(e);
+            });
+          }
         }
-        // TODO(kschaaf): event listeners created need to be decorated with e.model
         klass.prototype._bindTemplate(template);
         this._prepInstanceProperties(klass, template, options);
         return klass;

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -3,7 +3,7 @@
 
     <x-templatizer obj="{{objA}}" prop="{{propA}}" id="templatizerA">
       <template>
-        <x-child id="childA"
+        <x-child on-tap="handleTap" id="childA"
           outer-prop="{{outerProp}}"
           outer-obj="{{outerObj}}"
           outer-obj-prop="{{outerObj.prop}}"
@@ -157,6 +157,9 @@
       'objAChanged(objA.*)',
       'objBChanged(objB.*)'
     ],
+    created: function() {
+      this.handleTap = sinon.spy();
+    },
     outerObjChanged: function() {},
     objAChanged: function() {},
     objBChanged: function() {},

--- a/test/unit/templatizer.html
+++ b/test/unit/templatizer.html
@@ -132,6 +132,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(host.$.templatizerA[undefined], undefined);
     });
 
+    test('able to add gesture listeners', function() {
+      assert.equal(host.handleTap.callCount, 0);
+      childA.click();
+      assert.equal(host.handleTap.callCount, 1);
+    });
+
+    test('listener event decorated with model', function() {
+      host.outerProp = 'foo';
+      childA.click();
+      assert.equal(host.handleTap.callCount, 1);
+      let event = host.handleTap.firstCall.args[0];
+      assert.instanceOf(event, Event);
+      assert.ok(event.model);
+      assert.equal(event.model.outerProp, 'foo');
+      host.outerProp = 'bar';
+      assert.equal(event.model.outerProp, 'bar');
+    });
+
   });
 
   suite('templatizer client and template separate', function() {


### PR DESCRIPTION
Add gesture support and e.model to templatizer event handling. Fixes #4016.

Please merge PR #4055 first; this is based on that since it adds templatizer tests.