### PR TITLE
`Polymer.dom(..).activeElement` gets `_activeElement` (ShadyDOM) if available.

### DIFF
--- a/src/utils/polymer.dom.html
+++ b/src/utils/polymer.dom.html
@@ -248,6 +248,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return list;
     }
 
+    get activeElement() {
+      let node = this.node;
+      return node._activeElement !== undefined ? node._activeElement : node.activeElement;
+    }
   }
 
   function forwardMethods(proto, methods) {
@@ -293,7 +297,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ]);
 
   forwardReadOnlyProperties(DomApi.prototype, [
-    'activeElement',
     'parentNode', 'firstChild', 'lastChild',
     'nextSibling', 'previousSibling', 'firstElementChild',
     'lastElementChild', 'nextElementSibling', 'previousElementSibling',

--- a/test/unit/polymer-dom.html
+++ b/test/unit/polymer-dom.html
@@ -59,6 +59,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </script>
   </dom-module>
 
+  <dom-module id="x-focusable-in-shadow">
+    <template>
+      <input id="focusable"></input>
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'x-focusable-in-shadow'
+      });
+    });
+    </script>
+  </dom-module>
+
    <test-fixture id="scoped">
     <template>
       <x-event-scoped></x-event-scoped>
@@ -68,6 +81,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="slot">
     <template>
       <x-container-slot></x-container-slot>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="focusableInShadow">
+    <template>
+      <x-focusable-in-shadow></x-focusable-in-shadow>
     </template>
   </test-fixture>
 
@@ -155,6 +174,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       el.fireComposed();
     });
 
+  });
+
+  suite('activeElement getter', function() {
+    test('Retrieves `_activeElement` (ShadyDOM) or `activeElement`.', function() {
+      var focusableInShadow = fixture('focusableInShadow');
+      focusableInShadow.$.focusable.focus();
+      var rootNode = focusableInShadow.getRootNode();
+      assert.equal(Polymer.dom(rootNode).activeElement, focusableInShadow);
+      assert.equal(Polymer.dom(focusableInShadow.shadowRoot).activeElement, focusableInShadow.$.focusable);
+    });
   });
 
 </script>


### PR DESCRIPTION
This PR hides the `_activeElement` vs `activeElement` distinction in ShadyDOM from users of the older `Polymer.dom` API so that getting `activeElement` from it continues to work in 2.0.