### PR TITLE
Prevent _showHideChildren from being called on placeholders.

### DIFF
--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -720,7 +720,8 @@ Then the `observe` property should be configured as follows:
     // Implements extension point from Templatizer mixin
     _showHideChildren: function(hidden) {
       for (var i=0; i<this._instances.length; i++) {
-        this._instances[i]._showHideChildren(hidden);
+        if (!this._instances[i].isPlaceholder)
+          this._instances[i]._showHideChildren(hidden);
       }
     },
 


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->

This CL fixes issue #4096 where certain cases could cause
_showHideChildren to get called on template placeholders.