### PR TITLE
check if attribute actually changed

### DIFF
--- a/src/legacy/dom-module.html
+++ b/src/legacy/dom-module.html
@@ -28,8 +28,10 @@
 
     static get observedAttributes() { return ['id'] }
 
-    attributeChangedCallback() {
-      this.register();
+    attributeChangedCallback(name, value, old) {
+      if (value !== old) {
+        this.register();
+      }
     }
 
     _styleOutsideTemplateCheck() {


### PR DESCRIPTION
Fix to avoid infinite loops in STP (id gets set in `register`, then `attributeChangedCallback` would call `register` again causing the infinite loop)

@sorvell PTAL
