### PR TITLE
Don't flush props if props aren't passed

### DIFF
--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -75,8 +75,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // template
         klass = class TemplateInstance extends baseClass {};
         klass.prototype.__template = template;
-        klass.instCount = 0;   
-        template.__templatizerClass = klass;         
+        klass.instCount = 0;
+        template.__templatizerClass = klass;
         return klass;
       }
 
@@ -95,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // is guaranteed to have a __dataHost (due to being in __dataNodes for
             // purposes of getting templateContent)
             let templateHost = this.__template.__dataHost;
-            this._rootDataHost = 
+            this._rootDataHost =
               templateHost && templateHost._rootDataHost || templateHost;
             this._hostProps = template._content._hostProps;
             this._configureProperties(props);
@@ -110,7 +110,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             if (host.__hideTemplateChildren__) {
               this._showHideChildren(true);
             }
-            this._flushProperties(true);
+            // Flush props only when props are passed if instance props exist
+            // or when there isn't instance props.
+            if ((props && options.instanceProps) || !options.instanceProps) {
+              this._flushProperties(true);
+            }
           }
           _showHideChildren(hide) {
             var c = this.children;
@@ -167,7 +171,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               this._rootDataHost._addEventListenerToNode(node, eventName, (e) => {
                 e.model = this;
                 handler(e);
-              });              
+              });
             }
           }
         }

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -88,7 +88,7 @@
         this.instance.flushProperties();
       }
     },
-    go: function() {
+    go: function(withProps) {
       var template = Polymer.dom(this).querySelector('template');
       template.host = this;
       var ctor = templatizer.templatize(template, {
@@ -106,13 +106,14 @@
           inst.__template.host.set(prop, value);
         }
       });
-      this.instance = new ctor(this, {
-        obj: this.obj,
-        prop: this.prop,
-        outerInnerConflict: {
-          prop: 'bar'
-        }
-      });
+      this.instance = new ctor(this,
+        withProps ? {
+          obj: this.obj,
+          prop: this.prop,
+          outerInnerConflict: {
+            prop: 'bar'
+          }
+        } : null);
       var parent = Polymer.dom(this).parentNode;
       Polymer.dom(parent).appendChild(this.instance.root);
     }

--- a/test/unit/templatizer.html
+++ b/test/unit/templatizer.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       host = document.createElement('x-host');
       document.body.appendChild(host);
       customElements.flush && customElements.flush();
-      host.$.templatizerA.go();
+      host.$.templatizerA.go(true);
       childA = host.shadowRoot.querySelector('#childA');
       assert.ok(childA);
     });
@@ -161,9 +161,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       host = document.createElement('x-host');
       document.body.appendChild(host);
       customElements.flush && customElements.flush();
-      host.shadowRoot.querySelector('[name=templatizerB]').go();
-      childB = host.shadowRoot.querySelector('#childB');
-      assert.ok(childB);
+
     });
 
     teardown(function() {
@@ -171,7 +169,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('templatizer with no dataHost', function() {
+      host.shadowRoot.querySelector('[name=templatizerB]').go(true);
+      childB = host.shadowRoot.querySelector('#childB');
+      assert.ok(childB);
       assert.equal(childB.computedFromLiteral, '33-prop-a');
+    });
+
+    test('templatizer with no props', function() {
+      host.shadowRoot.querySelector('[name=templatizerB]').go(false);
+      childB = host.shadowRoot.querySelector('#childB');
+      assert.ok(childB);
+      assert.isUndefined(childB.computedFromLiteral);
     });
 
   });


### PR DESCRIPTION
The current implementation of `Templatizer` automatically flushes instance properties even when props aren't passed to the constructor. This causes bindings to run with `undefined` values.

This change will make properties flush at construction time only if:
1. There is no instance properties defined.
2.  If instance properties are passed when these are defined (via `options.instanceProps`).

Otherwise, `instance.flushProperties()` should be called after instance props are forwarded.

