### PR TITLE
More practical caching strategy for importHref

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -416,7 +416,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // will be automatically created again the next time `importHref` is
         // called.
         if (link.parentNode) {
-          link.parentNode.removeChild(this);
+          link.parentNode.removeChild(link);
         }
         if (onerror) {
           whenImportsReady(function() {

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -17,16 +17,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
-  // run a callback when HTMLImports are ready or immediately if
-  // this api is not available.
-  function whenImportsReady(cb) {
-    if (window.HTMLImports) {
-      HTMLImports.whenReady(cb);
-    } else {
-      cb();
-    }
-  }
-
   Polymer.Base._addFeature({
 
     /**
@@ -405,9 +395,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // it is called with the same href param.
         link.__dynamicImportLoaded = true;
         if (onload) {
-          whenImportsReady(function() {
-            onload.call(self, event);
-          });
+          onload.call(self, event);
         }
       };
       var errorListener = function(event) {
@@ -419,9 +407,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           link.parentNode.removeChild(link);
         }
         if (onerror) {
-          whenImportsReady(function() {
-            onerror.call(self, event);
-          });
+          onerror.call(self, event);
         }
       };
       link.addEventListener('load', loadListener);

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -367,50 +367,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {HTMLLinkElement} The link element for the URL to be loaded.
      */
     importHref: function(href, onload, onerror, optAsync) {
-      var link = document.createElement('link');
-      link.rel = 'import';
-      link.href = href;
-      var list = Polymer.Base.importHref.imported = 
-        Polymer.Base.importHref.imported || {};
-      var cached = list[link.href];
-      var imprt = cached || link;
+      var link = document.head.querySelector('[href="' + href + '"]');
       var self = this;
-      var loadListener = function(e) {
-        e.target.__firedLoad = true;
-        e.target.removeEventListener('load', loadListener);
-        e.target.removeEventListener('error', errorListener);
-        return onload.call(self, e);
-      };
-      var errorListener = function(e) {
-        e.target.__firedError = true;
-        e.target.removeEventListener('load', loadListener);
-        e.target.removeEventListener('error', errorListener);
-        return onerror.call(self, e);
-      };
-      if (onload) {
-        imprt.addEventListener('load', loadListener);
+
+      if (link == null) {
+        link = document.createElement('link');
+        link.rel = 'import';
+        link.__dynamicImport = true;
       }
-      if (onerror) {
-        imprt.addEventListener('error', errorListener);
+
+      if (optAsync) {
+        link.setAttribute('async', '');
       }
-      // if already loaded/erroed, fire 'fake' load/error event
-      if (cached) {
-        if (cached.__firedLoad) {
-          cached.dispatchEvent(new Event('load'));
+
+      var loadListener = function(event) {
+        link.removeEventListener('load', loadListener);
+        link.removeEventListener('error', errorListener);
+        // In case of a successful load, cache the load event on the link so
+        // that it can be used to short-circuit this method in the future when
+        // it is called with the same href param.
+        link.__dynamicImportLoaded = true;
+
+        if (onload != null) {
+          return onload.call(self, event);
         }
-        if (cached.__firedError) {
-          cached.dispatchEvent(new Event('error'));
+      };
+      var errorListener = function(event) {
+        link.removeEventListener('load', loadListener);
+        link.removeEventListener('error', errorListener);
+        // In case of an error, remove the link from the document so that it
+        // will be automatically created again the next time `importHref` is
+        // called.
+        document.head.removeChild(link);
+        if (onerror != null) {
+          return onerror.call(self, event);
         }
-      // otherwise put in dom!
-      } else {
-        list[link.href] = link;
-        optAsync = Boolean(optAsync);
-        if (optAsync) {
-          link.setAttribute('async', '');
-        }
+      };
+
+      link.addEventListener('load', loadListener);
+      link.addEventListener('error', errorListener);
+
+      if (link.parentNode == null) {
+        link.href = href;
         document.head.appendChild(link);
+      } else if (link.__dynamicImportLoaded || !link.__dynamicImport) {
+        link.dispatchEvent(new Event('load'));
       }
-      return imprt;
+
+      return link;
     },
 
     /**
@@ -460,17 +464,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /*
     We patch importHref under the CE polyfill for 2 separate reasons:
     (1) performance optimization: CE registrations upgrade the entire document
-    tree including imports. Therefore if an import is loaded every element 
-    registered will upgrade the entire doc tree. This is $ and is optimized 
+    tree including imports. Therefore if an import is loaded every element
+    registered will upgrade the entire doc tree. This is $ and is optimized
     via batching to occur once at startup (before WebComponentsReady). We
-    override importHref here so that we can batch upgrades until after the 
+    override importHref here so that we can batch upgrades until after the
     import has loded, leveraging the same batching optimization.
     (2) the CE polyfill upgrades elements in HI in the wrong order. They upgrade
-    after all scripts in the import have run rather than being interleaved with 
-    them. Therefore, any script that depends on a previous custom element in 
+    after all scripts in the import have run rather than being interleaved with
+    them. Therefore, any script that depends on a previous custom element in
     the import will fail. By deferring upgrades until after async imports load
-    we reduce the chance of a problem because upgrade time dependencies are 
-    no longer an issue. (e.g. `dom-module` is a registration time dependency 
+    we reduce the chance of a problem because upgrade time dependencies are
+    no longer an issue. (e.g. `dom-module` is a registration time dependency
     when `lazyRegister` is not used and it is specially handled in `dom-module`;
     `custom-style` is an upgrade time dependency native css properties are used).
 

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -17,6 +17,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
+  // run a callback when HTMLImports are ready or immediately if
+  // this api is not available.
+  function whenImportsReady(cb) {
+    if (window.HTMLImports) {
+      HTMLImports.whenReady(cb);
+    } else {
+      cb();
+    }
+  }
+
   Polymer.Base._addFeature({
 
     /**
@@ -367,53 +377,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {HTMLLinkElement} The link element for the URL to be loaded.
      */
     importHref: function(href, onload, onerror, optAsync) {
-      var link = document.head.querySelector('[href="' + href + '"]');
-      var self = this;
-
-      if (link == null) {
+      var link =
+        document.head.querySelector('link[href="' + href + '"][import-href]');
+      if (!link) {
         link = document.createElement('link');
         link.rel = 'import';
-        link.__dynamicImport = true;
+        link.href = href;
+        link.setAttribute('import-href', '');
       }
-
+      // always ensure link has `async` attribute if user specified one,
+      // even if it was previously not async. This is considered less confusing.
       if (optAsync) {
         link.setAttribute('async', '');
       }
-
-      var loadListener = function(event) {
+      // NOTE: the link may now be in 3 states: (1) pending insertion,
+      // (2) inflight, (3) already laoded. In each case, we need to add
+      // event listeners to process callbacks.
+      var cleanup = function() {
         link.removeEventListener('load', loadListener);
         link.removeEventListener('error', errorListener);
+      }
+      var self = this;
+      var loadListener = function(event) {
+        cleanup();
         // In case of a successful load, cache the load event on the link so
         // that it can be used to short-circuit this method in the future when
         // it is called with the same href param.
         link.__dynamicImportLoaded = true;
-
-        if (onload != null) {
-          return onload.call(self, event);
+        if (onload) {
+          whenImportsReady(function() {
+            onload.call(self, event);
+          });
         }
       };
       var errorListener = function(event) {
-        link.removeEventListener('load', loadListener);
-        link.removeEventListener('error', errorListener);
+        cleanup();
         // In case of an error, remove the link from the document so that it
         // will be automatically created again the next time `importHref` is
         // called.
-        document.head.removeChild(link);
-        if (onerror != null) {
-          return onerror.call(self, event);
+        if (link.parentNode) {
+          link.parentNode.removeChild(this);
+        }
+        if (onerror) {
+          whenImportsReady(function() {
+            onerror.call(self, event);
+          });
         }
       };
-
       link.addEventListener('load', loadListener);
       link.addEventListener('error', errorListener);
-
       if (link.parentNode == null) {
-        link.href = href;
         document.head.appendChild(link);
-      } else if (link.__dynamicImportLoaded || !link.__dynamicImport) {
+      // if the link already loaded, dispatch a fake load event
+      // so that listeners are called and get a proper event argument.
+      } else if (link.__dynamicImportLoaded) {
         link.dispatchEvent(new Event('load'));
       }
-
       return link;
     },
 

--- a/test/unit/dynamic-import.html
+++ b/test/unit/dynamic-import.html
@@ -40,6 +40,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       var url = 'dynamic-imports/dynamic-element.html';
 
+      test('importHref does not cache failed results', function(done) {
+        Polymer.Base.importHref('does_not_exist.html', function() {
+          throw new Error('Load handler should not be called.');
+        }, function() {
+          var link = document.head
+              .querySelector('[href="does_not_exist.html"]');
+          assert.isNotOk(link, 'The link should not exist');
+          done();
+        });
+      });
+
+      test('importHref caches successful results', function(done) {
+        var targetUrl = 'dynamic-imports/async-import.html';
+
+        Polymer.Base.importHref(targetUrl, function(event) {
+          var targetOne = event.target;
+          Polymer.Base.importHref(targetUrl, function(event) {
+            var targetTwo = event.target;
+
+            assert.isOk(targetOne, 'Event target should be available');
+            assert.strictEqual(targetOne, targetTwo,
+                'Link element references should be identical');
+            done();
+          }, done);
+        }, done);
+      });
+
       test('importHref sync loads by default', function(done) {
         Polymer.Base.importHref(url, function(e) {
           assert.isFalse(e.target.hasAttribute('async'),


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fixes https://github.com/Polymer/polymer/issues/3908

Previously, importHref would cache failed results. This caused failures
to be cached indefinitely, even when the failure was the result of
conditions that are subject to change over time (such as poor network
connectivity).

This implementation no longer caches failures. Additionally, it relies
on the link tag's presence in the <head> of the document as an
indication that it is loading or has loaded, rather than keeping an
object map of URLs to link tags.