### PR TITLE
Avoid calling `ShadyDOM.flush` in `observeNodes`.

### DIFF
--- a/src/utils/polymer.dom.html
+++ b/src/utils/polymer.dom.html
@@ -183,9 +183,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     observeNodes(callback) {
-      if (window.ShadyDOM) {
-        ShadyDOM.flush();
-      }
       return new EffectiveNodesObserver(this.node, callback);
     }
 

--- a/test/unit/polymer-dom-observeNodes.html
+++ b/test/unit/polymer-dom-observeNodes.html
@@ -17,6 +17,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
+  <dom-module id='test-self-observe'>
+    <template>
+      <slot id="slot"></slot>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is:'test-self-observe',
+        attached: function() {
+          this._observer = Polymer.dom(this).observeNodes(function(info) {
+            this.info = info;
+          })
+        },
+        detached: function() {
+          Polymer.dom(this).unobserveNodes(this._observer);
+        }
+      });
+    });
+    </script>
+  </dom-module>
+
   <dom-module id='test-static'>
     <template>
       <div>static</div>
@@ -1039,6 +1060,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
+    });
+
+    test('element distributed to insertion point observing itself', function() {
+      var host = document.createElement('test-slot');
+      var el = document.createElement('test-self-observe');
+      host.appendChild(el);
+      document.body.appendChild(host);
+      if (customElements.flush) {
+        customElements.flush();
+      }
+      if (window.ShadyDOM) {
+        ShadyDOM.flush();
+      }
+      assert.ok(el._observer);
+      var div = document.createElement('div');
+      el.appendChild(div);
+      el._observer.flush();
+      assert.equal(el.info.addedNodes[0], div);
+      document.body.removeChild(host);
     });
 
   });


### PR DESCRIPTION
### Reference Issue
Fixes #4049. 

 This was unnecessary and could cause an exception. Consider an element that calls `observeNodes` in connected and stores the returned observer and then calls `unobserveNodes(observer)` in disconnected. Since `flush` triggers distribution and under ShadyDOM this can cause disconnect/connect, this means a disconnectedCallback could run prior to observerNodes returning.