### PR TITLE
Fixes #4247: limit simple property observer callbacks

### DIFF
--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -167,7 +167,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function runObserverEffect(inst, property, value, old, info) {
     let fn = inst[info.methodName];
     if (fn) {
-      fn.call(inst, value, old);
+      if (info.property === property) {
+        fn.call(inst, value, old);
+      }
     } else {
       console.warn('observer method `' + info.methodName + '` not defined');
     }
@@ -2007,6 +2009,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._addPropertyEffect(property, TYPES.OBSERVE, {
           fn: runObserverEffect,
           info: {
+            property: property,
             methodName: methodName
           }
         });

--- a/test/unit/notify-path-elements.html
+++ b/test/unit/notify-path-elements.html
@@ -81,6 +81,15 @@
     Polymer({
       is: 'x-stuff',
       properties: {
+        simplyObserved: {
+          type: Object,
+          value: function () {
+            return {
+              nestedField: "originalArbitraryValue",
+            };
+          },
+          observer: "simplyObservedChanged",
+        },
         computedFromPaths: {
           computed: 'computeFromPaths(a, nested.b, nested.obj.c)'
         }
@@ -121,6 +130,7 @@
         this.aChanged = sinon.spy();
         this.xChanged = sinon.spy();
         this.yChanged = sinon.spy();
+        this.simplyObservedChanged = sinon.spy();
         if (this.$) {
           this.$.compose.resetObservers();
           this.$.forward.resetObservers();

--- a/test/unit/notify-path.html
+++ b/test/unit/notify-path.html
@@ -430,6 +430,31 @@ suite('path effects', function() {
     assert.equal(el.$.boundChild.computedFromPaths, 100);
   });
 
+  test('simple property observer with shallow modification', function() {
+    // Setup
+    var simplyObservedOld = el.simplyObserved;
+    var simplyObserved = {
+      nestedField: "differentArbitraryValue"
+    };
+    el.resetObservers();
+    // Do the thing
+    el.simplyObserved = simplyObserved;
+    // Verify
+    assert.equal(el.simplyObservedChanged.callCount, 1);
+    assert.equal(el.simplyObservedChanged.firstCall.args[0], simplyObserved);
+    assert.equal(el.simplyObservedChanged.firstCall.args[1], simplyObservedOld);
+  });
+
+  test('simple property observer with deep modification', function() {
+    // Setup
+    var nestedField = "differentArbitraryValue";
+    el.resetObservers();
+    // Do the thing
+    el.set("simplyObserved.nestedField", nestedField);
+    // Verify
+    assert.equal(el.simplyObservedChanged.callCount, 0);
+  });
+
   test('array.splices notified', function() {
     el.arrayNoColl = [];
     assert.equal(el.arrayNoCollChanged.callCount, 1);


### PR DESCRIPTION
-	prevent deep/multi-part-path modification from triggering simple observer callbacks

### Reference Issue
Fixes #4247
