### PR TITLE
Adjust `attributeChangedCallback` to match custom elements spec

### DIFF
--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -340,10 +340,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       attributeChangedCallback(name, old, value) {
-        let property = caseMap.dashToCamelCase(name);
-        let type = this.constructor._flattenedProperties[property].type;
-        if (!this._hasReadOnlyEffect(property)) {
-          this._attributeToProperty(name, value, type);
+        if (old !== value) {
+          let property = caseMap.dashToCamelCase(name);
+          let type = this.constructor._flattenedProperties[property].type;
+          if (!this._hasReadOnlyEffect(property)) {
+            this._attributeToProperty(name, value, type);
+          }
         }
       }
 

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -76,8 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       attributeChangedCallback(name, old, value) {
-        super.attributeChangedCallback(name, old, value);
-        this.attributeChanged(name, old, value);
+        if (old !== value) {
+          super.attributeChangedCallback(name, old, value);
+          this.attributeChanged(name, old, value);
+        }
       }
 
       created() {}

--- a/src/legacy/dom-module.html
+++ b/src/legacy/dom-module.html
@@ -28,8 +28,10 @@
 
     static get observedAttributes() { return ['id'] }
 
-    attributeChangedCallback() {
-      this.register();
+    attributeChangedCallback(name, old, value) {
+      if (old !== value) {
+        this.register();
+      }
     }
 
     _styleOutsideTemplateCheck() {


### PR DESCRIPTION
Makes 2.x better work with Safari Tech Preview's implementation of custom elements.