### PR TITLE
Move resolveUrl to Polymer.Element, get `is` from ctor. Fixes #3992

### DIFF
--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -281,6 +281,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      /**
+       * Rewrites a given URL relative to the original location of the document
+       * containing the `dom-module` for this element.  This method will return
+       * the same URL before and after vulcanization.
+       *
+       * @method resolveUrl
+       * @param {string} url URL to resolve.
+       * @return {string} Rewritten URL relative to the import
+       */
+      resolveUrl(url) {
+        var module = Polymer.DomModule.import(this.constructor.is);
+        var root = '';
+        if (module) {
+          var assetPath = module.getAttribute('assetpath') || '';
+          root = Polymer.ResolveUrl.resolveUrl(
+            assetPath, module.ownerDocument.baseURI);
+        }
+        return Polymer.ResolveUrl.resolveUrl(url, root);
+      }
+
     }
 
   });

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -163,26 +163,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return dom;
       }
 
-      /**
-       * Rewrites a given URL relative to the original location of the document
-       * containing the `dom-module` for this element.  This method will return
-       * the same URL before and after vulcanization.
-       *
-       * @method resolveUrl
-       * @param {string} url URL to resolve.
-       * @return {string} Rewritten URL relative to the import
-       */
-      resolveUrl(url) {
-        var module = Polymer.DomModule.import(this.is);
-        var root = '';
-        if (module) {
-          var assetPath = module.getAttribute('assetpath') || '';
-          root = Polymer.ResolveUrl.resolveUrl(
-            assetPath, module.ownerDocument.baseURI);
-        }
-        return Polymer.ResolveUrl.resolveUrl(url, root);
-      }
-
       /* **** Begin Events **** */
       /**
        * Dispatches a custom event with an optional detail value.

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -24,7 +24,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     HTMLImports.whenReady(function() {
-      Polymer({is: 'x-resolve'});
+      class XResolve extends Polymer.Element {
+        static get is() { return 'x-resolve'; }
+      }
+      customElements.define(XResolve.is, XResolve);
     });
   </script>
 

--- a/test/unit/sub/resolveurl-elements.html
+++ b/test/unit/sub/resolveurl-elements.html
@@ -28,10 +28,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 </dom-module>
 <script>
-  Polymer({is: 'p-r'});
+  class PR extends Polymer.Element {
+    static get is() { return 'p-r'; }
+  }
+  customElements.define(PR.is, PR);
 </script>
 
 <dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>
 <script>
-  Polymer({is: 'p-r-ap'});
+  class PRAp extends Polymer.Element {
+    static get is() { return 'p-r-ap'; }
+  }
+  customElements.define(PRAp.is, PRAp);
 </script>


### PR DESCRIPTION
### Reference Issue
Fixes #3992

### Details
The reason `resolveUrl` didn't work even on `class extend LegacyElement` is because in the class-based syntax the `static get is()` getter is only on the constructor, and never gets put on the prototype/instance.

For this change, I just made `resolveUrl` look at `this.constructor.is` instead of `this.is`.  However, we might want to re-consider if we really want to lose `is` from the prototype/instance or not (was this an intentional change?).

