### PR TITLE
Dom-repeat... fixed when to throw message about absent template

### DIFF
--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -288,10 +288,10 @@ Then the `observe` property should be configured as follows:
       // it until then
       if (!this._ctor) {
         var template = this.template = this.querySelector('template');
-        template.__domRepeat = this;
         if (!template) {
           throw new Error('dom-repeat requires a <template> child');
         }
+        template.__domRepeat = this;
         // Template instance props that should be excluded from forwarding
         var instanceProps = {};
         instanceProps[this.as] = true;


### PR DESCRIPTION
Fixed small bug where absent `<template>` in `<dom-repeat>` was causing `NullPoint`
