### PR TITLE
Implement array-selector. Fixes #4154

### DIFF
--- a/polymer.html
+++ b/polymer.html
@@ -3,5 +3,6 @@
 <link rel="import" href="src/templatizer/dom-bind.html">
 <link rel="import" href="src/templatizer/dom-repeat.html">
 <link rel="import" href="src/templatizer/dom-if.html">
+<link rel="import" href="src/templatizer/array-selector.html">
 <!-- custom-style -->
 <link rel="import" href="src/styling/custom-style.html">

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1693,11 +1693,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         to = Polymer.Path.normalize(to);
         from = Polymer.Path.normalize(from);
         this.__dataLinkedPaths = this.__dataLinkedPaths || {};
-        if (from) {
-          this.__dataLinkedPaths[to] = from;
-        } else {
-          this.__dataLinkedPaths(to);
-        }
+        this.__dataLinkedPaths[to] = from;
       }
 
       /**

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -187,29 +187,31 @@ is false, `selected` is a property representing the last selected item.  When
       }
 
       _applySplices(splices) {
+        let toRemove = [];
         for (let i=0; i<splices.length; i++) {
+          let removed = []
           let s = splices[i];
           let selected = new IntegerSet();
           let sidx = 0;
-          let toRemove = [];
           this._selectedSet.forEach(idx => {
             if (idx < s.index) {
               selected.add(idx);
             } else if (idx >= s.index + s.removed.length) {
               selected.add(idx + s.addedCount - s.removed.length);
             } else {
-              toRemove.push(sidx);
+              removed.unshift(sidx);
             }
             sidx++;
           });
+          toRemove = toRemove.concat(removed);
           this._selectedSet = selected;
-          this._updateLinks();
-          for (let i=toRemove.length-1; i>=0; i--) {
-            if (this.multi) {
-              this.splice('selected', toRemove[i], 1);
-            } else {
-              this.selected = this.selectedItem = null;
-            }
+        }
+        this._updateLinks();
+        for (let i=0; i<toRemove.length; i++) {
+          if (this.multi) {
+            this.splice('selected', toRemove[i], 1);
+          } else {
+            this.selected = this.selectedItem = null;
           }
         }
       }
@@ -258,6 +260,13 @@ is false, `selected` is a property representing the last selected item.  When
         }
       }
 
+      /**
+       * Returns whether the index is currently selected.
+       *
+       * @method isSelected
+       * @param {number} index Index from `items` array to test
+       * @return {boolean} Whether the item is selected
+       */
       isIndexSelected(idx) {
         return this._selectedSet.has(idx);
       }

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -69,6 +69,35 @@ is false, `selected` is a property representing the last selected item.  When
 <script>
 (function() {
 
+  // Limited polyfill of `Set` that accepts integer values backed by Object
+  // and relying on for/in iterating keys in insertion order ('.' prefix
+  // ensures insertion order on modern browsers, as integers are treated specially)
+  let IntegerSet = window.Set || class IntegerSet {
+    constructor() {
+      this.clear();
+    }
+    add(value) {
+      this._set['.' + value] = true;
+    }
+    delete(value) {
+      if (this.has(value)) {
+        delete this._set['.' + value];
+        return true;
+      }
+    }
+    has(value) {
+      return Boolean(this._set['.' + value]);
+    }
+    forEach(cb) {
+      for (let k in this._set) {
+        cb(parseInt(k.slice(1)));
+      }
+    }
+    clear() {
+      this._set = {};
+    }
+  }
+
   let ArraySelectorMixin = Polymer.Utils.dedupingMixin(superClass => {
 
     return class extends superClass {
@@ -160,56 +189,44 @@ is false, `selected` is a property representing the last selected item.  When
       _applySplices(splices) {
         for (let i=0; i<splices.length; i++) {
           let s = splices[i];
-          for (let j=0; j<s.removed.length; j++) {
-            this.deselect(s.removed[j]);
-          }
-          if (this.multi) {
-            this._addRemoveMulti(s.index, s.removed.length, s.addedCount);
-          } else {
-            this._addRemoveSingle(s.index, s.removed.length, s.addedCount);
-          }
-        }
-      }
-
-      _addRemoveMulti(start, removed, added) {
-        const links = this.__dataLinkedPaths;
-        for (let sidx=0; sidx<this.selected.length; sidx++) {
-          let idx = parseInt(links['selected.' + sidx].slice('items.'.length));
-          if (idx >= start) {
-            if (idx >= (start + removed)) {
-              this.linkPaths('selected.' + sidx, 'items.' + (idx + added - removed));
+          let selected = new IntegerSet();
+          let sidx = 0;
+          let toRemove = [];
+          this._selectedSet.forEach(idx => {
+            if (idx < s.index) {
+              selected.add(idx);
+            } else if (idx >= s.index + s.removed.length) {
+              selected.add(idx + s.addedCount - s.removed.length);
             } else {
-              this.unlinkPaths('selected.' + sidx);
+              toRemove.push(sidx);
+            }
+            sidx++;
+          });
+          this._selectedSet = selected;
+          this._updateLinks();
+          for (let i=toRemove.length-1; i>=0; i--) {
+            if (this.multi) {
+              this.splice('selected', toRemove[i], 1);
+            } else {
+              this.selected = this.selectedItem = null;
             }
           }
         }
       }
 
-      _addRemoveSingle(start, removed, added) {
-        const links = this.__dataLinkedPaths;
-        if (this.selected != undefined) {
-          let idx = parseInt(links['selected'].slice('items.'.length));
-          if (idx >= start) {
-            if (idx >= (start + removed)) {
-              let newItemPath = 'items.' + (idx + added - removed);
-              this.linkPaths('selected', newItemPath);
-              this.linkPaths('selectedItem', newItemPath);
-            } else {
-              this.unlinkPaths('selected');
-              this.unlinkPaths('selectedItem');
-            }
-          }        
+      _updateLinks() {
+        this.__dataLinkedPaths = {};
+        if (this.multi) {
+          let sidx = 0;
+          this._selectedSet.forEach(idx => {
+            this.linkPaths('items.' + idx, 'selected.' + sidx++);
+          });      
+        } else {
+          this._selectedSet.forEach(idx => {
+            this.linkPaths('selected', 'items.' + idx);
+            this.linkPaths('selectedItem', 'items.' + idx);
+          });
         }
-      }
-
-      _unlinkMulti(sidx) {
-        const links = this.__dataLinkedPaths;
-        // shift other selected items down
-        for (let i=sidx+1; i<this.selected.length; i++) {
-          this.linkPaths('selected.' + (i-1), links['selected.' + i]);
-        }
-        // unlink last
-        this.unlinkPaths('selected.' + (this.selected.length-1));
       }
 
       /**
@@ -219,20 +236,10 @@ is false, `selected` is a property representing the last selected item.  When
        */
       clearSelection() {
         // Unbind previous selection
-        if (Array.isArray(this.selected)) {
-          for (var i=0; i<this.selected.length; i++) {
-            this.unlinkPaths('selected.' + i);
-          }
-        } else {
-          this.unlinkPaths('selected');
-          this.unlinkPaths('selectedItem');
-        }
+        this.__dataLinkedPaths = {};
+        this._selectedSet = new IntegerSet();
         // Initialize selection
-        if (this.multi) {
-          this.selected = [];
-        } else {
-          this.selected = null;
-        }
+        this.selected = this.multi ? [] : null
         this.selectedItem = null;
       }
 
@@ -245,11 +252,14 @@ is false, `selected` is a property representing the last selected item.  When
        */
       isSelected(item) {
         if (this.multi) {
-          // TODO(kschaaf) use Map for perf
           return this.selected.indexOf(item) >= 0;
         } else {
           return this.selected == item;
         }
+      }
+
+      isIndexSelected(idx) {
+        return this._selectedSet.has(idx);
       }
 
       /**
@@ -259,18 +269,26 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {*} item Item from `items` array to deselect
        */
       deselect(item) {
-        if (this.multi) {
-          let sidx = this.selected.indexOf(item);
-          if (sidx >= 0) {
-            this._unlinkMulti(sidx);
-            this.splice('selected', sidx, 1);
+        this.deselectIndex(this.items.indexOf(item));
+      }
+
+      /**
+       * Deselects the given index if it is already selected.
+       *
+       * @method deselect
+       * @param {number} index Index from `items` array to deselect
+       */
+      deselectIndex(idx) {
+        if (this._selectedSet.delete(idx)) {
+          let sidx;
+          if (this.multi) {
+            sidx = parseInt(this.__dataLinkedPaths['items.' + idx].slice('selected.'.length));
           }
-        } else {
-          if (!item || this.selected === item){
-            this.selected = null;
-            this.selectedItem = null;
-            this.unlinkPaths('selected');
-            this.unlinkPaths('selectedItem');            
+          this._updateLinks();
+          if (this.multi) {
+            this.splice('selected', sidx, 1);
+          } else {
+            this.selected = this.selectedItem = null;
           }
         }
       }
@@ -283,25 +301,31 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {*} item Item from `items` array to select
        */
       select(item) {
-        let idx = this.items.indexOf(item);
-        if (this.multi) {
-          if (this.isSelected(item)) {
-            if (this.toggle) {
-              this.deselect(item);
-            }
-          } else {
-            let sidx = this.push('selected', item) - 1;
-            this.linkPaths('selected.' + sidx, 'items.' + idx);
+        this.selectIndex(this.items.indexOf(item));
+      }
+
+      /**
+       * Selects the given index.  When `toggle` is true, this will automatically
+       * deselect the item if already selected.
+       *
+       * @method select
+       * @param {number} index Index from `items` array to select
+       */
+      selectIndex(idx) {
+        if (!this._selectedSet.has(idx)) {
+          if (!this.multi) {
+            this._selectedSet.clear();
           }
-        } else {
-          if (this.toggle && item == this.selected) {
-            this.deselect();
+          this._selectedSet.add(idx);
+          this._updateLinks();
+          let item = this.items[idx];
+          if (this.multi) {
+            this.push('selected', item);
           } else {
-            this.selected = item;
-            this.selectedItem = item;
-            this.linkPaths('selected', 'items.' + idx);
-            this.linkPaths('selectedItem', 'items.' + idx);
+            this.selected = this.selectedItem = item;
           }
+        } else if (this.toggle) {
+          this.deselectIndex(idx);
         }
       }
 

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -163,10 +163,12 @@ is false, `selected` is a property representing the last selected item.  When
           let s = splices[i];
           selected.forEach((idx, item) => {
             if (idx < s.index) {
-              selected.set(item, idx);
+              // no change
             } else if (idx >= s.index + s.removed.length) {
+              // adjust index
               selected.set(item, idx + s.addedCount - s.removed.length);
             } else {
+              // remove index
               selected.set(item, -1);
             }
           });

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -148,7 +148,7 @@ is false, `selected` is a property representing the last selected item.  When
           }
           if (lastItems) {
             let splices = Polymer.ArraySplice.calculateSplices(newItems, lastItems);
-            this._applySplices(splices, lastItems);
+            this._applySplices(splices);
           }
           this.__lastItems = newItems;
           this.__lastMulti = multi;
@@ -173,14 +173,13 @@ is false, `selected` is a property representing the last selected item.  When
 
       _addRemoveMulti(start, removed, added) {
         const links = this.__dataLinkedPaths;
-        let selectedRemoved = 0;
         for (let sidx=0; sidx<this.selected.length; sidx++) {
           let idx = parseInt(links['selected.' + sidx].slice('items.'.length));
           if (idx >= start) {
-            this.unlinkPaths('selected.' + sidx);
             if (idx >= (start + removed)) {
-              this.linkPaths('selected.' + (sidx - selectedRemoved),
-                'items.' + (idx + added - removed));
+              this.linkPaths('selected.' + sidx, 'items.' + (idx + added - removed));
+            } else {
+              this.unlinkPaths('selected.' + sidx);
             }
           }
         }
@@ -191,12 +190,13 @@ is false, `selected` is a property representing the last selected item.  When
         if (this.selected != undefined) {
           let idx = parseInt(links['selected'].slice('items.'.length));
           if (idx >= start) {
-            this.unlinkPaths('selected');
-            this.unlinkPaths('selectedItem');
             if (idx >= (start + removed)) {
               let newItemPath = 'items.' + (idx + added - removed);
               this.linkPaths('selected', newItemPath);
               this.linkPaths('selectedItem', newItemPath);
+            } else {
+              this.unlinkPaths('selected');
+              this.unlinkPaths('selectedItem');
             }
           }        
         }

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -132,6 +132,12 @@ is false, `selected` is a property representing the last selected item.  When
 
       }
 
+      constructor() {
+        super();
+        this.__lastItems = null;
+        this.__lastMulti = null;
+      }
+
       _updateSelection(multi, itemsInfo) {
         if (itemsInfo.path == 'items') {
           let newItems = itemsInfo.base || [];

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -134,15 +134,18 @@ is false, `selected` is a property representing the last selected item.  When
 
       _updateSelection(multi, itemsInfo) {
         if (itemsInfo.path == 'items') {
-          let newItems = itemsInfo.base;
+          let newItems = itemsInfo.base || [];
           let lastItems = this.__lastItems;
+          let lastMulti = this.__lastMulti;
+          if (multi !== lastMulti) {
+            this.clearSelection();
+          }
           if (lastItems) {
             let splices = Polymer.ArraySplice.calculateSplices(newItems, lastItems);
             this._applySplices(splices, lastItems);
-          } else {
-            this.clearSelection();
           }
-          this.__lastItems = newItems ? newItems.slice() : [];
+          this.__lastItems = newItems;
+          this.__lastMulti = multi;
         } else if (itemsInfo.path == 'items.splices') {
           this._applySplices(itemsInfo.value.indexSplices);
         }
@@ -152,7 +155,7 @@ is false, `selected` is a property representing the last selected item.  When
         for (let i=0; i<splices.length; i++) {
           let s = splices[i];
           for (let j=0; j<s.removed.length; j++) {
-            this.deselect(s.removed[i]);
+            this.deselect(s.removed[j]);
           }
           if (this.multi) {
             this._addRemoveMulti(s.index, s.removed.length, s.addedCount);
@@ -220,9 +223,7 @@ is false, `selected` is a property representing the last selected item.  When
         }
         // Initialize selection
         if (this.multi) {
-          if (!this.selected || this.selected.length) {
-            this.selected = [];
-          }
+          this.selected = [];
         } else {
           this.selected = null;
         }

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -69,35 +69,6 @@ is false, `selected` is a property representing the last selected item.  When
 <script>
 (function() {
 
-  // Limited polyfill of `Set` that accepts integer values backed by Object
-  // and relying on for/in iterating keys in insertion order ('.' prefix
-  // ensures insertion order on modern browsers, as integers are treated specially)
-  let IntegerSet = window.Set || class IntegerSet {
-    constructor() {
-      this.clear();
-    }
-    add(value) {
-      this._set['.' + value] = true;
-    }
-    delete(value) {
-      if (this.has(value)) {
-        delete this._set['.' + value];
-        return true;
-      }
-    }
-    has(value) {
-      return Boolean(this._set['.' + value]);
-    }
-    forEach(cb) {
-      for (let k in this._set) {
-        cb(parseInt(k.slice(1)));
-      }
-    }
-    clear() {
-      this._set = {};
-    }
-  }
-
   let ArraySelectorMixin = Polymer.Utils.dedupingMixin(superClass => {
 
     return class extends superClass {
@@ -187,44 +158,52 @@ is false, `selected` is a property representing the last selected item.  When
       }
 
       _applySplices(splices) {
-        let toRemove = [];
+        let selected = this._selectedMap;
         for (let i=0; i<splices.length; i++) {
-          let removed = []
           let s = splices[i];
-          let selected = new IntegerSet();
-          let sidx = 0;
-          this._selectedSet.forEach(idx => {
+          selected.forEach((idx, item) => {
             if (idx < s.index) {
-              selected.add(idx);
+              selected.set(item, idx);
             } else if (idx >= s.index + s.removed.length) {
-              selected.add(idx + s.addedCount - s.removed.length);
+              selected.set(item, idx + s.addedCount - s.removed.length);
             } else {
-              removed.unshift(sidx);
+              selected.set(item, -1);
             }
-            sidx++;
           });
-          toRemove = toRemove.concat(removed);
-          this._selectedSet = selected;
-        }
-        this._updateLinks();
-        for (let i=0; i<toRemove.length; i++) {
-          if (this.multi) {
-            this.splice('selected', toRemove[i], 1);
-          } else {
-            this.selected = this.selectedItem = null;
+          for (let j=0; j<s.addedCount; j++) {
+            let idx = s.index + j;
+            if (selected.has(this.items[idx])) {
+              selected.set(this.items[idx], idx);
+            }
           }
         }
+        this._updateLinks();
+        let sidx = 0;
+        selected.forEach((idx, item) => {
+          if (idx < 0) {
+            if (this.multi) {
+              this.splice('selected', sidx, 1);
+            } else {
+              this.selected = this.selectedItem = null;
+            }
+            selected.delete(item);
+          } else {
+            sidx++;
+          }
+        });
       }
 
       _updateLinks() {
         this.__dataLinkedPaths = {};
         if (this.multi) {
           let sidx = 0;
-          this._selectedSet.forEach(idx => {
-            this.linkPaths('items.' + idx, 'selected.' + sidx++);
+          this._selectedMap.forEach(idx => {
+            if (idx >= 0) {
+              this.linkPaths('items.' + idx, 'selected.' + sidx++);
+            }
           });      
         } else {
-          this._selectedSet.forEach(idx => {
+          this._selectedMap.forEach(idx => {
             this.linkPaths('selected', 'items.' + idx);
             this.linkPaths('selectedItem', 'items.' + idx);
           });
@@ -239,7 +218,7 @@ is false, `selected` is a property representing the last selected item.  When
       clearSelection() {
         // Unbind previous selection
         this.__dataLinkedPaths = {};
-        this._selectedSet = new IntegerSet();
+        this._selectedMap = new Map();
         // Initialize selection
         this.selected = this.multi ? [] : null
         this.selectedItem = null;
@@ -268,7 +247,7 @@ is false, `selected` is a property representing the last selected item.  When
        * @return {boolean} Whether the item is selected
        */
       isIndexSelected(idx) {
-        return this._selectedSet.has(idx);
+        return this._selectedMap.has(this.items[idx]);
       }
 
       /**
@@ -288,7 +267,7 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {number} index Index from `items` array to deselect
        */
       deselectIndex(idx) {
-        if (this._selectedSet.delete(idx)) {
+        if (this._selectedMap.delete(this.items[idx])) {
           let sidx;
           if (this.multi) {
             sidx = parseInt(this.__dataLinkedPaths['items.' + idx].slice('selected.'.length));
@@ -321,11 +300,11 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {number} index Index from `items` array to select
        */
       selectIndex(idx) {
-        if (!this._selectedSet.has(idx)) {
+        if (!this._selectedMap.has(this.items[idx])) {
           if (!this.multi) {
-            this._selectedSet.clear();
+            this._selectedMap.clear();
           }
-          this._selectedSet.add(idx);
+          this._selectedMap.set(this.items[idx], idx);
           this._updateLinks();
           let item = this.items[idx];
           if (this.multi) {

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -248,7 +248,7 @@ is false, `selected` is a property representing the last selected item.  When
        * @return {boolean} Whether the item is selected
        */
       isIndexSelected(idx) {
-        return this._selectedMap.has(this.items[idx]);
+        return this.isSelected(this.items[idx]);
       }
 
       /**
@@ -301,13 +301,13 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {number} index Index from `items` array to select
        */
       selectIndex(idx) {
-        if (!this._selectedMap.has(this.items[idx])) {
+        let item = this.items[idx];
+        if (!this.isSelected(item)) {
           if (!this.multi) {
             this._selectedMap.clear();
           }
-          this._selectedMap.set(this.items[idx], idx);
+          this._selectedMap.set(item, idx);
           this._updateLinks();
-          let item = this.items[idx];
           if (this.multi) {
             this.push('selected', item);
           } else {

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -1,0 +1,315 @@
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!--
+Keeping structured data in sync requires that Polymer understand the path
+associations of data being bound.  The `array-selector` element ensures path
+linkage when selecting specific items from an array (either single or multiple).
+The `items` property accepts an array of user data, and via the `select(item)`
+and `deselect(item)` API, updates the `selected` property which may be bound to
+other parts of the application, and any changes to sub-fields of `selected`
+item(s) will be kept in sync with items in the `items` array.  When `multi`
+is false, `selected` is a property representing the last selected item.  When
+`multi` is true, `selected` is an array of multiply selected items.
+
+```html
+<dom-module id="employee-list">
+
+  <template>
+
+    <div> Employee list: </div>
+    <template is="dom-repeat" id="employeeList" items="{{employees}}">
+        <div>First name: <span>{{item.first}}</span></div>
+        <div>Last name: <span>{{item.last}}</span></div>
+        <button on-click="toggleSelection">Select</button>
+    </template>
+
+    <array-selector id="selector" items="{{employees}}" selected="{{selected}}" multi toggle></array-selector>
+
+    <div> Selected employees: </div>
+    <template is="dom-repeat" items="{{selected}}">
+        <div>First name: <span>{{item.first}}</span></div>
+        <div>Last name: <span>{{item.last}}</span></div>
+    </template>
+
+  </template>
+
+  <script>
+    Polymer({
+      is: 'employee-list',
+      ready() {
+        this.employees = [
+            {first: 'Bob', last: 'Smith'},
+            {first: 'Sally', last: 'Johnson'},
+            ...
+        ];
+      },
+      toggleSelection(e) {
+        var item = this.$.employeeList.itemForElement(e.target);
+        this.$.selector.select(item);
+      }
+    });
+  </script>
+
+</dom-module>
+```
+-->
+
+<link rel="import" href="../../polymer-element.html">
+<link rel="import" href="../utils/utils.html">
+<link rel="import" href="../utils/array-splice.html">
+
+<script>
+(function() {
+
+  let ArraySelectorMixin = Polymer.Utils.dedupingMixin(superClass => {
+
+    return class extends superClass {
+
+      static get config() {
+      
+        return {
+
+          properties: {
+
+            /**
+             * An array containing items from which selection will be made.
+             */
+            items: {
+              type: Array,
+            },
+
+            /**
+             * When `true`, multiple items may be selected at once (in this case,
+             * `selected` is an array of currently selected items).  When `false`,
+             * only one item may be selected at a time.
+             */
+            multi: {
+              type: Boolean,
+              value: false,
+            },
+
+            /**
+             * When `multi` is true, this is an array that contains any selected.
+             * When `multi` is false, this is the currently selected item, or `null`
+             * if no item is selected.
+             */
+            selected: {
+              type: Object,
+              notify: true
+            },
+
+            /**
+             * When `multi` is false, this is the currently selected item, or `null`
+             * if no item is selected.
+             */
+            selectedItem: {
+              type: Object,
+              notify: true
+            },
+
+            /**
+             * When `true`, calling `select` on an item that is already selected
+             * will deselect the item.
+             */
+            toggle: {
+              type: Boolean,
+              value: false
+            }
+
+          },
+
+          observers: ['_updateSelection(multi, items.*)'],
+
+        }
+
+      }
+
+      _updateSelection(multi, itemsInfo) {
+        if (itemsInfo.path == 'items') {
+          let newItems = itemsInfo.base;
+          let lastItems = this.__lastItems;
+          if (lastItems) {
+            let splices = Polymer.ArraySplice.calculateSplices(newItems, lastItems);
+            this._applySplices(splices, lastItems);
+          } else {
+            this.clearSelection();
+          }
+          this.__lastItems = newItems ? newItems.slice() : [];
+        } else if (itemsInfo.path == 'items.splices') {
+          this._applySplices(itemsInfo.value.indexSplices);
+        }
+      }
+
+      _applySplices(splices) {
+        for (let i=0; i<splices.length; i++) {
+          let s = splices[i];
+          for (let j=0; j<s.removed.length; j++) {
+            this.deselect(s.removed[i]);
+          }
+          if (this.multi) {
+            this._addRemoveMulti(s.index, s.removed.length, s.addedCount);
+          } else {
+            this._addRemoveSingle(s.index, s.removed.length, s.addedCount);
+          }
+        }
+      }
+
+      _addRemoveMulti(start, removed, added) {
+        const links = this.__dataLinkedPaths;
+        let selectedRemoved = 0;
+        for (let sidx=0; sidx<this.selected.length; sidx++) {
+          let idx = parseInt(links['selected.' + sidx].slice('items.'.length));
+          if (idx >= start) {
+            this.unlinkPaths('selected.' + sidx);
+            if (idx >= (start + removed)) {
+              this.linkPaths('selected.' + (sidx - selectedRemoved),
+                'items.' + (idx + added - removed));
+            }
+          }
+        }
+      }
+
+      _addRemoveSingle(start, removed, added) {
+        const links = this.__dataLinkedPaths;
+        if (this.selected != undefined) {
+          let idx = parseInt(links['selected'].slice('items.'.length));
+          if (idx >= start) {
+            this.unlinkPaths('selected');
+            this.unlinkPaths('selectedItem');
+            if (idx >= (start + removed)) {
+              let newItemPath = 'items.' + (idx + added - removed);
+              this.linkPaths('selected', newItemPath);
+              this.linkPaths('selectedItem', newItemPath);
+            }
+          }        
+        }
+      }
+
+      _unlinkMulti(sidx) {
+        const links = this.__dataLinkedPaths;
+        // shift other selected items down
+        for (let i=sidx+1; i<this.selected.length; i++) {
+          this.linkPaths('selected.' + (i-1), links['selected.' + i]);
+        }
+        // unlink last
+        this.unlinkPaths('selected.' + (this.selected.length-1));
+      }
+
+      /**
+       * Clears the selection state.
+       *
+       * @method clearSelection
+       */
+      clearSelection() {
+        // Unbind previous selection
+        if (Array.isArray(this.selected)) {
+          for (var i=0; i<this.selected.length; i++) {
+            this.unlinkPaths('selected.' + i);
+          }
+        } else {
+          this.unlinkPaths('selected');
+          this.unlinkPaths('selectedItem');
+        }
+        // Initialize selection
+        if (this.multi) {
+          if (!this.selected || this.selected.length) {
+            this.selected = [];
+          }
+        } else {
+          this.selected = null;
+        }
+        this.selectedItem = null;
+      }
+
+      /**
+       * Returns whether the item is currently selected.
+       *
+       * @method isSelected
+       * @param {*} item Item from `items` array to test
+       * @return {boolean} Whether the item is selected
+       */
+      isSelected(item) {
+        if (this.multi) {
+          // TODO(kschaaf) use Map for perf
+          return this.selected.indexOf(item) >= 0;
+        } else {
+          return this.selected == item;
+        }
+      }
+
+      /**
+       * Deselects the given item if it is already selected.
+       *
+       * @method deselect
+       * @param {*} item Item from `items` array to deselect
+       */
+      deselect(item) {
+        if (this.multi) {
+          let sidx = this.selected.indexOf(item);
+          if (sidx >= 0) {
+            this._unlinkMulti(sidx);
+            this.splice('selected', sidx, 1);
+          }
+        } else {
+          if (!item || this.selected === item){
+            this.selected = null;
+            this.selectedItem = null;
+            this.unlinkPaths('selected');
+            this.unlinkPaths('selectedItem');            
+          }
+        }
+      }
+
+      /**
+       * Selects the given item.  When `toggle` is true, this will automatically
+       * deselect the item if already selected.
+       *
+       * @method select
+       * @param {*} item Item from `items` array to select
+       */
+      select(item) {
+        let idx = this.items.indexOf(item);
+        if (this.multi) {
+          if (this.isSelected(item)) {
+            if (this.toggle) {
+              this.deselect(item);
+            }
+          } else {
+            let sidx = this.push('selected', item) - 1;
+            this.linkPaths('selected.' + sidx, 'items.' + idx);
+          }
+        } else {
+          if (this.toggle && item == this.selected) {
+            this.deselect();
+          } else {
+            this.selected = item;
+            this.selectedItem = item;
+            this.linkPaths('selected', 'items.' + idx);
+            this.linkPaths('selectedItem', 'items.' + idx);
+          }
+        }
+      }
+
+    }
+
+  });
+
+  // export mixin
+  Polymer.ArraySelectorMixin = ArraySelectorMixin;
+
+  // define element class & export
+  class ArraySelector extends ArraySelectorMixin(Polymer.Element) { }
+  customElements.define('array-selector', ArraySelector);
+  Polymer.ArraySelector = ArraySelector;
+
+})();
+
+</script>

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -159,6 +159,7 @@ is false, `selected` is a property representing the last selected item.  When
 
       _applySplices(splices) {
         let selected = this._selectedMap;
+        // Adjust selected indices and mark removals
         for (let i=0; i<splices.length; i++) {
           let s = splices[i];
           selected.forEach((idx, item) => {
@@ -179,7 +180,9 @@ is false, `selected` is a property representing the last selected item.  When
             }
           }
         }
+        // Update linked paths
         this._updateLinks();
+        // Remove selected items that were removed from the items array
         let sidx = 0;
         selected.forEach((idx, item) => {
           if (idx < 0) {
@@ -234,18 +237,14 @@ is false, `selected` is a property representing the last selected item.  When
        * @return {boolean} Whether the item is selected
        */
       isSelected(item) {
-        if (this.multi) {
-          return this.selected.indexOf(item) >= 0;
-        } else {
-          return this.selected == item;
-        }
+        return this._selectedMap.has(item);
       }
 
       /**
-       * Returns whether the index is currently selected.
+       * Returns whether the item is currently selected.
        *
        * @method isSelected
-       * @param {number} index Index from `items` array to test
+       * @param {*} idx Index from `items` array to test
        * @return {boolean} Whether the item is selected
        */
       isIndexSelected(idx) {
@@ -259,7 +258,7 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {*} item Item from `items` array to deselect
        */
       deselect(item) {
-        this.deselectIndex(this.items.indexOf(item));
+        this.deselectIndex(this._selectedMap.get(item));
       }
 
       /**

--- a/test/runner.html
+++ b/test/runner.html
@@ -49,6 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dom-repeat.html',
       'unit/dom-if.html',
       'unit/dom-bind.html',
+      'unit/array-selector.html',
       'unit/polymer-dom.html',
       'unit/polymer-dom-observeNodes.html',
       'unit/importHref.html',

--- a/test/unit/array-selector-elements.html
+++ b/test/unit/array-selector-elements.html
@@ -1,0 +1,11 @@
+<script>
+Polymer({
+  is: 'observe-el',
+  observers: [
+    'singleChanged(singleSelected.*)',
+    'multiChanged(multiSelected.*)'
+  ],
+  singleChanged: function() {},
+  multiChanged: function() {}
+});
+</script>

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+  <link rel="import" href="array-selector-elements.html">
+<body>
+
+<test-fixture id="singleConfigured">
+  <template>
+    <array-selector
+      items='[{"name": "one"},{"name": "two"},{"name": "three"}]'>
+    </array-selector>
+  </template>
+</test-fixture>
+
+<test-fixture id="multiConfigured">
+  <template>
+    <array-selector multi
+      items='[{"name": "one"},{"name": "two"},{"name": "three"}]'>
+    </array-selector>
+  </template>
+</test-fixture>
+
+<test-fixture id="bind">
+  <template>
+    <dom-bind>
+      <template>
+        <observe-el id="observer" single-selected="{{singleSelected}}" multi-selected="{{multiSelected}}"></observe-el>
+        <array-selector id="singleBound" items="{{items}}" selected="{{singleSelected}}"></array-selector>
+        <array-selector id="multiBound" items="{{items}}" selected="{{multiSelected}}" multi></array-selector>
+      </template>
+    </dom-bind>
+  </template>
+</test-fixture>
+
+<script>
+/* global bind observer singleBound multiBound */
+suite('basic', function() {
+  test('single selection', function() {
+    var el = fixture('singleConfigured');
+    // Nothing selected
+    assert.strictEqual(el.selectedItem, null);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 0
+    el.select(el.items[0]);
+    assert.strictEqual(el.selectedItem, el.items[0]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Re-select 0
+    el.select(el.items[0]);
+    assert.strictEqual(el.selectedItem, el.items[0]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 2
+    el.select(el.items[2]);
+    assert.strictEqual(el.selectedItem, el.items[2]);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.strictEqual(el.selectedItem, null);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.strictEqual(el.selectedItem, el.items[2]);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // clearSelection
+    el.clearSelection();
+    assert.equal(el.selectedItem, null);
+  });
+
+  test('multiple selection', function() {
+    var el = fixture('multiConfigured');
+    // Nothing selected
+    assert.sameMembers(el.selected, []);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 0
+    el.select(el.items[0]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Re-select 0
+    el.select(el.items[0]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 2
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // clear selection
+    el.clearSelection();
+    assert.sameMembers(el.selected, []);
+  });
+
+  test('bound defaults', function() {
+    let bind = fixture('bind');
+    assert.equal(bind.$.observer.singleSelected, null);
+    assert.sameMembers(bind.$.observer.multiSelected, []);
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    assert.equal(bind.$.observer.singleSelected, null);
+    assert.sameMembers(bind.$.observer.multiSelected, []);
+  });
+
+  test('single selection notification', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.$.singleBound.select(bind.items[2]);
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, bind.items[2]);
+    assert.equal(bind.$.observer.singleSelected, bind.items[2]);
+    // clear selection
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.$.singleBound.clearSelection();
+    assert.equal(bind.$.observer.singleSelected, null);
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, null);
+  });
+
+  test('single selection sub-property change', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[2]);
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.set(['items', 2, 'name'], 'test');
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected.name');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, 'test');
+    assert.equal(bind.$.observer.singleSelected.name, 'test');
+
+    bind.$.singleBound.select(bind.items[1]);
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.set(['items', 1, 'name'], 'test2');
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected.name');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, 'test2');
+    assert.equal(bind.$.observer.singleSelected.name, 'test2');
+  });
+
+  test('single selection sub-property change after unshift', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[2]);
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.unshift('items', {name: 'zero'});
+    bind.set(['items', 3, 'name'], 'test2');
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected.name');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, 'test2');
+    assert.equal(bind.$.observer.singleSelected.name, 'test2');
+  });
+
+  test('multi selection notification', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    // select first
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.select(bind.items[2]);
+    assert.isTrue(bind.$.observer.multiChanged.calledTwice);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 0);
+    assert.sameMembers(bind.$.observer.multiSelected, [bind.items[2]]);
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].path, 'multiSelected.length');
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].value, 1);
+    // select second
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.select(bind.items[0]);
+    assert.isTrue(bind.$.observer.multiChanged.calledTwice);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 0);
+    assert.sameMembers(bind.$.observer.multiSelected, [bind.items[2], bind.items[0]]);
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].path, 'multiSelected.length');
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].value, 2);
+    // clear selection
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.clearSelection();
+    assert.sameMembers(bind.$.observer.multiSelected, []);
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected');
+    assert.sameMembers(bind.$.observer.multiChanged.firstCall.args[0].value, []);
+  });
+
+  test('multi selection sub-property change', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    multiBound.select(bind.items[2]);
+    multiBound.select(bind.items[0]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set(['items', 2, 'name'], 'test');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.0.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test');
+    assert.equal(bind.$.observer.multiSelected[0].name, 'test');
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set(['items', 0, 'name'], 'test2');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.1.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test2');
+    assert.equal(bind.$.observer.multiSelected[1].name, 'test2');
+  });
+
+
+  test('multi selection sub-property change after unshift', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    multiBound.select(bind.items[2]);
+    multiBound.select(bind.items[0]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.unshift('items', {name: 'zero'});
+    bind.set(['items', 1, 'name'], 'test');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.1.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test');
+    assert.equal(bind.$.observer.multiSelected[1].name, 'test');
+  });
+
+  test('multi selection sub-property change after splice (removal)', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    multiBound.select(bind.items[0]);
+    multiBound.select(bind.items[2]);
+
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.splice('items', 0, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].index, 0);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 0);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 1);
+
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set(['items', 1, 'name'], 'test');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.0.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test');
+    assert.equal(bind.$.observer.multiSelected[0].name, 'test');
+  });
+
+  test('multi selection sub-property change after deselect', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    multiBound.select(bind.items[2]);
+    multiBound.select(bind.items[0]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set(['items', 0, 'name'], 'test');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.1.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test');
+    assert.equal(bind.$.observer.multiSelected[1].name, 'test');
+
+    multiBound.deselect(bind.items[2]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set(['items', 0, 'name'], 'test4');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.0.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test4');
+    assert.equal(bind.$.observer.multiSelected[0].name, 'test4');
+  });
+
+});
+</script>
+
+</body>
+</html>

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -212,6 +212,22 @@ suite('basic', function() {
     assert.equal(bind.$.observer.singleSelected.name, 'test2');
   });
 
+  test('single selection removal via splice', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[1]);
+    bind.$.observer.singleChanged = sinon.spy();
+    bind.splice('items', 1, 2);
+    assert.isTrue(bind.$.observer.singleChanged.calledOnce);
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected');
+    assert.equal(bind.$.observer.singleChanged.firstCall.args[0].value, null);
+    assert.equal(bind.$.observer.singleSelected, null);
+  });
+
   test('multi selection notification', function() {
     let bind = fixture('bind');
     bind.items = [

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -540,7 +540,7 @@ suite('corner cases', function() {
   });
 
   // Current algorithm does not handle reordering array while maintaining selection state
-  test.skip('reset mutated array reordered resulting in multiple splices', function() {
+  test('reset mutated array reordered resulting in multiple splices', function() {
     var bind = fixture('bind');
     let i = bind.items = [
       {name: '0'}, {name: '1'}, {name: '2'}, {name: '3'},

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -46,29 +46,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </test-fixture>
 
 <script>
-/* global bind observer singleBound multiBound */
-suite('basic', function() {
+suite('single selection', function() {
+
   test('single selection', function() {
     var el = fixture('singleConfigured');
     // Nothing selected
+    assert.strictEqual(el.selected, null);
     assert.strictEqual(el.selectedItem, null);
     assert.isFalse(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
     assert.isFalse(el.isSelected(el.items[2]));
     // Select 0
     el.select(el.items[0]);
+    assert.strictEqual(el.selected, el.items[0]);
     assert.strictEqual(el.selectedItem, el.items[0]);
     assert.isTrue(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
     assert.isFalse(el.isSelected(el.items[2]));
     // Re-select 0
     el.select(el.items[0]);
+    assert.strictEqual(el.selected, el.items[0]);
     assert.strictEqual(el.selectedItem, el.items[0]);
     assert.isTrue(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
     assert.isFalse(el.isSelected(el.items[2]));
     // Select 2
     el.select(el.items[2]);
+    assert.strictEqual(el.selected, el.items[2]);
     assert.strictEqual(el.selectedItem, el.items[2]);
     assert.isFalse(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
@@ -76,6 +80,7 @@ suite('basic', function() {
     // Toggle 2
     el.toggle = true;
     el.select(el.items[2]);
+    assert.strictEqual(el.selected, null);
     assert.strictEqual(el.selectedItem, null);
     assert.isFalse(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
@@ -83,6 +88,7 @@ suite('basic', function() {
     // Toggle 2
     el.toggle = true;
     el.select(el.items[2]);
+    assert.strictEqual(el.selected, el.items[2]);
     assert.strictEqual(el.selectedItem, el.items[2]);
     assert.isFalse(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
@@ -90,50 +96,6 @@ suite('basic', function() {
     // clearSelection
     el.clearSelection();
     assert.equal(el.selectedItem, null);
-  });
-
-  test('multiple selection', function() {
-    var el = fixture('multiConfigured');
-    // Nothing selected
-    assert.sameMembers(el.selected, []);
-    assert.isFalse(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isFalse(el.isSelected(el.items[2]));
-    // Select 0
-    el.select(el.items[0]);
-    assert.sameMembers(el.selected, [el.items[0]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isFalse(el.isSelected(el.items[2]));
-    // Re-select 0
-    el.select(el.items[0]);
-    assert.sameMembers(el.selected, [el.items[0]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isFalse(el.isSelected(el.items[2]));
-    // Select 2
-    el.select(el.items[2]);
-    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isTrue(el.isSelected(el.items[2]));
-    // Toggle 2
-    el.toggle = true;
-    el.select(el.items[2]);
-    assert.sameMembers(el.selected, [el.items[0]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isFalse(el.isSelected(el.items[2]));
-    // Toggle 2
-    el.toggle = true;
-    el.select(el.items[2]);
-    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isTrue(el.isSelected(el.items[2]));
-    // clear selection
-    el.clearSelection();
-    assert.sameMembers(el.selected, []);
   });
 
   test('bound defaults', function() {
@@ -228,6 +190,99 @@ suite('basic', function() {
     assert.equal(bind.$.observer.singleSelected, null);
   });
 
+  test('copy array, selection should remain', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[2]);
+    assert.equal(bind.$.singleBound.selected, bind.items[2]);
+    // set items to copy; all should still be selected
+    bind.items = bind.items.slice();
+    assert.equal(bind.$.singleBound.selected, bind.items[2]);
+  });
+
+  test('change array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[2]);
+    assert.equal(bind.$.singleBound.selected, bind.items[2]);
+    // set items to new objects; all should be removed (selection based on identity)
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    assert.equal(bind.$.singleBound.selected, null);
+  });
+
+  test('null array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[2]);
+    assert.equal(bind.$.singleBound.selected, bind.items[2]);
+    // set items to new objects; all should be removed (selection based on identity)
+    bind.items = null;
+    assert.equal(bind.$.singleBound.selected, null);
+  });
+
+});
+
+suite('multi selection', function() {
+
+  test('multi selection', function() {
+    var el = fixture('multiConfigured');
+    // Nothing selected
+    assert.sameMembers(el.selected, []);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 0
+    el.select(el.items[0]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Re-select 0
+    el.select(el.items[0]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 2
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Toggle 2
+    el.toggle = true;
+    el.select(el.items[2]);
+    assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isTrue(el.isSelected(el.items[2]));
+    // clear selection
+    el.clearSelection();
+    assert.sameMembers(el.selected, []);
+  });
   test('multi selection notification', function() {
     let bind = fixture('bind');
     bind.items = [
@@ -273,8 +328,8 @@ suite('basic', function() {
       {name: 'two'},
       {name: 'three'}
     ];
-    multiBound.select(bind.items[2]);
-    multiBound.select(bind.items[0]);
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
     bind.$.observer.multiChanged = sinon.spy();
     bind.set(['items', 2, 'name'], 'test');
     assert.isTrue(bind.$.observer.multiChanged.calledOnce);
@@ -297,8 +352,8 @@ suite('basic', function() {
       {name: 'two'},
       {name: 'three'}
     ];
-    multiBound.select(bind.items[2]);
-    multiBound.select(bind.items[0]);
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
     bind.$.observer.multiChanged = sinon.spy();
     bind.unshift('items', {name: 'zero'});
     bind.set(['items', 1, 'name'], 'test');
@@ -315,8 +370,8 @@ suite('basic', function() {
       {name: 'two'},
       {name: 'three'}
     ];
-    multiBound.select(bind.items[0]);
-    multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
+    bind.$.multiBound.select(bind.items[2]);
 
     bind.$.observer.multiChanged = sinon.spy();
     bind.splice('items', 0, 1);
@@ -341,8 +396,8 @@ suite('basic', function() {
       {name: 'two'},
       {name: 'three'}
     ];
-    multiBound.select(bind.items[2]);
-    multiBound.select(bind.items[0]);
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
     bind.$.observer.multiChanged = sinon.spy();
     bind.set(['items', 0, 'name'], 'test');
     assert.isTrue(bind.$.observer.multiChanged.calledOnce);
@@ -350,7 +405,7 @@ suite('basic', function() {
     assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'test');
     assert.equal(bind.$.observer.multiSelected[1].name, 'test');
 
-    multiBound.deselect(bind.items[2]);
+    bind.$.multiBound.deselect(bind.items[2]);
     bind.$.observer.multiChanged = sinon.spy();
     bind.set(['items', 0, 'name'], 'test4');
     assert.isTrue(bind.$.observer.multiChanged.calledOnce);
@@ -359,7 +414,101 @@ suite('basic', function() {
     assert.equal(bind.$.observer.multiSelected[0].name, 'test4');
   });
 
+  test('copy array, selection should remain', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2], bind.items[0]]);
+    // set items to copy; all should still be selected
+    bind.items = bind.items.slice();
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2], bind.items[0]]);
+  });
+
+  test('change array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2], bind.items[0]]);
+    // set items to new objects; all should be removed (selection based on identity)
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    assert.sameMembers(bind.$.multiBound.selected, []);
+  });
+
+  test('null array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2], bind.items[0]]);
+    // set items to new objects; all should be removed (selection based on identity)
+    bind.items = null;
+    assert.sameMembers(bind.$.multiBound.selected, []);
+  });
+
 });
+
+suite('corner cases', function() {
+
+  test('switch from single to multi', function() {
+    var el = fixture('singleConfigured');
+    // Nothing selected
+    assert.strictEqual(el.selected, null);
+    assert.strictEqual(el.selectedItem, null);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 0
+    el.select(el.items[0]);
+    assert.strictEqual(el.selected, el.items[0]);
+    assert.strictEqual(el.selectedItem, el.items[0]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // switch to multi
+    el.multi = true;
+    assert.sameMembers(el.selected, []);
+    assert.equal(el.selectedItem, null);
+  });
+
+  test('switch from multi to single', function() {
+    var el = fixture('multiConfigured');
+    // Nothing selected
+    assert.sameMembers(el.selected, []);
+    assert.isFalse(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // Select 0
+    el.select(el.items[0]);
+    assert.sameMembers(el.selected, [el.items[0]]);
+    assert.isTrue(el.isSelected(el.items[0]));
+    assert.isFalse(el.isSelected(el.items[1]));
+    assert.isFalse(el.isSelected(el.items[2]));
+    // switch to single
+    el.multi = false;
+    assert.equal(el.selected, null);
+    assert.equal(el.selectedItem, null);
+  });
+
+});
+
 </script>
 
 </body>

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -165,8 +165,8 @@ suite('single selection', function() {
       {name: 'three'}
     ];
     bind.$.singleBound.select(bind.items[2]);
-    bind.$.observer.singleChanged = sinon.spy();
     bind.unshift('items', {name: 'zero'});
+    bind.$.observer.singleChanged = sinon.spy();
     bind.set(['items', 3, 'name'], 'test2');
     assert.isTrue(bind.$.observer.singleChanged.calledOnce);
     assert.equal(bind.$.observer.singleChanged.firstCall.args[0].path, 'singleSelected.name');
@@ -354,8 +354,8 @@ suite('multi selection', function() {
     ];
     bind.$.multiBound.select(bind.items[2]);
     bind.$.multiBound.select(bind.items[0]);
-    bind.$.observer.multiChanged = sinon.spy();
     bind.unshift('items', {name: 'zero'});
+    bind.$.observer.multiChanged = sinon.spy();
     bind.set(['items', 1, 'name'], 'test');
     assert.isTrue(bind.$.observer.multiChanged.calledOnce);
     assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.1.name');
@@ -375,6 +375,8 @@ suite('multi selection', function() {
 
     bind.$.observer.multiChanged = sinon.spy();
     bind.splice('items', 0, 1);
+    // assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected');
+    // assert.sameMembers(bind.$.observer.multiChanged.firstCall.args[0].value, [bind.items[1]]);
     assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
     assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
     assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].index, 0);

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -70,13 +70,13 @@ suite('single selection', function() {
     assert.isTrue(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
     assert.isFalse(el.isSelected(el.items[2]));
-    // Select 2
-    el.select(el.items[2]);
+    // Select 2 (using index-based API)
+    el.selectIndex(2);
     assert.strictEqual(el.selected, el.items[2]);
     assert.strictEqual(el.selectedItem, el.items[2]);
-    assert.isFalse(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isTrue(el.isSelected(el.items[2]));
+    assert.isFalse(el.isIndexSelected(0));
+    assert.isFalse(el.isIndexSelected(1));
+    assert.isTrue(el.isIndexSelected(2));
     // Toggle 2
     el.toggle = true;
     el.select(el.items[2]);
@@ -259,12 +259,12 @@ suite('multi selection', function() {
     assert.isTrue(el.isSelected(el.items[0]));
     assert.isFalse(el.isSelected(el.items[1]));
     assert.isFalse(el.isSelected(el.items[2]));
-    // Select 2
-    el.select(el.items[2]);
+    // Select 2 (using index-based API)
+    el.selectIndex(2);
     assert.sameMembers(el.selected, [el.items[0], el.items[2]]);
-    assert.isTrue(el.isSelected(el.items[0]));
-    assert.isFalse(el.isSelected(el.items[1]));
-    assert.isTrue(el.isSelected(el.items[2]));
+    assert.isTrue(el.isIndexSelected(0));
+    assert.isFalse(el.isIndexSelected(1));
+    assert.isTrue(el.isIndexSelected(2));
     // Toggle 2
     el.toggle = true;
     el.select(el.items[2]);
@@ -507,6 +507,67 @@ suite('corner cases', function() {
     el.multi = false;
     assert.equal(el.selected, null);
     assert.equal(el.selectedItem, null);
+  });
+
+  test('reset mutated array with gaps resulting in multiple splices', function() {
+    var bind = fixture('bind');
+    let i = bind.items = [
+      {name: '0'}, {name: '1'}, {name: '2'}, {name: '3'},
+      {name: '4'}, {name: '5'}, {name: '6'}, {name: '7'}
+    ];
+    bind.$.multiBound.selectIndex(2);
+    bind.$.multiBound.selectIndex(6);
+    bind.$.multiBound.selectIndex(1);
+    bind.$.multiBound.selectIndex(5);
+    bind.$.multiBound.selectIndex(0);
+    bind.$.multiBound.selectIndex(4);
+    assert.sameMembers(bind.$.multiBound.selected, [i[2], i[6], i[1], i[5], i[0], i[4]]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set('items.4.name', 'changed1');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.5.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'changed1');
+
+    bind.items = [
+      i[0], i[3], i[4], i[7]
+    ];
+    assert.sameMembers(bind.$.multiBound.selected, [i[0], i[4]]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set('items.2.name', 'changed2');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.1.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'changed2');
+  });
+
+  // Current algorithm does not handle reordering array while maintaining selection state
+  test.skip('reset mutated array reordered resulting in multiple splices', function() {
+    var bind = fixture('bind');
+    let i = bind.items = [
+      {name: '0'}, {name: '1'}, {name: '2'}, {name: '3'},
+      {name: '4'}, {name: '5'}, {name: '6'}, {name: '7'}
+    ];
+    bind.$.multiBound.selectIndex(2);
+    bind.$.multiBound.selectIndex(6);
+    bind.$.multiBound.selectIndex(1);
+    bind.$.multiBound.selectIndex(5);
+    bind.$.multiBound.selectIndex(0);
+    bind.$.multiBound.selectIndex(4);
+    assert.sameMembers(bind.$.multiBound.selected, [i[2], i[6], i[1], i[5], i[0], i[4]]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set('items.4.name', 'changed1');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.5.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'changed1');
+
+    bind.items = [
+      i[4], i[5], i[6], i[7], i[0], i[1], i[2], i[3]
+    ];
+    assert.sameMembers(bind.$.multiBound.selected, [i[2], i[6], i[1], i[5], i[0], i[4]]);
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.set('items.0.name', 'changed2');
+    assert.isTrue(bind.$.observer.multiChanged.calledOnce);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.5.name');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value, 'changed2');
   });
 
 });


### PR DESCRIPTION
Implements `<array-selector>` for 2.x.

* Updated to ES6 `Polymer.Element` class syntax
* Removes use of `Polymer.Collection`; instead uses splice information to adjust linked indices between the `items` & `selected` arrays
* When the object is reset, current selection is persisted based on object identity by synthesizing splice info via `Polymer.ArraySplice` (Levenshtein minimum edit distance algorithm); this makes `array-selector` compatible with the proposed changes to [object dirty checking](https://github.com/Polymer/polymer/blob/2.0-preview/README.md#breaking-data-dirty-checking) in 2.0.  However, this is a small break in API behavior (previously setting to a new array would clear selection; it no longer necessarily does).
* Small API improvement: when items are removed that were previously selected, the selected item is removed from the `selected` array/item (in 1.x you had to manually deselect first, which seemed onerous)

### Reference Issue
Fixes #4154
