### PR TITLE
Allow property to be computed that is used as dependency of another computed property

### DIFF
--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -201,18 +201,79 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
-      // create a property using the metadata in the `config` object
+      /**
+       * Creates effects for a property.
+       *
+       * Example:
+       *
+       *     this._createPropertyFromConfig('foo', {
+       *       type: String, value: 'foo', reflectToAttribute: true
+       *     });
+       *
+       * Note, once a property has been set to
+       * `readOnly`, `computed`, `reflectToAttribute`, or `notify`
+       * these values may not be changed. For example, a subclass cannot
+       * alter these settings. However, additional `observers` may be added
+       * by subclasses.
+       *
+       * @param {string} name Name of the property.
+       * @param {*=} info Info object from which to create property effects.
+       * Supported keys:
+       *
+       * * type: {function} type to which an attribute matching the property
+       * is deserialized. Note the property is camel-cased from a dash-cased
+       * attribute. For example, 'foo-bar' attribute is dersialized to a
+       * property named 'fooBar'.
+       *
+       * * readOnly: {boolean} creates a readOnly property and
+       * makes a private setter for the private of the form '_setFoo' for a
+       * property 'foo',
+       *
+       * * computed: {string} creates a computed property. A computed property
+       * also automatically is set to `readOnly: true`. The value is calculated
+       * by running a method and arguments parsed from the given string. For
+       * example 'compute(foo)' will compute a given property when the
+       * 'foo' property changes by executing the 'compute' method. This method
+       * must return the computed value.
+       *
+       * * reflectToAttriute: {boolean} If true, the property value is reflected
+       * to an attribute of the same name. Note, the attribute is dash-cased
+       * so a property named 'fooBar' is reflected as 'foo-bar'.
+       *
+       * * notify: {boolean} sends a non-bubbline notification event when
+       * the property changes. For example, a property named 'foo' sends an
+       * event named 'foo-changed' with `event.detail` set to the value of
+       * the property.
+       *
+       * * observer: {string} name of a method that runs when the property
+       * changes. The arguments of the method are (value, previousValue).
+       *
+      */
+      /* TODO(sorvell): Users may want control over modifying property
+       effects via subclassing. For example, a user might want to make a
+       reflectToAttribute property not do so in a subclass. We've chosen to
+       disable this because it leads to additional complication.
+       For example, a readOnly effect generates a special setter. If a subclass
+       disables the effect, the setter would fail unexpectedly.
+       Based on feedback, we may want to try to make effects more malleable
+       and/or provide an advanced api for manipulating them.
+       Also consider adding warnings when an effect cannot be changed.
+      */
       _createPropertyFromConfig(name, info) {
         // computed forces readOnly...
         if (info.computed) {
           info.readOnly = true;
         }
-        // readOnly, computed, reflect, notify only if not already doing so...
+        // Note, since all computed properties are readOnly, this prevents
+        // adding additional computed property effects (which leads to a confusing
+        // setup where multiple triggers for setting a property)
+        // While we do have `hasComputedEffect` this is set on the property's
+        // dependencies rather than itself.
+        if (info.computed  && !this._hasReadOnlyEffect(name)) {
+          this._createComputedProperty(name, info.computed);
+        }
         if (info.readOnly && !this._hasReadOnlyEffect(name)) {
           this._createReadOnlyProperty(name, !info.computed);
-        }
-        if (info.computed && !this._hasComputedEffect(name)) {
-          this._createComputedProperty(name, info.computed);
         }
         if (info.reflectToAttribute && !this._hasReflectEffect(name)) {
           this._createReflectedProperty(name);

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -47,6 +47,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         hasBehaviorA: {
           value: true
+        },
+
+        computeADependency: {
+          value: true
+        },
+
+        computeA: {
+          computed: '_computeProp(computeADependency)'
         }
       },
 
@@ -75,6 +83,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _toOverride: function() {
+      },
+
+      _computeProp: function(a) {
+        return a;
       }
     };
 
@@ -98,6 +110,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         overridablePropertyB: {
           value: true
+        },
+
+        computeADependencyDependency: {
+          value: 'hi'
+        },
+
+        computeADependency: {
+          computed: '_computeProp(computeADependencyDependency)'
         }
 
       },
@@ -319,10 +339,14 @@ suite('single behavior element', function() {
     assert.equal(el.__change, 'bar');
   });
 
-  test('property info from behavior A', function() {
+  test('property info from behavior', function() {
     assert.equal(el._hasNotifyEffect('hasOptionsA'), true);
     assert.equal(el._hasReadOnlyEffect('hasOptionsA'), true);
     assert.equal(typeof el._setHasOptionsA, 'function');
+  });
+
+  test('compute property from behavior', function() {
+    assert.equal(el.computeA, true);
   });
 
   test.skip('beforeRegister behavior', function() {
@@ -401,6 +425,10 @@ suite('multi-behaviors element', function() {
     assert.equal(el._hasReadOnlyEffect('hasOptionsB'), true);
     assert.equal(el._hasNotifyEffect('hasOptionsB'), true);
     assert.equal(typeof el._setHasOptionsB, 'function');
+  });
+
+  test('computed property dependency can become a computed property', function() {
+    assert.equal(el.computeA, 'hi');
   });
 
   test('multi-behavior overrides ordering', function() {

--- a/test/unit/polymer.element.html
+++ b/test/unit/polymer.element.html
@@ -33,6 +33,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               prop: {
                 value: 'base',
                 observer: '_propObserver'
+              },
+              computedPropDep: {
+                value: true
+              },
+              computedProp: {
+                computed: '_compute(computedPropDep)'
               }
             },
             observers: [
@@ -64,6 +70,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._ensureAttribute('tabIndex', 0);
           this.addEventListener('click', (e) => this._tapListener(e));
           this._calledReady++;
+        }
+
+        _compute(value) {
+          return value;
         }
       }
 
@@ -98,6 +108,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               prop2: {
                 value: 'prop2',
                 observer: '_prop2Observer'
+              },
+              computedPropDep: {
+                computed: '_compute(prop2)'
               }
             },
             observers: [
@@ -316,6 +329,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(el._tapListener.callCount, 1);
     });
 
+    test('properties', function() {
+      assert.equal(el.prop, 'base');
+      assert.equal(el.computedPropDep, true);
+      assert.equal(el.computedProp, true);
+    });
+
     test('attributes', function() {
       var fixtureEl = fixture('my-element-attr');
       assert.equal(fixtureEl.prop, 'attr');
@@ -373,6 +392,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('listeners', function() {
       el.dispatchEvent(new CustomEvent('click'));
       assert.equal(el._tapListener.callCount, 2);
+    });
+
+    test('properties', function() {
+      assert.equal(el.prop, 'sub');
+      assert.equal(el.prop2, 'prop2');
+      assert.equal(el.computedPropDep, 'prop2');
+      assert.equal(el.computedProp, 'prop2', 'computedProp dependency cannot itself be a computed property');
     });
 
     test('attributes', function() {


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fixes #4122

Computed properties, once defined cannot be altered. The check used to determine if a property was computed was incorrect (instead checking the property was a dependency of another computed property). Now we simply check if the property has been made readOnly. Also added docs explaining the functionality and limitations of `_createPropertyFromConfig`.