### PR TITLE
Lazily create & return computedProps if necessary. Fixes #3931.

### DIFF
--- a/src/properties/batched-effects.html
+++ b/src/properties/batched-effects.html
@@ -41,6 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function computeLinkedPaths(inst, changedProps, computedProps) {
     const links = inst.__dataLinkedPaths;
     if (links) {
+      computedProps = computedProps || {};
       let link;
       for (let a in links) {
         let b = links[a];
@@ -57,6 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
     }
+    return computedProps;
   }
 
   function notifyProperties(inst, changedProps, computedProps, oldProps) {
@@ -160,7 +162,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Compute
         let computedProps = runComputedEffects(this, changedProps, oldProps);
         // Compute linked paths
-        computeLinkedPaths(this, changedProps, computedProps);
+        computedProps = computeLinkedPaths(this, changedProps, computedProps);
         // Notify
         let props = notifyProperties(this, changedProps, computedProps, oldProps);
         if (props) {

--- a/test/unit/notify-path-elements.html
+++ b/test/unit/notify-path-elements.html
@@ -96,9 +96,11 @@
         'arrayChangedDeep(array.*)',
         'arrayNoCollChanged(arrayNoColl.splices)',
         'arrayOrPropChanged(prop, array.splices)',
+        // a has other (computed) effects; x & y don't, which allows testing
+        // different code paths in linkPaths tests
         'aChanged(a.*)',
-        'bChanged(b.*)',
-        'cChanged(c.*)'
+        'xChanged(x.*)',
+        'yChanged(y.*)',
       ],
       created: function() {
         this.resetObservers();
@@ -117,8 +119,8 @@
         this.arrayNoCollChanged = sinon.spy();
         this.arrayOrPropChanged = sinon.spy();
         this.aChanged = sinon.spy();
-        this.bChanged = sinon.spy();
-        this.cChanged = sinon.spy();
+        this.xChanged = sinon.spy();
+        this.yChanged = sinon.spy();
         if (this.$) {
           this.$.compose.resetObservers();
           this.$.forward.resetObservers();

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -860,79 +860,69 @@ suite('path API', function() {
   });
 
   test('link two objects', function() {
-    var aChanged = 0;
-    var bChanged = 0;
-    el.a = el.b = {};
-    el.linkPaths('b', 'a');
-    el.aChanged = function() { aChanged++; };
-    el.bChanged = function() { bChanged++; };
-    el.set('a.foo', 1);
-    assert.equal(aChanged, 1);
-    assert.equal(bChanged, 1);
-    el.unlinkPaths('b');
-    el.set('a.foo', 2);
-    assert.equal(aChanged, 2);
-    assert.equal(bChanged, 1);
+    el.x = el.y = {};
+    el.linkPaths('y', 'x');
+    el.xChanged = sinon.spy();
+    el.yChanged = sinon.spy();
+    el.set('x.foo', 1);
+    assert.equal(el.xChanged.callCount, 1);
+    assert.equal(el.yChanged.callCount, 1);
+    el.unlinkPaths('y');
+    el.set('x.foo', 2);
+    assert.equal(el.xChanged.callCount, 2);
+    assert.equal(el.yChanged.callCount, 1);
   });
 
   test('link three objects', function() {
-    var aChanged = 0;
-    var bChanged = 0;
-    var cChanged = 0;
-    el.a = el.b = el.c = {};
-    el.linkPaths('b', 'a');
-    el.linkPaths('c', 'a');
-    el.aChanged = function() { aChanged++; };
-    el.bChanged = function() { bChanged++; };
-    el.cChanged = function() { cChanged++; };
-    el.set('a.foo', 1);
-    assert.equal(aChanged, 1);
-    assert.equal(bChanged, 1);
-    assert.equal(cChanged, 1);
-    el.unlinkPaths('b');
+    el.x = el.y = el.a = {};
+    el.linkPaths('y', 'x');
+    el.linkPaths('a', 'x');
+    el.xChanged = sinon.spy();
+    el.yChanged = sinon.spy();
+    el.aChanged = sinon.spy();
+    el.set('x.foo', 1);
+    assert.equal(el.xChanged.callCount, 1);
+    assert.equal(el.yChanged.callCount, 1);
+    assert.equal(el.aChanged.callCount, 1);
+    el.unlinkPaths('y');
     el.set('a.foo', 2);
-    assert.equal(aChanged, 2);
-    assert.equal(bChanged, 1);
-    assert.equal(cChanged, 2);
+    assert.equal(el.xChanged.callCount, 2);
+    assert.equal(el.yChanged.callCount, 1);
+    assert.equal(el.aChanged.callCount, 2);
   });
 
   test('link two arrays', function() {
-    var aChanged = 0;
-    var bChanged = 0;
-    el.a = el.b = [];
-    el.linkPaths('b', 'a');
-    el.aChanged = function() { aChanged++; };
-    el.bChanged = function() { bChanged++; };
-    el.push('a', {});
+    el.x = el.y = [];
+    el.linkPaths('y', 'x');
+    el.xChanged = sinon.spy();
+    el.yChanged = sinon.spy();
+    el.push('x', {});
     // 2 changes for arrays (splices & length)
-    assert.equal(aChanged, 2);
-    assert.equal(bChanged, 2);
-    el.unlinkPaths('b');
-    el.push('a', {});
-    assert.equal(aChanged, 4);
-    assert.equal(bChanged, 2);
+    assert.equal(el.xChanged.callCount, 2);
+    assert.equal(el.yChanged.callCount, 2);
+    el.unlinkPaths('y');
+    el.push('x', {});
+    assert.equal(el.xChanged.callCount, 4);
+    assert.equal(el.yChanged.callCount, 2);
   });
 
   test('link three arrays', function() {
-    var aChanged = 0;
-    var bChanged = 0;
-    var cChanged = 0;
-    el.a = el.b = el.c = [];
-    el.linkPaths('b', 'a');
-    el.linkPaths('c', 'a');
-    el.aChanged = function() { aChanged++; };
-    el.bChanged = function() { bChanged++; };
-    el.cChanged = function() { cChanged++; };
-    el.push('a', {});
+    el.x = el.y = el.a = [];
+    el.linkPaths('y', 'x');
+    el.linkPaths('a', 'x');
+    el.xChanged = sinon.spy();
+    el.yChanged = sinon.spy();
+    el.aChanged = sinon.spy();
+    el.push('x', {});
     // 2 changes for arrays (splices & length)
-    assert.equal(aChanged, 2);
-    assert.equal(bChanged, 2);
-    assert.equal(cChanged, 2);
-    el.unlinkPaths('b');
-    el.push('a', {});
-    assert.equal(aChanged, 4);
-    assert.equal(bChanged, 2);
-    assert.equal(cChanged, 4);
+    assert.equal(el.xChanged.callCount, 2);
+    assert.equal(el.yChanged.callCount, 2);
+    assert.equal(el.aChanged.callCount, 2);
+    el.unlinkPaths('y');
+    el.push('x', {});
+    assert.equal(el.xChanged.callCount, 4);
+    assert.equal(el.yChanged.callCount, 2);
+    assert.equal(el.aChanged.callCount, 4);
   });
 
   test('get from path in deep observer', function() {


### PR DESCRIPTION
Lazily create & return computedProps if necessary. Fixes #3931.

`computeLinkedPaths` added linked paths to its `computedProps` argument, but that could be null if there were no computed props computed by `runComputedEffects`.  The `linkPath` tests linked properties that also happened to have `computed` effects, which is why it didn't catch the problem.  Adjusted those tests to use a combination of properties that have no other effects (`x` & `y`), plus a third that does (`a`).