### PR TITLE
Observer property pass

### DIFF
--- a/src/lib/bind/effects.html
+++ b/src/lib/bind/effects.html
@@ -48,7 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _observerEffect: function(source, value, effect, old) {
       var fn = this[effect.method];
       if (fn) {
-        fn.call(this, value, old);
+        fn.call(this, value, old, source);
       } else {
         this._warn(this._logf('_observerEffect', 'observer method `' +
           effect.method + '` not defined'));

--- a/test/unit/bind-elements.html
+++ b/test/unit/bind-elements.html
@@ -164,42 +164,47 @@
           this.observerCounts[i] = 0;
         }
       },
-      valueChanged: function(val, old) {
+      valueChanged: function(val, old, property) {
         this.observerCounts.valueChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.value, 'observer value argument wrong');
         assert.equal(old, this._value, 'observer old argument wrong');
+        assert.equal(property, 'value', 'observer property argument wrong');
         this._value = val;
       },
       computeValue: function(val) {
         return val + 1;
       },
-      computedvalueChanged: function(val, old) {
+      computedvalueChanged: function(val, old, property) {
         this.observerCounts.computedvalueChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.computedvalue, 'observer value argument wrong');
         assert.equal(old, this._computedvalue, 'observer old argument wrong');
+        assert.equal(property, 'computedvalue', 'observer property argument wrong');
         this._computedvalue = val;
       },
-      computedvaluetwoChanged: function(val, old) {
+      computedvaluetwoChanged: function(val, old, property) {
         this.observerCounts.computedvaluetwoChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.computedvaluetwo, 'observer value argument wrong');
         assert.equal(old, this._computedvaluetwo, 'observer old argument wrong');
+        assert.equal(property, 'computedvaluetwo', 'observer property argument wrong');
         this._computedvaluetwo = val;
       },
-      notifyingvalueChanged: function(val, old) {
+      notifyingvalueChanged: function(val, old, property) {
         this.observerCounts.notifyingvalueChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.notifyingvalue, 'observer value argument wrong');
         assert.equal(old, this._notifyingvalue, 'observer old argument wrong');
+        assert.equal(property, 'notifyingvalue', 'observer property argument wrong');
         this._notifyingvalue = val;
       },
-      readonlyvalueChanged: function(val, old) {
+      readonlyvalueChanged: function(val, old, property) {
         this.observerCounts.readonlyvalueChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.readonlyvalue, 'observer value argument wrong');
         assert.equal(old, this._readonlyvalue, 'observer old argument wrong');
+        assert.equal(property, 'readonlyvalue', 'observer property argument wrong');
         this._readonlyvalue = val;
       },
       notifierWithoutComputingChanged: function() {
@@ -215,11 +220,12 @@
         assert.equal(divide, this.divide, 'observer value argument wrong');
         return (sum1 + sum2) / divide;
       },
-      computedFromMultipleValuesChanged: function(val, old) {
+      computedFromMultipleValuesChanged: function(val, old, property) {
         this.observerCounts.computedFromMultipleValuesChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.computedFromMultipleValues, 'observer value argument wrong');
         assert.equal(old, this._computedFromMultipleValues, 'observer old argument wrong');
+        assert.equal(property, 'computedFromMultipleValues', 'observer property argument wrong');
         this._computedFromMultipleValues = val;
       },
       multipleDepChangeHandler: function(dep1, dep2, dep3) {
@@ -236,11 +242,12 @@
         assert.equal(divide, this.divide, 'dependency 3 argument wrong');
         return (value + add) / divide;
       },
-      customEventValueChanged: function(val, old) {
+      customEventValueChanged: function(val, old, property) {
         this.observerCounts.customEventValueChanged++;
-        assert.equal(arguments.length, 2, 'observer argument length wrong');
+        assert.equal(arguments.length, 3, 'observer argument length wrong');
         assert.equal(val, this.customEventValue, 'observer value argument wrong');
         assert.equal(old, this._customEventValue, 'observer old argument wrong');
+        assert.equal(property, 'customEventValue', 'observer property argument wrong');
         this._customEventValue = val;
       },
       customEventObjectValueChanged: function(val) {


### PR DESCRIPTION
Pass `property` name as third argument in observer callback. It's very useful to reuse observer logic when we know the name of changed property.
