### PR TITLE
3336 use classList.add to avoid duplicate classes

### DIFF
--- a/src/standard/styling.html
+++ b/src/standard/styling.html
@@ -166,12 +166,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var self = this;
         var scopify = function(node) {
           if (node.nodeType === Node.ELEMENT_NODE) {
-            var className = node.getAttribute('class');
-            node.setAttribute('class', self._scopeElementClass(node, className));
+            node.classList.add(Polymer.StyleTransformer.SCOPE_NAME, self.is);
             var n$ = node.querySelectorAll('*');
             for (var i=0, n; (i<n$.length) && (n=n$[i]); i++) {
-              className = n.getAttribute('class');
-              n.setAttribute('class', self._scopeElementClass(n, className));
+              n.classList.add(Polymer.StyleTransformer.SCOPE_NAME, self.is);
             }
           }
         };


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes https://github.com/Polymer/polymer/issues/3336

in `scopeSubtree()` use `classList.add('class')` instead of `setAttribute('class', ...)` when setting scoped style classes to avoid adding duplicate classes

duplicates can happen when the observer fires e.g. when D3 does weird things