### PR TITLE
Fix for #4150

### DIFF
--- a/src/standard/annotations.html
+++ b/src/standard/annotations.html
@@ -114,6 +114,15 @@ TODO(sjmiles): this module should produce either syntactic metadata
 
 */
 
+(function () {
+  var ifTextAreaHasPlaceholderBug = (function () {
+    var textArea = document.createElement('textarea'),
+        placeholderValue = "bugged";
+    textArea.setAttribute('placeholder', placeholderValue);
+    return textArea.textContent === placeholderValue;
+  }());
+
+
   Polymer.Base._addFeature({
 
     // registration-time
@@ -126,14 +135,29 @@ TODO(sjmiles): this module should produce either syntactic metadata
         var self = this;
         Polymer.Annotations.prepElement = function(element) {
           self._prepElement(element);
-        }
+        };
         if (this._template._content && this._template._content._notes) {
           this._notes = this._template._content._notes;
         }  else {
+          if (ifTextAreaHasPlaceholderBug) {
+            this._fixTextAreaPlaceholderBug(this._template.content.querySelectorAll('textarea'));
+          }
+
           this._notes = Polymer.Annotations.parseAnnotations(this._template);
           this._processAnnotations(this._notes);
         }
         Polymer.Annotations.prepElement = null;
+      }
+    },
+
+    _fixTextAreaPlaceholderBug: function(elementList) {
+      if (!elementList.length) {
+        return;
+      }
+
+      var i;
+      for (i = 0; i < elementList.length; ++i) {
+        elementList[i].textContent = elementList[i].value;
       }
     },
 
@@ -326,5 +350,6 @@ TODO(sjmiles): this module should produce either syntactic metadata
     }
 
   });
+}());
 
 </script>

--- a/test/unit/dom-module-elements.html
+++ b/test/unit/dom-module-elements.html
@@ -16,3 +16,19 @@
     is: 'Test-element'
   });
 </script>
+
+<dom-module id="textarea-test">
+  <template>
+    <textarea id="outer-textarea" placeholder="placeholder"></textarea>
+
+    <div>
+      <textarea id="inner-textarea" placeholder="placeholder" ></textarea>
+    </div>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'textarea-test'
+  });
+</script>

--- a/test/unit/dom-module.html
+++ b/test/unit/dom-module.html
@@ -58,6 +58,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
+    suite('textarea element inside dom-module', function () {
+      var element;
+
+      setup(function () {
+        element = document.createElement('textarea-test');
+      });
+
+      test('`placeholder` value is not being copied as content', function() {
+        assert.equal(element.$$('#inner-textarea').innerHTML, '');
+      });
+
+      test('`placeholder` value is not being copied as content when element is nested', function() {
+        assert.equal(element.$$('#outer-textarea').innerHTML, '');
+      });
+    });
+
   </script>
 
 </body>


### PR DESCRIPTION
Fixes #4150

The source of the bug is a problem from IE 10/11 that causes `placeholder` attribute value to be copied as textarea content. It caused an additional and improper(?) binding that was found at _parseChildNodesAnnotations.

