### PR TITLE
[2.x] Treat non-Polymer `<template is="smth">` as any other element. 

### DIFF
--- a/src/template/annotations.html
+++ b/src/template/annotations.html
@@ -241,7 +241,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (node.localName === 'template') {
           let t = node;
           let is = t.getAttribute('is');
-          if (is) {
+          // stamp `<dom-*>` elements
+          if (is && is.indexOf('dom-') === 0) {
             t.removeAttribute('is');
             node = t.ownerDocument.createElement(is);
             root.replaceChild(node, t);


### PR DESCRIPTION
Treat non-Polymer `<template is="smth">` as any other element. 
Stamp non-`dom-*` template untouched, do not change it to `<smth>`


### Reference Issue
Polymer/polymer/issues/4060
Polymer/polymer/issues/4068

