### PR TITLE
Upgrade shorthand type to {type:Type} when flattening. Fixes #4066.

### DIFF
--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../utils/boot.html">
 <link rel="import" href="../legacy/dom-module.html">
-<link rel="import" href="../utils/utils.html">
 <link rel="import" href="../utils/case-map.html">
 <link rel="import" href="../events/event-listeners.html">
 <link rel="import" href="../template/template-stamp.html">
@@ -23,8 +22,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
-  let utils = Polymer.Utils;
   let caseMap = Polymer.CaseMap;
+
+  // Same as Polymer.Utils.mixin, but upgrades shorthand type
+  // syntax to { type: Type }
+  function flattenProperties(flattenedProps, props) {
+    for (let p in props) {
+      let o = props[p];
+      if (typeof o == 'function') {
+        o = { type: o };
+      }
+      flattenedProps[p] = o;
+    }
+    return flattenedProps;
+  }
 
   Polymer.ElementMixin = Polymer.Utils.cachingMixin(function(base) {
 
@@ -49,10 +60,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // (2) element default values
       static get _flattenedProperties() {
         if (!this.hasOwnProperty('__flattenedProperties')) {
-          this.__flattenedProperties = this._ownConfig.properties || {};
+          this.__flattenedProperties = flattenProperties({}, this._ownConfig.properties);
           let superCtor = Object.getPrototypeOf(this.prototype).constructor;
           if (superCtor.prototype instanceof PolymerElement) {
-            this.__flattenedProperties = utils.mixin(
+            this.__flattenedProperties = flattenProperties(
               Object.create(superCtor._flattenedProperties),
               this.__flattenedProperties);
           }

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -60,6 +60,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // (2) element default values
       static get _flattenedProperties() {
         if (!this.hasOwnProperty('__flattenedProperties')) {
+          // TODO(sorvell): consider optimizing; shorthand type support requires
+          // an extra loop to upgrade shorthand property info to longhand
           this.__flattenedProperties = flattenProperties({}, this._ownConfig.properties);
           let superCtor = Object.getPrototypeOf(this.prototype).constructor;
           if (superCtor.prototype instanceof PolymerElement) {

--- a/test/unit/attributes-elements.html
+++ b/test/unit/attributes-elements.html
@@ -9,6 +9,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <script>
+  let PropertyTypeBehavior = {
+    properties: {
+      behaviorShorthandNumber: Number,
+      behaviorShorthandBool: Boolean,
+      behaviorNumber: {
+        value: 11,
+        type: Number
+      },
+      behaviorBool: {
+        value: false,
+        type: Boolean
+      }
+    }
+  };
+
   Polymer({
     is: 'x-basic',
     hostAttributes: {
@@ -21,6 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'attr-stupid': false,
       class: 'foo bar baz'
     },
+    behaviors: [ PropertyTypeBehavior ],
     properties: {
       object: {
         type: Object,
@@ -70,10 +86,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: 'prop',
         observer: 'propChanged'
       },
-
       attr1: {
         observer: 'attr1Changed'
-      }
+      },
+      shorthandNumber: Number,
+      shorthandBool: Boolean
     },
 
     propChangedCount: 0,
@@ -93,6 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   Polymer({
     is: 'x-reflect',
+    behaviors: [ PropertyTypeBehavior ],
     properties: {
       object: {
         type: Object,
@@ -146,7 +164,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: String,
         value: 'default',
         readOnly: true
-      }
+      },
+      shorthandNumber: Number,
+      shorthandBool: Boolean
     },
     _warn: function() {
       var search = Array.prototype.join.call(arguments, '');

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -43,7 +43,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         no-type="Should be String"
         read-only="Should not change"
         class="Should not deserialize"
-        nard="Should not deserialize">
+        nard="Should not deserialize"
+        behavior-bool
+        behavior-number="77"
+        shorthand-bool
+        shorthand-number="88"
+        behavior-shorthand-bool
+        behavior-shorthand-number="99"
+        >
       </x-basic>
     </template>
   </test-fixture>
@@ -68,7 +75,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         no-type="Should be String"
         read-only="Should not change"
         class="Should not deserialize"
-        nard="Should not deserialize">
+        nard="Should not deserialize"
+        behavior-bool
+        behavior-number="77"
+        shorthand-bool
+        shorthand-number="88"
+        behavior-shorthand-bool
+        behavior-shorthand-number="99">
       </x-reflect>
     </template>
   </test-fixture>
@@ -87,6 +100,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(element.UPCASE, 'none');
       assert.strictEqual(element.noType, 'none');
       assert.strictEqual(element.readOnly, 'default');
+      assert.strictEqual(element.behaviorNumber, 11);
+      assert.strictEqual(element.behaviorBool, false);
+      assert.strictEqual(element.shorthandNumber, undefined);
+      assert.strictEqual(element.shorthandBool, undefined);
+      assert.strictEqual(element.behaviorShorthandNumber, undefined);
+      assert.strictEqual(element.behaviorShorthandBool, undefined);
     }
 
     function testAttributesMatchCustomConfiguration(element) {
@@ -108,6 +127,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(element.readOnly, 'default');
       assert.strictEqual(element.class, undefined);
       assert.strictEqual(element.nard, undefined);
+      assert.strictEqual(element.behaviorNumber, 77);
+      assert.strictEqual(element.behaviorBool, true);
+      assert.strictEqual(element.shorthandNumber, 88);
+      assert.strictEqual(element.shorthandBool, true);
+      assert.strictEqual(element.behaviorShorthandNumber, 99);
+      assert.strictEqual(element.behaviorShorthandBool, true);
     }
 
     test('basic default values', function() {


### PR DESCRIPTION
### Reference Issue
Fixes #4066

