### PR TITLE
Make Polymer 2.0 compatible with Closure Compiler

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "Polymer": true,
     "ShadyDOM": true,
     "ShadyCSS": true,
-    "ApplyShim": true
+    "ApplyShim": true,
+    "goog": true
   }
 }

--- a/externs/closure-upstream-externs.js
+++ b/externs/closure-upstream-externs.js
@@ -1,15 +1,11 @@
 /**
- * @fileoverview Externs for Polymer, polyfills, and missing stuff in Closure Compiler
+ * @fileoverview Externs to upstream to closure compiler
  * @externs
- * */
-
-/* externs to upstream to closure compiler */
-
-/**
- * @record
  */
+
+/** @record */
 function CustomElement(){}
-/** @type {!Array<string> | undefined} */
+/** @type {!Array<string>|undefined} */
 CustomElement.observedAttributes;
 /** @type {function()|undefined} */
 CustomElement.prototype.connectedCallback;
@@ -76,60 +72,3 @@ const customElements = {
   whenDefined(tagName){}
 }
 window.customElements = customElements;
-
-/* externs to include in webcomponents polyfills */
-/**
- * @constructor
- * @extends {HTMLElement}
- */
-function CustomStyle(){}
-/**
- * @param {!HTMLStyleElement} style
- */
-CustomStyle.prototype.processHook = function(style){};
-
-let HTMLImports = {
-  /**
-   * @param {function()} callback
-   */
-  whenReady(callback){}
-};
-
-window.HTMLImports = HTMLImports;
-
-let ShadyCSS = {
-  applyStyle(){},
-  updateStyles(){},
-  prepareTemplate(){},
-  nativeCss: false,
-  nativeCssApply: false,
-  nativeShadow: false
-};
-window.ShadyCSS = ShadyCSS;
-
-let ShadyDOM = {
-  inUse: false,
-  flush(){},
-  observeChildren(){},
-  unobserveChildren(){},
-  patch(){}
-};
-
-window.ShadyDOM = ShadyDOM;
-
-let WebComponents = {};
-window.WebComponents = WebComponents;
-
-/** @type {Element} */
-HTMLElement.prototype._activeElement;
-
-/**
- * @param {HTMLTemplateElement} template
- */
-HTMLTemplateElement.prototype.decorate = function(template){};
-
-/**
- * @param {!{is: string}} init
- * @return {!CustomElement}
- */
-function Polymer(init){}

--- a/externs/externs.js
+++ b/externs/externs.js
@@ -1,16 +1,51 @@
-window.Polymer = {};
+/**
+ * @fileoverview Externs for Polymer, polyfills, and missing stuff in Closure Compiler
+ * @externs
+ * */
+/**
+ * @param {!{is: string}} init
+ */
+function Polymer(init){}
 
-function Polymer(){}
+/**
+ * @record
+ */
+function CustomElement(){}
+/** @type {!Array<string> | undefined} */
+CustomElement.observedAttributes;
+/** @type {function()|undefined} */
+CustomElement.prototype.connectedCallback;
+/** @type {function()|undefined} */
+CustomElement.prototype.disconnectedCallback;
+/** @type {function(string, ?string, ?string, ?string)|undefined} */
+CustomElement.prototype.attributeChangedCallback;
 
-let customElements = {
-  define(){},
-  get(){},
-  whenDefined(){}
+const customElements = {
+  /**
+   * @param {string} tagName
+   * @param {!CustomElement} klass
+   * @param {Object=} options
+   * @return {CustomElement}
+   */
+  define(tagName, klass, options){},
+  /**
+   * @param {string} tagName
+   * @return {CustomElement}
+   */
+  get(tagName){},
+  /**
+   * @param {string} tagName
+   * @return {Promise<!CustomElement>}
+   */
+  whenDefined(tagName){}
 }
 window.customElements = customElements;
 
 let HTMLImports = {
-  whenReady(){}
+  /**
+   * @param {function()} callback
+   */
+  whenReady(callback){}
 };
 
 window.HTMLImports = HTMLImports;
@@ -63,24 +98,6 @@ function CustomStyle(){}
  * @param {!HTMLStyleElement} style
  */
 CustomStyle.prototype.processHook = function(style){};
-
-/**
- * @record
- */
-function CustomElement(){}
-/**
- * @type {!Array<string> | undefined}
- */
-CustomElement.observedAttributes;
-CustomElement.prototype.connectedCallback = function(){};
-CustomElement.prototype.disconnectedCallback = function(){};
-/**
- * @param {string} attributeName
- * @param {?string} oldValue
- * @param {?string} newValue
- * @param {?string} namespaceURI
- */
-CustomElement.prototype.attributeChangedCallback = function(attributeName, oldValue, newValue, namespaceURI){};
 
 /**
  * @constructor

--- a/externs/externs.js
+++ b/externs/externs.js
@@ -1,0 +1,83 @@
+window.Polymer = {};
+function Polymer(){}
+
+let customElements = {
+  define(){},
+  get(){},
+  whenDefined(){}
+}
+window.customElements = customElements;
+
+let HTMLImports = {
+  whenReady(){}
+};
+
+window.HTMLImports = HTMLImports;
+
+let addEventListener = window.addEventListener;
+
+let ShadyCSS = {
+  applyStyle(){},
+  updateStyles(){},
+  prepareTemplate(){},
+  nativeCss: false,
+  nativeCssApply: false,
+  nativeShadow: false
+};
+window.ShadyCSS = ShadyCSS;
+
+let ShadyDOM = {
+  inUse: false,
+  flush(){},
+  observeChildren(){},
+  unobserveChildren(){},
+  patch(){}
+};
+
+window.ShadyDOM = ShadyDOM;
+
+let WebComponents = {};
+window.WebComponents = WebComponents;
+
+Event.prototype.composed = false;
+
+HTMLElement.prototype.attachShadow = function(){};
+
+/**
+ * @record
+ */
+function CustomStyle(){}
+/**
+ * @param {!HTMLStyleElement} style
+ */
+CustomStyle.prototype.processHook = function(style){};
+
+/**
+ * @record
+ */
+function CustomElement(){}
+/**
+ * @type {Array<string> | undefined}
+ */
+CustomElement.observedAttributes;
+CustomElement.prototype.connectedCallback = function(){};
+CustomElement.prototype.disconnectedCallback = function(){};
+/**
+ * @param {!string} attributeName
+ * @param {?string} oldValue
+ * @param {?string} newValue
+ * @param {?string} namespaceURI
+ */
+CustomElement.prototype.attributeChangedCallback = function(attributeName, oldValue, newValue, namespaceURI){};
+
+/**
+ * @constructor
+ * @extends HTMLElement
+ */
+function HTMLSlotElement(){}
+
+/**
+ * @param {{flatten: boolean} | undefined} options
+ * @return {Array<Node>}
+ */
+HTMLSlotElement.prototype.assignedNodes = function(options){};

--- a/externs/externs.js
+++ b/externs/externs.js
@@ -2,10 +2,8 @@
  * @fileoverview Externs for Polymer, polyfills, and missing stuff in Closure Compiler
  * @externs
  * */
-/**
- * @param {!{is: string}} init
- */
-function Polymer(init){}
+
+/* externs to upstream to closure compiler */
 
 /**
  * @record
@@ -20,12 +18,50 @@ CustomElement.prototype.disconnectedCallback;
 /** @type {function(string, ?string, ?string, ?string)|undefined} */
 CustomElement.prototype.attributeChangedCallback;
 
+/** @type {boolean} */
+Event.prototype.composed;
+
+/**
+ * @return {!Array<!(Element|ShadowRoot|Document|Window)>}
+ */
+Event.prototype.composedPath = function(){};
+
+/**
+ * @param {!{mode: string}} options
+ * @return {!ShadowRoot}
+ */
+HTMLElement.prototype.attachShadow = function(options){};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLSlotElement(){}
+
+/**
+ * @param {!{flatten: boolean}=} options
+ * @return {!Array<!Node>}
+ */
+HTMLSlotElement.prototype.assignedNodes = function(options){};
+
+/** @type {HTMLSlotElement} */
+Node.prototype.assignedSlot;
+
+/** @constructor */
+function InputDeviceCapabilities(){}
+
+/** @type {boolean} */
+InputDeviceCapabilities.prototype.firesTouchEvents;
+
+/** @type {InputDeviceCapabilities} */
+MouseEvent.prototype.sourceCapabilities;
+
 const customElements = {
   /**
    * @param {string} tagName
    * @param {!CustomElement} klass
    * @param {Object=} options
-   * @return {CustomElement}
+   * @return {!CustomElement}
    */
   define(tagName, klass, options){},
   /**
@@ -40,6 +76,17 @@ const customElements = {
   whenDefined(tagName){}
 }
 window.customElements = customElements;
+
+/* externs to include in webcomponents polyfills */
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function CustomStyle(){}
+/**
+ * @param {!HTMLStyleElement} style
+ */
+CustomStyle.prototype.processHook = function(style){};
 
 let HTMLImports = {
   /**
@@ -73,69 +120,16 @@ window.ShadyDOM = ShadyDOM;
 let WebComponents = {};
 window.WebComponents = WebComponents;
 
-/**
- * @type {boolean}
- */
-Event.prototype.composed;
-
-/**
- * @return {!Array<!(Element|ShadowRoot|Document|Window)>}
- */
-Event.prototype.composedPath = function(){};
-
-/**
- * @param {!{mode: string}} options
- * @return {!ShadowRoot}
- */
-HTMLElement.prototype.attachShadow = function(options){};
-
-/**
- * @constructor
- * @extends {HTMLElement}
- */
-function CustomStyle(){}
-/**
- * @param {!HTMLStyleElement} style
- */
-CustomStyle.prototype.processHook = function(style){};
-
-/**
- * @constructor
- * @extends {HTMLElement}
- */
-function HTMLSlotElement(){}
-
-/**
- * @param {!{flatten: boolean} | undefined} options
- * @return {!Array<!Node>}
- */
-HTMLSlotElement.prototype.assignedNodes = function(options){};
-
-/**
- * @type {HTMLSlotElement}
- */
-Node.prototype.assignedSlot;
-
-/**
- * @constructor
- */
-function InputDeviceCapabilities(){}
-/**
- * @type {boolean}
- */
-InputDeviceCapabilities.prototype.firesTouchEvents;
-
-/**
- * @type {InputDeviceCapabilities}
- */
-MouseEvent.prototype.sourceCapabilities;
-
-/**
- * @type {Element}
- */
+/** @type {Element} */
 HTMLElement.prototype._activeElement;
 
 /**
  * @param {HTMLTemplateElement} template
  */
 HTMLTemplateElement.prototype.decorate = function(template){};
+
+/**
+ * @param {!{is: string}} init
+ * @return {!CustomElement}
+ */
+function Polymer(init){}

--- a/externs/externs.js
+++ b/externs/externs.js
@@ -1,4 +1,5 @@
 window.Polymer = {};
+
 function Polymer(){}
 
 let customElements = {
@@ -13,8 +14,6 @@ let HTMLImports = {
 };
 
 window.HTMLImports = HTMLImports;
-
-let addEventListener = window.addEventListener;
 
 let ShadyCSS = {
   applyStyle(){},
@@ -39,12 +38,25 @@ window.ShadyDOM = ShadyDOM;
 let WebComponents = {};
 window.WebComponents = WebComponents;
 
-Event.prototype.composed = false;
-
-HTMLElement.prototype.attachShadow = function(){};
+/**
+ * @type {boolean}
+ */
+Event.prototype.composed;
 
 /**
- * @record
+ * @return {!Array<!(Element|ShadowRoot|Document|Window)>}
+ */
+Event.prototype.composedPath = function(){};
+
+/**
+ * @param {!{mode: string}} options
+ * @return {!ShadowRoot}
+ */
+HTMLElement.prototype.attachShadow = function(options){};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
  */
 function CustomStyle(){}
 /**
@@ -57,13 +69,13 @@ CustomStyle.prototype.processHook = function(style){};
  */
 function CustomElement(){}
 /**
- * @type {Array<string> | undefined}
+ * @type {!Array<string> | undefined}
  */
 CustomElement.observedAttributes;
 CustomElement.prototype.connectedCallback = function(){};
 CustomElement.prototype.disconnectedCallback = function(){};
 /**
- * @param {!string} attributeName
+ * @param {string} attributeName
  * @param {?string} oldValue
  * @param {?string} newValue
  * @param {?string} namespaceURI
@@ -72,12 +84,41 @@ CustomElement.prototype.attributeChangedCallback = function(attributeName, oldVa
 
 /**
  * @constructor
- * @extends HTMLElement
+ * @extends {HTMLElement}
  */
 function HTMLSlotElement(){}
 
 /**
- * @param {{flatten: boolean} | undefined} options
- * @return {Array<Node>}
+ * @param {!{flatten: boolean} | undefined} options
+ * @return {!Array<!Node>}
  */
 HTMLSlotElement.prototype.assignedNodes = function(options){};
+
+/**
+ * @type {HTMLSlotElement}
+ */
+Node.prototype.assignedSlot;
+
+/**
+ * @constructor
+ */
+function InputDeviceCapabilities(){}
+/**
+ * @type {boolean}
+ */
+InputDeviceCapabilities.prototype.firesTouchEvents;
+
+/**
+ * @type {InputDeviceCapabilities}
+ */
+MouseEvent.prototype.sourceCapabilities;
+
+/**
+ * @type {Element}
+ */
+HTMLElement.prototype._activeElement;
+
+/**
+ * @param {HTMLTemplateElement} template
+ */
+HTMLTemplateElement.prototype.decorate = function(template){};

--- a/externs/polymer-externs.js
+++ b/externs/polymer-externs.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview Externs for Polymer
+ * @externs
+ */
+
+/**
+ * @param {!{is: string}} init
+ * @return {!CustomElement}
+ */
+function Polymer(init){}

--- a/externs/webcomponents-externs.js
+++ b/externs/webcomponents-externs.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Externs for webcomponents polyfills
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function CustomStyle(){}
+/**
+ * @param {!HTMLStyleElement} style
+ */
+CustomStyle.prototype.processHook = function(style){};
+
+let HTMLImports = {
+  /**
+   * @param {function()} callback
+   */
+  whenReady(callback){}
+};
+
+window.HTMLImports = HTMLImports;
+
+let ShadyCSS = {
+  /**
+   * @param {!HTMLElement} element
+   * @param {Object=} overrides
+   */
+  applyStyle(element, overrides){},
+  updateStyles(){},
+  /**
+   * @param {!HTMLTemplateElement} template
+   * @param {string} is
+   * @param {string=} extends
+   */
+  prepareTemplate(template, is, extends){},
+  nativeCss: false,
+  nativeShadow: false
+};
+window.ShadyCSS = ShadyCSS;
+
+let ShadyDOM = {
+  inUse: false,
+  flush(){},
+  /**
+   * @param {!Node} target
+   * @param {function(Array<MutationRecords>, MutationObserver)} callback
+   * @return {MutationObserver}
+   */
+  observeChildren(target, callback){},
+  /**
+   * @param {MutationObserver} observer
+   */
+  unobserveChildren(observer){},
+  /**
+   * @param {Node} node
+   */
+  patch(node){}
+};
+
+window.ShadyDOM = ShadyDOM;
+
+let WebComponents = {};
+window.WebComponents = WebComponents;
+
+/** @type {Element} */
+HTMLElement.prototype._activeElement;
+
+/**
+ * @param {HTMLTemplateElement} template
+ */
+HTMLTemplateElement.prototype.decorate = function(template){};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,10 @@ const ENTRY_POINTS = [POLYMER_LEGACY, POLYMER_ELEMENT];
 
 const polymer = require('polymer-build');
 const PolymerProject = polymer.PolymerProject;
-const project = new PolymerProject({ shell: DEFAULT_BUILD_TARGET });
+const project = new PolymerProject({
+  sources: ['./polymer.html'],
+  shell: './polymer.html'
+});
 const fork = polymer.forkStream;
 
 const mergeStream = require('merge-stream');
@@ -43,62 +46,91 @@ const htmlmin = require('gulp-htmlmin');
 const gzipSize = require('gzip-size');
 const prettyBytes = require('pretty-bytes');
 
-gulp.task('clean', function() {
+const closure = require('google-closure-compiler').gulp();
+
+gulp.task('clean', function () {
   return del(DIST_DIR);
 });
 
+const {Transform} = require('stream');
+
+class LogStream extends Transform {
+  constructor(prefix) {
+    super({objectMode: true});
+    this.prefix = prefix;
+  }
+  _transform(file, enc, cb) {
+    console.log(`${this.prefix}: ${file.path}`);
+    cb(null, file);
+  }
+  _flush(cb) {
+    cb();
+  }
+}
+
+class FilterStream extends Transform {
+  constructor() {
+    super({objectMode: true});
+  }
+  _transform(file, enc, cb) {
+    if (file.path.match(/polymer\.html_script_\d+\.js$/)) {
+      cb(null, file);
+    } else {
+      cb(null, null);
+    }
+  }
+}
+
 gulp.task('build', ['clean'], () => {
- // process source files in the project
- const sources = project.sources()
-   .pipe(project.splitHtml())
-   // add compilers or optimizers here!
-   .pipe(gulpif(/\.js$/, babel({presets: ['es2015']/*, plugins: ['external-helpers']*/})))
-   .pipe(gulpif(/\.js$/, uglify()))
-   .pipe(project.rejoinHtml())
-   .pipe(htmlmin({removeComments: true}));
 
- // process dependencies
- const dependencies = project.dependencies()
-   .pipe(project.splitHtml())
-   // add compilers or optimizers here!
-   .pipe(gulpif(/\.js$/, babel({presets: ['es2015']/*, plugins: ['external-helpers']*/})))
-   .pipe(gulpif(/\.js$/, uglify()))
-   .pipe(project.rejoinHtml())
-   .pipe(htmlmin({removeComments: true}));
+  const closureStream = closure({
+    // new_type_inf: true,
+    compilation_level: 'ADVANCED',
+    // compilation_level: 'SIMPLE',
+    language_in: 'ES6_STRICT',
+    language_out: 'ES5_STRICT',
+    warning_level: 'VERBOSE',
+    js_output_file: 'polymer.js',
+    output_wrapper: `${require('fs').readFileSync('LICENSE.txt')}\n(function(){\n%output%\n}).call(self)`,
+    rewrite_polyfills: false,
+    formatting: 'PRETTY_PRINT',
+    externs: ['externs/externs.js']
+  });
 
- // merge the source and dependencies streams to we can analyze the project
- const mergedFiles = mergeStream(sources, dependencies)
-   .pipe(project.analyzer);
+  // process source files in the project
+  const sources = project.sources()
 
- return mergeStream(
-   fork(mergedFiles)
-     .pipe(project.bundler)
-     // write to the bundled folder
-     .pipe(gulp.dest(BUNDLED_DIR)),
+  // process dependencies
+  const dependencies = project.dependencies()
 
-   fork(mergedFiles)
-     // write to the unbundled folder
-     .pipe(gulp.dest(UNBUNDLED_DIR))
- );
+  // merge the source and dependencies streams to we can analyze the project
+  const mergedFiles = mergeStream(sources, dependencies);
+
+  return mergedFiles
+    .pipe(project.bundler)
+    .pipe(project.splitHtml())
+    .pipe(new FilterStream())
+    .pipe(closureStream)
+    .pipe(gulp.dest(BUNDLED_DIR))
 });
 
 // copy bower.json into dist folder
-gulp.task('copy-bower-json', function() {
+gulp.task('copy-bower-json', function () {
   return gulp.src('bower.json').pipe(gulp.dest(DEFAULT_BUILD_DIR));
 });
 
 // Build
-gulp.task('build-steps', function(cb) {
+gulp.task('build-steps', function (cb) {
   runseq('restore-src', 'build', 'print-size', cb);
 });
 
 // Bundled build
-gulp.task('build-bundled', function(cb) {
+gulp.task('build-bundled', function (cb) {
   runseq('build-steps', 'save-src', 'link-bundled', cb);
 });
 
 // Unbundled build
-gulp.task('build-unbundled', function(cb) {
+gulp.task('build-unbundled', function (cb) {
   runseq('build-steps', 'save-src', 'link-unbundled', cb);
 });
 
@@ -106,58 +138,58 @@ gulp.task('build-unbundled', function(cb) {
 gulp.task('default', ['build-bundled']);
 
 // switch src and build for testing
-gulp.task('save-src', function() {
+gulp.task('save-src', function () {
   return gulp.src(ENTRY_POINTS)
-    .pipe(rename(function(p) {
+    .pipe(rename(function (p) {
       p.extname += '.src';
     }))
     .pipe(gulp.dest('.'));
 });
 
-gulp.task('restore-src', function(cb) {
-  const files = ENTRY_POINTS.map(f=>`${f}.src`);
+gulp.task('restore-src', function (cb) {
+  const files = ENTRY_POINTS.map(f => `${f}.src`);
   gulp.src(files)
-    .pipe(rename(function(p) {
+    .pipe(rename(function (p) {
       p.extname = '';
     }))
     .pipe(gulp.dest('.'))
-    .on('end', ()=>Promise.all(files.map(f=>del(f))).then(()=>cb()));
+    .on('end', () => Promise.all(files.map(f => del(f))).then(() => cb()));
 });
 
-gulp.task('link-bundled', function(cb) {
-  ENTRY_POINTS.forEach(f=>{
+gulp.task('link-bundled', function (cb) {
+  ENTRY_POINTS.forEach(f => {
     fs.writeFileSync(f, `<link rel="import" href="${DEFAULT_BUILD_DIR}/${DEFAULT_BUILD_TARGET}">`);
   });
   cb();
 });
 
-gulp.task('link-unbundled', function(cb) {
-  ENTRY_POINTS.forEach(f=>{
+gulp.task('link-unbundled', function (cb) {
+  ENTRY_POINTS.forEach(f => {
     fs.writeFileSync(f, `<link rel="import" href="${DEFAULT_BUILD_DIR}/${f}">`);
   });
   cb();
 });
 
-gulp.task('print-size', function(cb) {
-  fs.readFile(path.join(DEFAULT_BUILD_DIR, DEFAULT_BUILD_TARGET), function(err, contents) {
-    gzipSize(contents, function(err, size) {
+gulp.task('print-size', function (cb) {
+  fs.readFile(path.join(DEFAULT_BUILD_DIR, DEFAULT_BUILD_TARGET), function (err, contents) {
+    gzipSize(contents, function (err, size) {
       console.log(`${DEFAULT_BUILD_TARGET} size: ${prettyBytes(size)}`);
       cb();
     });
   });
 });
 
-gulp.task('audit', function() {
-  return gulp.src(ENTRY_POINTS.map(f=>path.join(DEFAULT_BUILD_DIR, f)))
+gulp.task('audit', function () {
+  return gulp.src(ENTRY_POINTS.map(f => path.join(DEFAULT_BUILD_DIR, f)))
     .pipe(audit('build.log', { repos: ['.'] }))
     .pipe(gulp.dest(DEFAULT_BUILD_DIR));
 });
 
-gulp.task('release', function(cb) {
+gulp.task('release', function (cb) {
   runseq('default', ['copy-bower-json', 'audit'], cb);
 });
 
-gulp.task('lint', function() {
+gulp.task('lint', function () {
   return gulp.src(['src/**/*.html', 'test/unit/*.html', 'util/*.js'])
     .pipe(eslint())
     .pipe(eslint.format())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,8 @@ gulp.task('build', ['clean'], () => {
     output_wrapper: '(function(){\n%output%\n}).call(self)',
     rewrite_polyfills: false,
     formatting: 'PRETTY_PRINT',
-    externs: ['externs/externs.js']
+    externs: 'externs/externs.js'
+    // polymer_pass: true
   });
 
   const closurePipeline = lazypipe()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('closure', ['clean'], () => {
     warning_level: 'VERBOSE',
     output_wrapper: '(function(){\n%output%\n}).call(self)',
     rewrite_polyfills: false,
-    externs: 'externs/externs.js'
+    externs: ['externs/closure-upstream-externs.js', 'externs/webcomponents-externs.js', 'externs/polymer-externs.js']
   });
 
   const closurePipeline = lazypipe()

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "test"
   },
   "devDependencies": {
-    "babel-plugin-external-helpers": "^6.8.0",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-babili": "0.0.10",
     "del": "^2.2.1",
     "dom5": "^1.3.1",
     "eslint-plugin-html": "^1.3.0",
@@ -18,19 +17,15 @@
     "gulp-audit": "^1.0.0",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
-    "gulp-htmlmin": "^2.0.0",
+    "gulp-htmlmin": "^3.0.0",
     "gulp-if": "^2.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-replace": "^0.5.3",
     "gulp-size": "^2.1.0",
-    "gulp-uglify": "^2.0.0",
     "gulp-vulcanize": "^6.0.1",
     "lazypipe": "^1.0.1",
-    "merge-stream": "^1.0.0",
-    "polyclean": "^1.2.0",
+    "merge-stream": "^1.0.1",
     "polymer-build": "^0.6.0",
     "run-sequence": "^1.1.0",
-    "through2": "^2.0.0",
     "web-component-tester": "^4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "del": "^2.2.1",
     "dom5": "^1.3.1",
     "eslint-plugin-html": "^1.3.0",
+    "google-closure-compiler": "^20161201.0.0",
     "gulp": "^3.9.1",
     "gulp-audit": "^1.0.0",
     "gulp-babel": "^6.1.2",
@@ -27,7 +28,7 @@
     "lazypipe": "^1.0.1",
     "merge-stream": "^1.0.0",
     "polyclean": "^1.2.0",
-    "polymer-build": "^0.3.0",
+    "polymer-build": "^0.6.0",
     "run-sequence": "^1.1.0",
     "through2": "^2.0.0",
     "web-component-tester": "^4"

--- a/polymer-element.html
+++ b/polymer-element.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <link rel="import" href="src/elements/element.html">

--- a/polymer-legacy.html
+++ b/polymer-legacy.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- bc compatible Polymer({...}); enabled via Polymer.LegacyElement -->
 <link rel="import" href="src/legacy/polymer-fn.html">
 <link rel="import" href="src/legacy/class.html">

--- a/polymer.html
+++ b/polymer.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <link rel="import" href="polymer-legacy.html">
 <!-- template elements -->
 <link rel="import" href="src/templatizer/dom-bind.html">

--- a/src/attributes/attributes.html
+++ b/src/attributes/attributes.html
@@ -190,12 +190,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           case String:
           default:
+            outValue = value;
             break;
         }
 
-        if (!outValue) {
-          outValue = value;
-        }
         return outValue;
       }
       /* eslint-enable no-fallthrough */

--- a/src/attributes/attributes.html
+++ b/src/attributes/attributes.html
@@ -20,7 +20,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.Attributes = Polymer.Utils.dedupingMixin(function(superClass) {
 
-    return class Attributes extends superClass {
+    /**
+     * @unrestricted
+     */
+    class Attributes extends superClass {
 
       constructor() {
         super();
@@ -66,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method _propertyToAttribute
        * @param {string} property Property name to reflect.
-       * @param {*=} attribute Attribute name to reflect.
+       * @param {string=} attribute Attribute name to reflect.
        * @param {*=} value Property value to refect.
        */
       _propertyToAttribute(property, attribute, value) {
@@ -85,11 +88,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * the attribute will be removed (this is the default for boolean
        * type `false`).
        *
-       * @method _valueToAttribute
-       * @param {Element=} node Element to set attribute to.
+       * @method _valueToNodeAttribute
+       * @param {Element} node Element to set attribute to.
        * @param {*} value Value to serialize.
        * @param {string} attribute Attribute name to serialize to.
-
        */
       _valueToNodeAttribute(node, value, attribute) {
         var str = this._serializeAttribute(value);
@@ -109,7 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method _serializeAttribute
        * @param {*} value Property value to serialize.
-       * @return {string} String serialized from the provided property value.
+       * @return {string | undefined} String serialized from the provided property value.
        */
       _serializeAttribute(value) {
         /* eslint-disable no-fallthrough */
@@ -119,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           case 'object':
             if (value instanceof Date) {
-              return value;
+              return value.toString();
             } else if (value) {
               try {
                 return JSON.stringify(value);
@@ -129,7 +131,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
 
           default:
-            return value != null ? value : undefined;
+            return value != null ? value.toString() : undefined;
         }
       }
 
@@ -152,18 +154,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {*} Typed value deserialized from the provided string.
        */
       _deserializeAttribute(value, type) {
+        /**
+         * @type {*}
+         */
+        let outValue;
         switch (type) {
           case Number:
-            value = Number(value);
+            outValue = Number(value);
             break;
 
           case Boolean:
-            value = (value !== null);
+            outValue = (value !== null);
             break;
 
           case Object:
             try {
-              value = JSON.parse(value);
+              outValue = JSON.parse(value);
             } catch(x) {
               // allow non-JSON literals like Strings and Numbers
             }
@@ -171,26 +177,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           case Array:
             try {
-              value = JSON.parse(value);
+              outValue = JSON.parse(value);
             } catch(x) {
-              value = null;
+              outValue = null;
               console.warn('Polymer::Attributes: couldn`t decode Array as JSON');
             }
             break;
 
           case Date:
-            value = new Date(value);
+            outValue = new Date(value);
             break;
 
           case String:
           default:
             break;
         }
-        return value;
+
+        if (!outValue) {
+          outValue = value;
+        }
+        return outValue;
       }
       /* eslint-enable no-fallthrough */
     }
 
+    return Attributes;
   });
 
 

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -39,7 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.ElementMixin = Polymer.Utils.cachingMixin(function(base) {
 
-    return class PolymerElement extends Polymer.PropertyEffects(base) {
+    const mixin = Polymer.PropertyEffects(base);
+    return class PolymerElement extends mixin {
 
       // returns the config object on specifically on `this` class (not super)
       // config is used for:
@@ -120,9 +121,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (config) {
             this._finalizeConfig(config);
           }
-          if (this.template) {
-            let template = this.template.cloneNode(true);
-            this._finalizeTemplate(template);
+          let template = this.template;
+          if (template) {
+            this._finalizeTemplate(template.cloneNode(true));
           }
         }
       }

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -125,9 +125,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (config) {
             this._finalizeConfig(config);
           }
-          let template = this.template;
-          if (template) {
-            this._finalizeTemplate(template.cloneNode(true));
+          if (this.template) {
+            this._finalizeTemplate(this.template.cloneNode(true));
           }
         }
       }
@@ -152,8 +151,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       static get template() {
         if (!this.hasOwnProperty(goog.reflect.objectProperty('_template', this))) {
-          // TODO(sorvell): support more ways to acquire template.
-          // this requires `is` on constructor...
           this._template = this._getTemplate() ||
             // note: implemented so a subclass can retrieve the super
             // template; call the super impl this way so that `this` points

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -146,11 +146,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      static _getTemplate() {
+        return Polymer.DomModule.import(this.is, 'template');
+      }
+
       static get template() {
         if (!this.hasOwnProperty(goog.reflect.objectProperty('_template', this))) {
           // TODO(sorvell): support more ways to acquire template.
           // this requires `is` on constructor...
-          this._template = Polymer.DomModule.import(this.is, 'template') ||
+          this._template = this._getTemplate() ||
             // note: implemented so a subclass can retrieve the super
             // template; call the super impl this way so that `this` points
             // to the superclass.

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -48,8 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // then used to make observedAttributes and set property defaults
       // (2) properties effects and observers are created from it at `finalize` time.
       static get _ownConfig() {
-        if (!this.hasOwnProperty('__ownConfig')) {
-          this.__ownConfig = this.hasOwnProperty('config') ? this.config : {};
+        if (!this.hasOwnProperty(goog.reflect.objectProperty('__ownConfig', this))) {
+          this.__ownConfig = this.hasOwnProperty(goog.reflect.objectProperty('config', this)) ? this.config : {};
         }
         return this.__ownConfig;
       }
@@ -60,7 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // (1) observedAttributes,
       // (2) element default values
       static get _flattenedProperties() {
-        if (!this.hasOwnProperty('__flattenedProperties')) {
+        if (!this.hasOwnProperty(goog.reflect.objectProperty('__flattenedProperties', this))) {
           // TODO(sorvell): consider optimizing; shorthand type support requires
           // an extra loop to upgrade shorthand property info to longhand
           this.__flattenedProperties = flattenProperties({}, this._ownConfig.properties);
@@ -75,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       static get observedAttributes() {
-        if (!this.hasOwnProperty('_observedAttributes')) {
+        if (!this.hasOwnProperty(goog.reflect.objectProperty('_observedAttributes', this))) {
           // observedAttributes must be finalized at registration time
           this._observedAttributes = this._addPropertiesToAttributes(
             this._flattenedProperties, []);
@@ -91,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       static get finalized() {
-        return this.hasOwnProperty('_finalized');
+        return this.hasOwnProperty(goog.reflect.objectProperty('_finalized', this));
       }
 
       static set finalized(value) {
@@ -114,7 +114,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             superCtor.finalize();
           }
           this.finalized = true;
-          if (this.hasOwnProperty('is') && this.is) {
+          if (this.hasOwnProperty(goog.reflect.objectProperty('is', this)) && this.is) {
             Polymer.telemetry.register(proto);
           }
           let config = this._ownConfig;
@@ -143,7 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       static get template() {
-        if (!this.hasOwnProperty('_template')) {
+        if (!this.hasOwnProperty(goog.reflect.objectProperty('_template', this))) {
           // TODO(sorvell): support more ways to acquire template.
           // this requires `is` on constructor...
           this._template = Polymer.DomModule.import(this.is, 'template') ||

--- a/src/elements/element.html
+++ b/src/elements/element.html
@@ -40,7 +40,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.ElementMixin = Polymer.Utils.cachingMixin(function(base) {
 
     const mixin = Polymer.PropertyEffects(base);
-    return class PolymerElement extends mixin {
+
+    /**
+     * @unrestricted
+     */
+    class PolymerElement extends mixin {
 
       // returns the config object on specifically on `this` class (not super)
       // config is used for:
@@ -319,8 +323,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * to put its dom in another location.
        *
        * @method _attachDom
+       * @throws {Error}
+       * @suppress {missingReturn}
        * @param {NodeList} dom to attach to the element.
-       * @returns {Node} node to which the dom has been attached.
+       * @return {Node} node to which the dom has been attached.
        */
       _attachDom(dom) {
         if (this.attachShadow) {
@@ -337,6 +343,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
            `Polymer.Element can
               create dom as children instead of in ShadowDOM by setting
               \`this.root = this;\` before \`ready\`.`);
+
         }
       }
 
@@ -350,6 +357,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      /**
+       * Update styling for this element
+       *
+       * @param {Object=} properties
+       *  Override styling with an object of properties where the keys are css properties, and the values are strings
+       *  Example: `this.updateStyles({'color': 'blue'})`
+       *  These properties are retained unless a value of `null` is set.
+       */
       updateStyles(properties) {
         if (window.ShadyCSS) {
           ShadyCSS.applyStyle(this, properties);
@@ -378,6 +393,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     }
 
+    return PolymerElement;
   });
 
   let hostStack = {

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       detached() {}
 
-      attributeChanged(name, old, value) {}
+      attributeChanged(name, old, value) {} // eslint-disable-line no-unused-vars
 
       serialize(value) {
         return this._serializeAttribute(value);

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       detached() {}
 
-      attributeChanged() {}
+      attributeChanged(name, old, value) {}
 
       serialize(value) {
         return this._serializeAttribute(value);
@@ -157,8 +157,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   template content.
       */
       instanceTemplate(template) {
-        var dom =
-          document.importNode(template._content || template.content, true);
+        var dom = /** @type {DocumentFragment} */
+          (document.importNode(template._content || template.content, true));
         return dom;
       }
 
@@ -167,14 +167,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Dispatches a custom event with an optional detail value.
        *
        * @method fire
-       * @param {String} type Name of event type.
+       * @param {string} type Name of event type.
        * @param {*=} detail Detail value containing event-specific
        *   payload.
        * @param {Object=} options Object specifying options.  These may include:
        *  `bubbles` (boolean, defaults to `true`),
        *  `cancelable` (boolean, defaults to false), and
        *  `node` on which to fire the event (HTMLElement, defaults to `this`).
-       * @return {CustomEvent} The new event that was fired.
+       * @return {Event} The new event that was fired.
        */
       fire(type, detail, options) {
         options = options || {};
@@ -341,7 +341,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * returned by <a href="#getEffectiveChildNodes>getEffectiveChildNodes</a>.
        *
        * @method getEffectiveTextContent
-       * @return {Array<Node>} List of effctive children.
+       * @return {string} List of effctive children.
        */
       getEffectiveTextContent() {
         var cn = this.getEffectiveChildNodes();
@@ -433,7 +433,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method isLocalDescendant
        * @param {HTMLElement=} node The element to be checked.
-       * @return {Boolean} true if node is in this element's local DOM tree.
+       * @return {boolean} true if node is in this element's local DOM tree.
        */
       isLocalDescendant(node) {
         return this.root === node.getRootNode();
@@ -658,8 +658,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cross-platform helper for setting an element's CSS `transform` property.
        *
-       * @method transformText
-       * @param {String} transform Transform setting.
+       * @param {string} transformText Transform setting.
        * @param {HTMLElement=} node Element to apply the transform to.
        * Defaults to `this`
        */
@@ -696,9 +695,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * notification is generated**.
        *
        * @method arrayDelete
-       * @param {String|Array} path Path to array from which to remove the item
+       * @param {string | Array<number|string>} arrayOrPath Path to array from which to remove the item
        *   (or the array itself).
-       * @param {any} item Item to remove.
+       * @param {*} item Item to remove.
        * @return {Array} Array containing item removed.
        */
       arrayDelete(arrayOrPath, item) {
@@ -715,6 +714,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             return this.splice(arrayOrPath, index, 1);
           }
         }
+        return null;
       }
 
     }

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -469,7 +469,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method debounce
        * @param {String} jobName String to indentify the debounce job.
-       * @param {Function} callback Function that is called (with `this`
+       * @param {function()} callback Function that is called (with `this`
        *   context) when the wait time elapses.
        * @param {number} wait Optional wait time in milliseconds (ms) after the
        *   last signal that must elapse before invoking `callback`

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -695,7 +695,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * notification is generated**.
        *
        * @method arrayDelete
-       * @param {string | Array<number|string>} arrayOrPath Path to array from which to remove the item
+       * @param {string | !Array<number|string>} arrayOrPath Path to array from which to remove the item
        *   (or the array itself).
        * @param {*} item Item to remove.
        * @return {Array} Array containing item removed.

--- a/src/elements/legacy-element.html
+++ b/src/elements/legacy-element.html
@@ -25,8 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.LegacyElementMixin = Polymer.Utils.cachingMixin(function(base) {
 
-    return class LegacyElement extends Polymer.Logging(
-      Polymer.GestureEventListeners(Polymer.ElementMixin(base))) {
+    const mixin = Polymer.Logging(
+      Polymer.GestureEventListeners(Polymer.ElementMixin(base)));
+    return class LegacyElement extends mixin {
 
       constructor() {
         super();

--- a/src/events/gesture-event-listeners.html
+++ b/src/events/gesture-event-listeners.html
@@ -84,6 +84,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   };
 
+  /**
+   * @param {boolean=} setup
+   */
   function setupTeardownMouseCanceller(setup) {
     let events = IS_TOUCH_ONLY ? ['click'] : MOUSE_EVENTS;
     for (let i = 0, en; i < events.length; i++) {

--- a/src/events/gesture-event-listeners.html
+++ b/src/events/gesture-event-listeners.html
@@ -726,7 +726,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.GestureEventListeners = Polymer.Utils.dedupingMixin(function(superClass) {
 
-    return class GestureEventListeners extends Polymer.EventListeners(superClass) {
+    const mixin = Polymer.EventListeners(superClass);
+    return class GestureEventListeners extends mixin {
 
       _addEventListenerToNode(node, eventName, handler) {
         if (!gestures.addListener(node, eventName, handler)) {

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -80,8 +80,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return config;
         }
 
-        static get template() {
-          return behavior._template || super.template || this.prototype._template;
+        static getTemplate() {
+          return behavior._template || super.getTemplate() || this.prototype._template;
         }
 
         _invokeFunction(fn, args) {

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -84,8 +84,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return config;
         }
 
-        static getTemplate() {
-          return behavior._template || super.getTemplate() || this.prototype._template;
+        static _getTemplate() {
+          return behavior._template || super._getTemplate();
         }
 
         /**

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -85,7 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         static _getTemplate() {
-          return behavior._template || super._getTemplate();
+          return behavior._template || super._getTemplate() || this.prototype._template;
         }
 
         /**

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -45,6 +45,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return klass;
     }
 
+    /**
+     * @param {Array} behaviors
+     * @param {Array=} list
+     */
     var flattenBehaviors = function(behaviors, list) {
       list = list || [];
       if (behaviors) {
@@ -84,6 +88,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return behavior._template || super.getTemplate() || this.prototype._template;
         }
 
+        /**
+         * @param {Function} fn
+         * @param {Array=} args
+         */
         _invokeFunction(fn, args) {
           if (fn) {
             fn.apply(this, args);

--- a/src/legacy/class.html
+++ b/src/legacy/class.html
@@ -92,7 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         _initializeProperties() {
           // call `registered` only if it was not called for *this* constructor
-          if (!PolymerGenerated.hasOwnProperty('__registered')) {
+          if (!PolymerGenerated.hasOwnProperty(goog.reflect.objectProperty('__registered', PolymerGenerated))) {
             PolymerGenerated.__registered = true;
             if (behavior.registered) {
               behavior.registered.call(Object.getPrototypeOf(this));

--- a/src/legacy/dom-module.html
+++ b/src/legacy/dom-module.html
@@ -28,10 +28,6 @@
 
     static get observedAttributes() { return ['id'] }
 
-    get modules() {
-      return modules;
-    }
-
     attributeChangedCallback(name, old, value) {
       if (old !== value) {
         this.register();
@@ -85,6 +81,8 @@
     }
 
   }
+
+  DomModule.prototype['modules'] = modules;
 
   customElements.define('dom-module', DomModule);
 

--- a/src/legacy/dom-module.html
+++ b/src/legacy/dom-module.html
@@ -28,6 +28,10 @@
 
     static get observedAttributes() { return ['id'] }
 
+    get modules() {
+      return modules;
+    }
+
     attributeChangedCallback(name, old, value) {
       if (old !== value) {
         this.register();
@@ -45,7 +49,7 @@
      * when a dom-module is imperatively created. For
      * example, `document.createElement('dom-module').register('foo')`.
      * @method register
-     * @param {String} id The id at which to register the dom-module.
+     * @param {string=} id The id at which to register the dom-module.
      */
     register(id) {
       id = id || this.id;
@@ -64,9 +68,9 @@
      * Retrieves the dom specified by `selector` in the module specified by
      * `id`. For example, this.import('foo', 'img');
      * @method register
-     * @param {String} id
-     * @param {String} selector
-     * @return {Object} Returns the dom which matches `selector` in the module
+     * @param {string} id
+     * @param {string=} selector
+     * @return {Element} Returns the dom which matches `selector` in the module
      * at the specified `id`.
      */
     import(id, selector) {
@@ -77,6 +81,7 @@
         }
         return m;
       }
+      return null;
     }
 
   }
@@ -85,8 +90,6 @@
 
   // export
   Polymer.DomModule = new DomModule();
-
-  Polymer.DomModule.modules = modules;
 
 })();
 

--- a/src/legacy/polymer-fn.html
+++ b/src/legacy/polymer-fn.html
@@ -18,9 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Polymer is a Function, but of course this is also an Object, so we
     // hang various other objects off of Polymer.*
 
-    var userPolymer = window.Polymer;
+    var userPolymer = window['Polymer'];
 
-    window.Polymer = function(info) {
+    window['Polymer'] = function(info) {
       // if input is a `class` (aka a function with a prototype), use the prototype
       // remember that the `constructor` will never be called
       var klass;

--- a/src/properties/property-accessors.html
+++ b/src/properties/property-accessors.html
@@ -55,12 +55,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Adding accessor to proto; save proto's value for instance-time use
           if (!model.__dataProto) {
             model.__dataProto = {};
-          } else if (!model.hasOwnProperty('__dataProto')) {
+          } else if (!model.hasOwnProperty(goog.reflect.objectProperty('__dataProto', model))) {
             model.__dataProto = Object.create(model.__dataProto);
           }
-          model.__dataProto[property] = value;          
+          model.__dataProto[property] = value;
         }
-      }      
+      }
     }
   }
 
@@ -209,7 +209,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-       * Callback called when any properties with accessors created via 
+       * Callback called when any properties with accessors created via
        * `_createPropertyAccessor` have been set.
        *
        * @param {Object} currentProps Bag of all current accessor values
@@ -242,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _shouldPropertyChange(property, value, old) {
         return (
           // Strict equality check for primitives
-          (old !== value && 
+          (old !== value &&
            // This ensures (old==NaN, value==NaN) always returns false
            (old === old || value === value))
         );

--- a/src/properties/property-accessors.html
+++ b/src/properties/property-accessors.html
@@ -234,7 +234,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Override this method to e.g. provide stricter checking for
        * Objects/Arrays when using immutable patterns.
        *
-       * @param {type} name Description
+       * @param {string} property
+       * @param {*} value
+       * @param {*} old
        * @return {boolean} Whether the property should be considered a change
        *   and enqueue a `_proeprtiesChanged` callback
        * @protected

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1985,7 +1985,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           propPath = info.path;
         } else if (Array.isArray(path)) {
           // Normalize path if needed
-          propPath = /** @type {string} */(Polymer.Path.normalize(path));
+          propPath = Polymer.Path.normalize(path);
         } else {
           propPath = /** @type{string} */(path);
         }

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1385,7 +1385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `path` can be a path string or array of path parts as accepted by the
        * public API.
        *
-       * @param {string | Array<number|string>} path Path to set
+       * @param {string | !Array<number|string>} path Path to set
        * @param {*} value Value to set
        * @param {boolean=} fromPath If the value being set was from a path; in
        *   this case the value was shared, so no dirty check is performed.
@@ -1413,14 +1413,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // already dirty checked at the point of entry and the underlying
           // object has already been updated
           let old = Polymer.Path.get(this, path);
-          path = Polymer.Path.set(this, path, value);
+          path = /** @type {string} */(Polymer.Path.set(this, path, value));
           // Use property-accessor's simpler dirty check
           if (!super._shouldPropertyChange(path, value, old)) {
             return undefined;
           }
         }
         if (hasEffect) {
-          return path;
+          return /** @type {string} */(path);
         } else {
           return undefined;
         }
@@ -1497,6 +1497,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * (`value === old`) or based on type.
        *
        * @override
+       * @param {string} property
+       * @param {*} value
+       * @param {*} old
+       * @return {boolean}
        */
       _shouldPropertyChange(property, value, old) {
         if (typeof value == 'object') {
@@ -1699,8 +1703,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * are routed to the other.
        *
        * @method linkPaths
-       * @param {string | Array<string|number>} to Target path to link.
-       * @param {string | Array<string|number>} from Source path to link.
+       * @param {string | !Array<string|number>} to Target path to link.
+       * @param {string | !Array<string|number>} from Source path to link.
        * @public
        */
       linkPaths(to, from) {
@@ -1717,7 +1721,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * linking the paths.
        *
        * @method unlinkPaths
-       * @param {string | Array<string|number>} path Target path to unlink.
+       * @param {string | !Array<string|number>} path Target path to unlink.
        * @public
        */
       unlinkPaths(path) {
@@ -1770,7 +1774,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * paths).
        *
        * @method get
-       * @param {(string|Array<(string|number)>)} path Path to the value
+       * @param {(string|!Array<(string|number)>)} path Path to the value
        *   to read.  The path may be specified as a string (e.g. `foo.bar.baz`)
        *   or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that
        *   bracketed expressions are not supported; string-based path parts
@@ -1795,7 +1799,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * dereferencing undefined paths).
        *
        * @method set
-       * @param {(string|Array<(string|number)>)} path Path to the value
+       * @param {(string|!Array<(string|number)>)} path Path to the value
        *   to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)
        *   or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that
        *   bracketed expressions are not supported; string-based path parts

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} inst The instance with effects to run
    * @param {string} type Type of effect to run
    * @param {Object} props Bag of current property changes
-   * @param {Object} oldProps Bag of previous values for changed properties
+   * @param {Object=} oldProps Bag of previous values for changed properties
    * @private
    */
   function runEffects(inst, type, props, oldProps) {
@@ -183,7 +183,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * `notify: true` to ensure object sub-property notifications were
    * sent.
    *
-   * @param {Object} inst The instance with effects to run
+   * @param {Element} inst The instance with effects to run
    * @param {Object} props Bag of current property changes
    * @param {Object} oldProps Bag of previous values for changed properties
    * @private
@@ -219,6 +219,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @param {Element} inst The element from which to fire the event
    * @param {string} path The path that was changed
+   * @param {*} value
    * @private
    */
   function notifyPath(inst, path, value) {
@@ -237,7 +238,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Element} inst The element from which to fire the event
    * @param {string} eventName The name of the event to send ('{property}-changed')
    * @param {*} value The value of the changed property
-   * @param {string=} path If a sub-path of this property changed, the path
+   * @param {string | null | undefined} path If a sub-path of this property changed, the path
    *   that changed (optional).
    * @private
    */
@@ -258,7 +259,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Dispatches a non-bubbling event named `info.eventName` on the instance
    * with a detail object containing the new `value`.
    *
-   * @param {Object} inst The instance the effect will be run on
+   * @param {Element} inst The instance the effect will be run on
    * @param {string} property Name of property
    * @param {*} value Current value of property
    * @param {*} old Previous value of property
@@ -379,10 +380,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * computed before other effects (binding propagation, observers, and notify)
    * run.
    *
-   * @param {Object} inst The instance the effect will be run on
+   * @param {Element} inst The instance the effect will be run on
    * @param {Object} changedProps Bag of changed properties
    * @param {Object} oldProps Bag of previous values for changed properties
-   * @return {Object} Bag of newly computed properties from "computed" effects
+   * @return {Object | null | undefined} Bag of newly computed properties from "computed" effects
    */
   function runComputedEffects(inst, changedProps, oldProps) {
     if (inst[TYPES.COMPUTE]) {
@@ -396,6 +397,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         inst.__dataPending = null;
       }
       return computedProps;
+    } else {
+      return undefined;
     }
   }
 
@@ -425,13 +428,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Computes path changes based on path links set up using the `linkPaths`
    * API.
    *
-   * @param {Object} inst The instance whose props are changing
+   * @param {Element} inst The instance whose props are changing
    * @param {Object} changedProps Bag of changed properties
-   * @param {Object} computedProps Bag of properties newly computed this turn
+   * @param {Object | undefined} computedProps Bag of properties newly computed this turn
    *   via "computed" effects; any linked paths generated via this method
    *   will be added both to the set of `changedProps` as well as to the
    *   set of `computedProps`; this is because the `fromAbove: true` case will
    *   notify only from the `computedProps` bag.
+   * @return {Object | undefined}
    * @private
    */
   function computeLinkedPaths(inst, changedProps, computedProps) {
@@ -504,8 +508,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Implements the "binding" (property/path binding) effect.
    *
-   * @param {Object} inst The instance the effect will be run on
-   * @param {string} property Name of property
+   * @param {Element} inst The instance the effect will be run on
+   * @param {string} path Name of property
    * @param {*} value Current value of property
    * @param {*} old Previous value of property
    * @param {Object} info Effect metadata
@@ -626,7 +630,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @param {Object} model Prototype or instance
    * @param {Object} note Binding note returned from Annotator
-   * @param {number} part The compound part metadata
+   * @param {Object} part The compound part metadata
    * @param {number} index Index into `__dataNodes` list of annotated nodes that the
    *   note applies to
    * @private
@@ -871,9 +875,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * optionally, for the method name if `dynamic` is true) that calls the
    * provided effect function.
    *
-   * @param {Object} inst Prototype or instance
+   * @param {Element | Object} model Prototype or instance
    * @param {Object} sig Method signature metadata
+   * @param {string} type
    * @param {Function} effectFn Function to run when arguments change
+   * @param {*=} methodInfo
    * @param {boolean=} dynamic Whether the method name should be included as
    *   a dependency to the effect.
    * @private
@@ -959,6 +965,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return sig;
       }
     }
+    return null;
   }
 
   /**
@@ -1141,7 +1148,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * Note: this implementation only accepts normalized paths
    *
-   * @param {Object} inst Instance to send notifications to
+   * @param {Element} inst Instance to send notifications to
    * @param {Array} array The array the mutations occurred on
    * @param {string} path The path to the array that was mutated
    * @param {Array} splices Array of splice records
@@ -1161,7 +1168,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * Note: this implementation only accepts normalized paths
    *
-   * @param {Object} inst Instance to send notifications to
+   * @param {Element} inst Instance to send notifications to
    * @param {Array} array The array the mutations occurred on
    * @param {string} path The path to the array that was mutated
    * @param {number} index Index at which the array mutation occurred
@@ -1194,7 +1201,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     const mixin = Polymer.TemplateStamp(
       Polymer.Attributes(Polymer.PropertyAccessors(superClass)));
-    return class PropertyEffects extends mixin {
+
+    /**
+     * @unrestricted
+     */
+    class PropertyEffects extends mixin {
 
       get PROPERTY_EFFECT_TYPES() {
         return TYPES;
@@ -1272,7 +1283,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {string} path Property (or path) that should trigger the effect
        * @param {string} type Effect type, from this.PROPERTY_EFFECT_TYPES
-       * @param {Object} effect Effect metadata object
+       * @param {Object=} effect Effect metadata object
        * @protected
        */
       _addPropertyEffect(path, type, effect) {
@@ -1300,7 +1311,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * of a certain type.
        *
        * @param {string} property Property name
-       * @param {string} type Effect type, from this.PROPERTY_EFFECT_TYPES
+       * @param {string=} type Effect type, from this.PROPERTY_EFFECT_TYPES
        * @return {boolean} True if the prototype/instance has an effect of this type
        * @protected
        */
@@ -1374,11 +1385,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `path` can be a path string or array of path parts as accepted by the
        * public API.
        *
-       * @param {string} path Path to set
+       * @param {string | Array<number|string>} path Path to set
        * @param {*} value Value to set
-       * @param {boolean} fromPath If the value being set was from a path; in
+       * @param {boolean=} fromPath If the value being set was from a path; in
        *   this case the value was shared, so no dirty check is performed.
-       * @return {?string} If the root of the path is a managed property,
+       * @return {string | undefined} If the root of the path is a managed property,
        *   returns a normalized string path suitable for setting into the system
        *   via `_setProperty`/`_setPendingProperty`. A null path is returned if
        *   a path was being set and fails a dirty check, unless `fromPath`
@@ -1405,11 +1416,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           path = Polymer.Path.set(this, path, value);
           // Use property-accessor's simpler dirty check
           if (!super._shouldPropertyChange(path, value, old)) {
-            return null;
+            return undefined;
           }
         }
         if (hasEffect) {
           return path;
+        } else {
+          return undefined;
         }
       }
 
@@ -1686,8 +1699,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * are routed to the other.
        *
        * @method linkPaths
-       * @param {string} to Target path to link.
-       * @param {string} from Source path to link.
+       * @param {string | Array<string|number>} to Target path to link.
+       * @param {string | Array<string|number>} from Source path to link.
        * @public
        */
       linkPaths(to, from) {
@@ -1708,7 +1721,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * linking the paths.
        *
        * @method unlinkPaths
-       * @param {string} path Target path to unlink.
+       * @param {string | Array<string|number>} path Target path to unlink.
        * @public
        */
       unlinkPaths(path) {
@@ -1749,7 +1762,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       */
       notifySplices(path, splices) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array} */(Polymer.Path.get(this, path, info));
         notifySplices(this, array, info.path, splices);
       }
 
@@ -1802,8 +1815,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (root) {
           Polymer.Path.set(root, path, value);
         } else {
-          if (!this._hasReadOnlyEffect(path)) {
-            if ((path = this._setPathOrUnmanagedProperty(path, value))) {
+          if (!this._hasReadOnlyEffect(/** @type {string} */(path))) {
+            /** @type {?string | undefined} */
+            let propPath;
+            if ((propPath = this._setPathOrUnmanagedProperty(path, value))) {
               this._setProperty(path, value);
             }
           }
@@ -1820,14 +1835,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * splice occurred to the array.
        *
        * @method push
-       * @param {String} path Path to array.
-       * @param {...any} var_args Items to push onto array
+       * @param {string} path Path to array.
+       * @param {...*} items Items to push onto array
        * @return {number} New length of the array.
        * @public
        */
       push(path, ...items) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array}*/(Polymer.Path.get(this, path, info));
         let len = array.length;
         let ret = array.push(...items);
         if (items.length) {
@@ -1846,13 +1861,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * splice occurred to the array.
        *
        * @method pop
-       * @param {String} path Path to array.
-       * @return {any} Item that was removed.
+       * @param {string} path Path to array.
+       * @return {*} Item that was removed.
        * @public
        */
       pop(path) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array} */(Polymer.Path.get(this, path, info));
         let hadLength = Boolean(array.length);
         let ret = array.pop();
         if (hadLength) {
@@ -1872,16 +1887,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * splice occurred to the array.
        *
        * @method splice
-       * @param {String} path Path to array.
+       * @param {string} path Path to array.
        * @param {number} start Index from which to start removing/inserting.
        * @param {number} deleteCount Number of items to remove.
-       * @param {...any} var_args Items to insert into array.
+       * @param {...*} items Items to insert into array.
        * @return {Array} Array of removed items.
        * @public
        */
       splice(path, start, deleteCount, ...items) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array} */(Polymer.Path.get(this, path, info));
         // Normalize fancy native splice handling of crazy start values
         if (start < 0) {
           start = array.length - Math.floor(-start);
@@ -1908,13 +1923,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * splice occurred to the array.
        *
        * @method shift
-       * @param {String} path Path to array.
-       * @return {any} Item that was removed.
+       * @param {string} path Path to array.
+       * @return {*} Item that was removed.
        * @public
        */
       shift(path) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array} */(Polymer.Path.get(this, path, info));
         let hadLength = Boolean(array.length);
         let ret = array.shift();
         if (hadLength) {
@@ -1933,14 +1948,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * splice occurred to the array.
        *
        * @method unshift
-       * @param {String} path Path to array.
-       * @param {...any} var_args Items to insert info array
+       * @param {string} path Path to array.
+       * @param {...*} items Items to insert info array
        * @return {number} New length of the array.
        * @public
        */
       unshift(path, ...items) {
         let info = {};
-        let array = Polymer.Path.get(this, path, info);
+        let array = /** @type {Array} */(Polymer.Path.get(this, path, info));
         let ret = array.unshift(...items);
         if (items.length) {
           notifySplice(this, array, info.path, 0, items.length, []);
@@ -1961,16 +1976,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @public
       */
       notifyPath(path, value) {
+        /** @type {string} */
+        let propPath;
         if (arguments.length == 1) {
           // Get value if not supplied
           let info = {};
           value = Polymer.Path.get(this, path, info);
-          path = info.path;
+          propPath = info.path;
         } else if (Array.isArray(path)) {
           // Normalize path if needed
-          path = Polymer.Path.normalize(path);
+          propPath = /** @type {string} */(Polymer.Path.normalize(path));
         }
-        this._setProperty(path, value);
+        this._setProperty(propPath, value);
       }
 
       /**
@@ -2122,6 +2139,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     }
 
+    return PropertyEffects;
   });
 
 })();

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1982,6 +1982,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else if (Array.isArray(path)) {
           // Normalize path if needed
           propPath = /** @type {string} */(Polymer.Path.normalize(path));
+        } else {
+          propPath = /** @type{string} */(path);
         }
         this._setProperty(propPath, value);
       }

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1817,9 +1817,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           if (!this._hasReadOnlyEffect(/** @type {string} */(path))) {
             /** @type {?string | undefined} */
-            let propPath;
-            if ((propPath = this._setPathOrUnmanagedProperty(path, value))) {
-              this._setProperty(path, value);
+            let propPath = this._setPathOrUnmanagedProperty(path, value);
+            if (propPath) {
+              this._setProperty(propPath, value);
             }
           }
         }

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -1496,6 +1496,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Override this to provide more strict dirty checking, i.e. immutable
        * (`value === old`) or based on type.
        *
+       * TODO(kschaaf): Can this go away (and just use @override) once we start using mixin interfaces?
        * @override
        * @param {string} property
        * @param {*} value

--- a/src/properties/property-effects.html
+++ b/src/properties/property-effects.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Ensures that the model has an own-property map of effects for the given type.
    * The model may be a prototype or an instance.
-   * 
+   *
    * Property effects are stored as arrays of effects by property in a map,
    * by named type on the model. e.g.
    *
@@ -58,7 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * If the model does not yet have an effect map for the type, one is created
    * and returned.  If it does, but it is not an own property (i.e. the
    * prototype had effects), the the map is deeply cloned and the copy is
-   * set on the model and returned, ready for new effects to be added. 
+   * set on the model and returned, ready for new effects to be added.
    *
    * @param {Object} model Prototype or instance
    * @param {string} type Property effect type
@@ -214,7 +214,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   /**
-   * Dispatches {property}-changed events with path information in the detail 
+   * Dispatches {property}-changed events with path information in the detail
    * object to indicate a sub-path of the property was changed.
    *
    * @param {Element} inst The element from which to fire the event
@@ -297,7 +297,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Event} e Notification event (e.g. '<property>-changed')
    * @param {Object} inst Host element instance handling the notification event
    * @param {string} property Child element property that was bound
-   * @param {string} path Host property/path that was bound 
+   * @param {string} path Host property/path that was bound
    * @param {boolean} negate Whether the binding was negated
    * @private
    */
@@ -430,7 +430,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} computedProps Bag of properties newly computed this turn
    *   via "computed" effects; any linked paths generated via this method
    *   will be added both to the set of `changedProps` as well as to the
-   *   set of `computedProps`; this is because the `fromAbove: true` case will 
+   *   set of `computedProps`; this is because the `fromAbove: true` case will
    *   notify only from the `computedProps` bag.
    * @private
    */
@@ -670,7 +670,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * - Memoizes the root property for path bindings
    * - Recurses into nested templates and processes those templates and
    *   extracts any host properties, which are set to the template's
-   *   `_content._hostProps` 
+   *   `_content._hostProps`
    * - Adds bindings from the host to <template> elements for any nested
    *   template's lexically bound "host properties"; template handling
    *   elements can then add accessors to the template for these properties
@@ -1052,7 +1052,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * The `path` and `value` arguments are used to fill in wildcard descriptor
    * when the method is being called as a result of a path notification.
-   * 
+   *
    * @param {Object} data Instance data storage object to read properties from
    * @param {Array<Object>} args Array of argument metadata
    * @return {Array<*>} Array of argument values
@@ -1096,7 +1096,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Initializes `__dataCompoundStorage` local storage on a bound node with
    * initial literal data for compound bindings, and sets the joined
    * literal parts to the bound property.
-   * 
+   *
    * When changes to compound parts occur, they are first set into the compound
    * storage array for that property, and then the array is joined to result in
    * the final value set to the property/attribute.
@@ -1137,7 +1137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // data api
 
   /**
-   * Sends array splice notifications (`.splices` and `.length`) 
+   * Sends array splice notifications (`.splices` and `.length`)
    *
    * Note: this implementation only accepts normalized paths
    *
@@ -1192,8 +1192,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.PropertyEffects = Polymer.Utils.dedupingMixin(function(superClass) {
 
-    return class PropertyEffects extends Polymer.TemplateStamp(
-      Polymer.Attributes(Polymer.PropertyAccessors(superClass))) {
+    const mixin = Polymer.TemplateStamp(
+      Polymer.Attributes(Polymer.PropertyAccessors(superClass)));
+    return class PropertyEffects extends mixin {
 
       get PROPERTY_EFFECT_TYPES() {
         return TYPES;
@@ -1369,7 +1370,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * If `path` is an unmanaged property (property without an accessor)
        * or a path, sets the value at that path.
-       * 
+       *
        * `path` can be a path string or array of path parts as accepted by the
        * public API.
        *
@@ -1406,7 +1407,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (!super._shouldPropertyChange(path, value, old)) {
             return null;
           }
-        } 
+        }
         if (hasEffect) {
           return path;
         }
@@ -1472,7 +1473,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Overrides default PropertyAccessors implementation to pull the value
-       * to dirty check against from the `__dataTemp` cache (rather than the 
+       * to dirty check against from the `__dataTemp` cache (rather than the
        * normal `__data` cache) for Objects.  Since the temp cache is cleared
        * at the end of a turn, this implementation allows side-effects of deep
        * object changes to be processed by re-setting the same object (using
@@ -1492,12 +1493,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-       * Overrides PropertyAccessor's default async queuing of 
+       * Overrides PropertyAccessor's default async queuing of
        * `_propertiesChanged`: if `__dataInitialized` is false (has not yet been
        * manually flushed), the function no-ops; otherwise flushes
        * `_propertiesChanged` synchronously.
        *
-       * Subclasses may set `this._asyncEffects = true` to cause 
+       * Subclasses may set `this._asyncEffects = true` to cause
        * `_propertiesChanged` to be flushed asynchronously.
        *
        * @override
@@ -1567,7 +1568,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._invalidateProperties();
       }
       /**
-       * Overrides PropertyAccessor's default async queuing of 
+       * Overrides PropertyAccessor's default async queuing of
        * `_propertiesChanged`, to instead synchronously flush
        * `_propertiesChanged` unless the `this._asyncEffects` property is true.
        *
@@ -1627,7 +1628,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * listeners, and the `this.$` map of `id`'s to nodes.  A document fragment
        * is returned containing the stamped DOM, ready for insertion into the
        * DOM.
-       * 
+       *
        * Note that for host data to be bound into the stamped DOM, the template
        * must have been previously bound to the prototype via a call to
        * `_bindTemplate`, which performs one-time template binding work.
@@ -1805,7 +1806,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             if ((path = this._setPathOrUnmanagedProperty(path, value))) {
               this._setProperty(path, value);
             }
-          }          
+          }
         }
       }
 
@@ -1976,7 +1977,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Creates a read-only accessor for the given property.
        *
        * To set the property, use the protected `_setProperty` API.
-       * To create a custom protected setter (e.g. `_setMyProp()` for 
+       * To create a custom protected setter (e.g. `_setMyProp()` for
        * property `myProp`), pass `true` for `protectedSetter`.
        *
        * Note, if the property will have other property effects, this method

--- a/src/styling/style-gather.html
+++ b/src/styling/style-gather.html
@@ -22,6 +22,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       return Polymer.DomModule.import(moduleId);
     },
+    /**
+     * @param {string} moduleIds
+     * @param {boolean=} warnIfNotFound
+     * @return {string}
+     */
     cssFromModules(moduleIds, warnIfNotFound) {
       var modules = moduleIds.trim().split(' ');
       var cssText = '';

--- a/src/template/annotations.html
+++ b/src/template/annotations.html
@@ -214,14 +214,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       list._hasInsertionPoint = true;
     }
     parseChildNodesAnnotations(element, note, list, stripWhiteSpace);
-    // TODO(sjmiles): is this for non-ELEMENT nodes? If so, we should
-    // change the contract of this method, or filter these out above.
     if (element.attributes) {
       parseNodeAttributeAnnotations(element, note);
-      // TODO(sorvell): ad hoc callback for doing work on elements while
-      // leveraging annotator's tree walk.
-      // Consider adding an node callback registry and moving specific
-      // processing out of this module.
       prepElement(element);
     }
     if (note.bindings.length || note.events.length || note.id) {

--- a/src/template/annotations.html
+++ b/src/template/annotations.html
@@ -217,7 +217,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // TODO(sjmiles): is this for non-ELEMENT nodes? If so, we should
     // change the contract of this method, or filter these out above.
     if (element.attributes) {
-      parseNodeAttributeAnnotations(element, note, list);
+      parseNodeAttributeAnnotations(element, note);
       // TODO(sorvell): ad hoc callback for doing work on elements while
       // leveraging annotator's tree walk.
       // Consider adding an node callback registry and moving specific

--- a/src/template/template-stamp.html
+++ b/src/template/template-stamp.html
@@ -143,7 +143,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.TemplateStamp = Polymer.Utils.dedupingMixin(function(superClass) {
 
-    return class TemplateStamp extends Polymer.Annotations(Polymer.EventListeners(superClass)) {
+    const mixin = Polymer.Annotations(Polymer.EventListeners(superClass));
+    return class TemplateStamp extends mixin {
 
       constructor() {
         super();

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -326,8 +326,7 @@ is false, `selected` is a property representing the last selected item.  When
   Polymer.ArraySelectorMixin = ArraySelectorMixin;
 
   // define element class & export
-  const ArraySelectorMixinImpl = ArraySelectorMixin(Polymer.Element);
-  class ArraySelector extends ArraySelectorMixinImpl { }
+  const ArraySelector = ArraySelectorMixin(Polymer.Element);
   customElements.define('array-selector', ArraySelector);
   Polymer.ArraySelector = ArraySelector;
 

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -74,7 +74,7 @@ is false, `selected` is a property representing the last selected item.  When
     return class extends superClass {
 
       static get config() {
-      
+
         return {
 
           properties: {
@@ -206,7 +206,7 @@ is false, `selected` is a property representing the last selected item.  When
             if (idx >= 0) {
               this.linkPaths('items.' + idx, 'selected.' + sidx++);
             }
-          });      
+          });
         } else {
           this._selectedMap.forEach(idx => {
             this.linkPaths('selected', 'items.' + idx);
@@ -265,13 +265,13 @@ is false, `selected` is a property representing the last selected item.  When
        * Deselects the given index if it is already selected.
        *
        * @method deselect
-       * @param {number} index Index from `items` array to deselect
+       * @param {number} idx Index from `items` array to deselect
        */
       deselectIndex(idx) {
         if (this._selectedMap.delete(this.items[idx])) {
           let sidx;
           if (this.multi) {
-            sidx = parseInt(this.__dataLinkedPaths['items.' + idx].slice('selected.'.length));
+            sidx = parseInt(this.__dataLinkedPaths['items.' + idx].slice('selected.'.length), 10);
           }
           this._updateLinks();
           if (this.multi) {
@@ -298,7 +298,7 @@ is false, `selected` is a property representing the last selected item.  When
        * deselect the item if already selected.
        *
        * @method select
-       * @param {number} index Index from `items` array to select
+       * @param {number} idx Index from `items` array to select
        */
       selectIndex(idx) {
         let item = this.items[idx];
@@ -326,7 +326,8 @@ is false, `selected` is a property representing the last selected item.  When
   Polymer.ArraySelectorMixin = ArraySelectorMixin;
 
   // define element class & export
-  class ArraySelector extends ArraySelectorMixin(Polymer.Element) { }
+  const ArraySelectorMixinImpl = ArraySelectorMixin(Polymer.Element);
+  class ArraySelector extends ArraySelectorMixinImpl { }
   customElements.define('array-selector', ArraySelector);
   Polymer.ArraySelector = ArraySelector;
 

--- a/src/templatizer/dom-bind.html
+++ b/src/templatizer/dom-bind.html
@@ -18,7 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   (function() {
 
-    class DomBind extends Polymer.PropertyEffects(HTMLElement) {
+    const mixin = Polymer.PropertyEffects(HTMLElement);
+
+    class DomBind extends mixin {
 
       connectedCallback() {
         this.render();

--- a/src/templatizer/dom-if.html
+++ b/src/templatizer/dom-if.html
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     static get template() { return null; }
 
-    static get config() { 
+    static get config() {
 
       return {
 
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _debounceRender() {
       this._renderDebouncer =
-        Polymer.Debouncer.debounce(this._renderDebouncer, this._render, null, this);
+        Polymer.Debouncer.debounce(this._renderDebouncer, this._render, undefined, this);
       Polymer.Templatizer.enqueueDebouncer(this._renderDebouncer);
     }
 

--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -112,7 +112,7 @@ Then the `observe` property should be configured as follows:
 
     static get template() { return null; }
 
-    static get config() { 
+    static get config() {
 
       return {
 
@@ -423,6 +423,10 @@ Then the `observe` property should be configured as follows:
       }
     }
 
+    /**
+     * @param {Function} fn
+     * @param {?number=} delay
+     */
     _debounceRender(fn, delay) {
       this._renderDebouncer =
         Polymer.Debouncer.debounce(this._renderDebouncer, fn, delay, this);
@@ -571,7 +575,7 @@ Then the `observe` property should be configured as follows:
       var dot = itemsPath.indexOf('.');
       var itemsIdx = dot < 0 ? itemsPath : itemsPath.substring(0, dot);
       // If path was index into array...
-      if (itemsIdx == parseInt(itemsIdx)) {
+      if (itemsIdx == parseInt(itemsIdx, 10)) {
         var itemPath = dot < 0 ? '' : itemsPath.substring(dot+1);
         // See if the item subpath should trigger a full refresh...
         if (!this._handleObservedPaths(itemPath)) {
@@ -582,7 +586,7 @@ Then the `observe` property should be configured as follows:
             inst.forwardProperty(this.as + (itemPath ? '.' + itemPath : ''), value);
             inst.flushProperties();
           }
-        }        
+        }
         return true;
       }
     }
@@ -597,7 +601,7 @@ Then the `observe` property should be configured as follows:
      *
      * @method itemForElement
      * @param {HTMLElement} el Element for which to return the item.
-     * @return {any} Item associated with the element.
+     * @return {*} Item associated with the element.
      */
     itemForElement(el) {
       var instance = this.modelForElement(el);
@@ -611,7 +615,7 @@ Then the `observe` property should be configured as follows:
      *
      * @method indexForElement
      * @param {HTMLElement} el Element for which to return the index.
-     * @return {any} Row index associated with the element (note this may
+     * @return {*} Row index associated with the element (note this may
      *   not correspond to the array index if a user `sort` is applied).
      */
     indexForElement(el) {
@@ -634,7 +638,7 @@ Then the `observe` property should be configured as follows:
      *
      * @method modelForElement
      * @param {HTMLElement} el Element for which to return a template model.
-     * @return {Object<Polymer.Base>} Model representing the binding scope for
+     * @return {Object} Model representing the binding scope for
      *   the element.
      */
     modelForElement(el) {

--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -424,7 +424,7 @@ Then the `observe` property should be configured as follows:
     }
 
     /**
-     * @param {Function} fn
+     * @param {function()} fn
      * @param {?number=} delay
      */
     _debounceRender(fn, delay) {

--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -425,7 +425,7 @@ Then the `observe` property should be configured as follows:
 
     /**
      * @param {function()} fn
-     * @param {?number=} delay
+     * @param {number=} delay
      */
     _debounceRender(fn, delay) {
       this._renderDebouncer =
@@ -634,6 +634,7 @@ Then the `observe` property should be configured as follows:
      *
      * @method modelForElement
      * @param {HTMLElement} el Element for which to return a template model.
+     * TODO(kschaaf): replace return type with interface for TemplateInstanceBaseInterface
      * @return {Object} Model representing the binding scope for
      *   the element.
      */

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -25,12 +25,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     PatchedHTMLTemplateElement.prototype = Object.create(HTMLTemplateElement.prototype, {
       constructor: {
-        value: PatchedHTMLTemplateElement
+        value: PatchedHTMLTemplateElement,
+        writable: true
       }
     });
     PatchedHTMLTemplateElement._newInstance = null;
 
-    class DataTemplate extends Polymer.PropertyEffects(PatchedHTMLTemplateElement) {
+    const mixin = Polymer.PropertyEffects(PatchedHTMLTemplateElement);
+    class DataTemplate extends mixin {
       static upgradeTemplate(template) {
         PatchedHTMLTemplateElement._newInstance = template;
         Object.setPrototypeOf(template, DataTemplate.prototype);

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -84,6 +84,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _createTemplatizerClass(template, options) {
         // Anonymous class created by the templatizer
+        /**
+         * @unrestricted
+         */
         var klass = class extends TemplateInstanceBase {
           //TODO(kschaaf): for debugging; remove?
           get localName() { return 'template#' + this.__template.id + '/TemplateInstance' }
@@ -267,7 +270,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method modelForElement
        * @param {HTMLElement} el Element for which to return a template model.
-       * @return {Object<Polymer.Base>} Model representing the binding scope for
+       * @return {Object} Model representing the binding scope for
        *   the element.
        */
       modelForElement(host, el) {
@@ -290,6 +293,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el = el.parentNode;
           }
         }
+        return null;
       }
     }
 

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -270,6 +270,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @method modelForElement
        * @param {HTMLElement} el Element for which to return a template model.
+       * TODO(kschaaf): replace return type with interface for TemplateInstanceBaseInterface
        * @return {Object} Model representing the binding scope for
        *   the element.
        */

--- a/src/utils/boot.html
+++ b/src/utils/boot.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   window.Polymer = window.Polymer || {};
   window.Polymer.version = '2.0-preview';
 
+  /* eslint-disable no-unused-vars */
   var goog = {
     reflect: {
       objectProperty(s, o) {
@@ -19,5 +20,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
   }
-
+  /* eslint-enable */
 </script>

--- a/src/utils/boot.html
+++ b/src/utils/boot.html
@@ -12,4 +12,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   window.Polymer = window.Polymer || {};
   window.Polymer.version = '2.0-preview';
 
+  var goog = {
+    reflect: {
+      objectProperty(s, o) {
+        return s;
+      }
+    }
+  }
+
 </script>

--- a/src/utils/boot.html
+++ b/src/utils/boot.html
@@ -13,6 +13,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   window.Polymer.version = '2.0-preview';
 
   /* eslint-disable no-unused-vars */
+  /*
+  When using Closure Compiler, goog.reflect.objectProperty(property, object) is replaced by the munged name for object[property]
+  We cannot alias this function, so we have to use a small shim that has the same behavior when not compiling.
+  */
   var goog = {
     reflect: {
       objectProperty(s, o) {

--- a/src/utils/case-map.html
+++ b/src/utils/case-map.html
@@ -9,8 +9,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <link rel="import" href="boot.html">
 <script>
+(function() {
 
-  Polymer.CaseMap = {
+  const CaseMap = {
 
     _caseMap: {},
     _rx: {
@@ -36,4 +37,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   };
 
+  Polymer.CaseMap = CaseMap;
+})();
 </script>

--- a/src/utils/debounce.html
+++ b/src/utils/debounce.html
@@ -12,55 +12,69 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="async.html">
 
 <script>
+class Debouncer {
 
-Polymer.Debouncer = function Debouncer(context) {
-  this.context = context;
-  var self = this;
-  this.boundFlush = function() {
-    self.flush();
-  };
-};
+  constructor(context) {
+    this.context = context;
+    /** @type {Function} */
+    this.finish;
+    /** @type {Function} */
+    this.callback;
+    this.boundFlush = () => {this.flush()};
+  }
 
-Polymer.Utils.mixin(Polymer.Debouncer.prototype, {
-
-  go: function(callback, wait) {
-    var h;
+  /**
+   * @param {Function} callback
+   * @param {?number=} wait
+   */
+  go(callback, wait) {
+    let cancelToken;
     this.finish = function() {
-      Polymer.Async.cancel(h);
+      Polymer.Async.cancel(cancelToken);
     };
-    h = Polymer.Async.run(this.boundFlush, wait);
+    cancelToken = Polymer.Async.run(this.boundFlush, wait);
     this.callback = callback;
-  },
+  }
 
-  cancel: function() {
+  cancel() {
     if (this.finish) {
       this.finish();
       this.finish = null;
     }
-  },
+  }
 
-  flush: function() {
+  flush() {
     if (this.finish) {
       this.cancel();
       this.callback.call(this.context);
     }
-  },
+  }
 
-  isActive: function() {
+  /**
+   * @return {boolean}
+   */
+  isActive() {
     return Boolean(this.finish);
   }
 
-});
-
-Polymer.Debouncer.debounce = function(debouncer, callback, wait, context) {
-  context = context || this;
-  if (debouncer) {
-    debouncer.cancel();
-  } else {
-    debouncer = new Polymer.Debouncer(context);
+    /**
+   * @param {Debouncer} debouncer
+   * @param {Function} callback
+   * @param {?number=} wait
+   * @param {Object=} context
+   * @return {Debouncer}
+   */
+  static debounce(debouncer, callback, wait, context) {
+    context = context || this;
+    if (debouncer) {
+      debouncer.cancel();
+    } else {
+      debouncer = new Debouncer(context);
+    }
+    debouncer.go(callback, wait);
+    return debouncer;
   }
-  debouncer.go(callback, wait);
-  return debouncer;
-};
+}
 
+Polymer.Debouncer = Debouncer;
 </script>

--- a/src/utils/debounce.html
+++ b/src/utils/debounce.html
@@ -63,7 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * @param {Debouncer} debouncer
      * @param {function()} callback
-     * @param {?number=} wait
+     * @param {number=} wait
      * @param {Object=} context
      * @return {Debouncer}
      */

--- a/src/utils/debounce.html
+++ b/src/utils/debounce.html
@@ -12,69 +12,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="async.html">
 
 <script>
-class Debouncer {
+(function() {
+  'use strict';
 
-  constructor(context) {
-    this.context = context;
-    /** @type {Function} */
-    this.finish;
-    /** @type {Function} */
-    this.callback;
-    this.boundFlush = () => {this.flush()};
-  }
+  class Debouncer {
 
-  /**
-   * @param {Function} callback
-   * @param {?number=} wait
-   */
-  go(callback, wait) {
-    let cancelToken;
-    this.finish = function() {
-      Polymer.Async.cancel(cancelToken);
-    };
-    cancelToken = Polymer.Async.run(this.boundFlush, wait);
-    this.callback = callback;
-  }
-
-  cancel() {
-    if (this.finish) {
-      this.finish();
-      this.finish = null;
+    constructor(context) {
+      this.context = context;
+      /** @type {Function} */
+      this.finish;
+      /** @type {Function} */
+      this.callback;
+      this.boundFlush = () => {this.flush()};
     }
-  }
-
-  flush() {
-    if (this.finish) {
-      this.cancel();
-      this.callback.call(this.context);
-    }
-  }
-
-  /**
-   * @return {boolean}
-   */
-  isActive() {
-    return Boolean(this.finish);
-  }
 
     /**
-   * @param {Debouncer} debouncer
-   * @param {Function} callback
-   * @param {?number=} wait
-   * @param {Object=} context
-   * @return {Debouncer}
-   */
-  static debounce(debouncer, callback, wait, context) {
-    context = context || this;
-    if (debouncer) {
-      debouncer.cancel();
-    } else {
-      debouncer = new Debouncer(context);
+     * @param {function()} callback
+     * @param {?number=} wait
+     */
+    go(callback, wait) {
+      let cancelToken;
+      this.finish = function() {
+        Polymer.Async.cancel(cancelToken);
+      };
+      cancelToken = Polymer.Async.run(this.boundFlush, wait);
+      this.callback = callback;
     }
-    debouncer.go(callback, wait);
-    return debouncer;
-  }
-}
 
-Polymer.Debouncer = Debouncer;
+    cancel() {
+      if (this.finish) {
+        this.finish();
+        this.finish = null;
+      }
+    }
+
+    flush() {
+      if (this.finish) {
+        this.cancel();
+        this.callback.call(this.context);
+      }
+    }
+
+    /**
+     * @return {boolean}
+     */
+    isActive() {
+      return Boolean(this.finish);
+    }
+
+    /**
+     * @param {Debouncer} debouncer
+     * @param {function()} callback
+     * @param {?number=} wait
+     * @param {Object=} context
+     * @return {Debouncer}
+     */
+    static debounce(debouncer, callback, wait, context) {
+      context = context || this;
+      if (debouncer) {
+        debouncer.cancel();
+      } else {
+        debouncer = new Debouncer(context);
+      }
+      debouncer.go(callback, wait);
+      return debouncer;
+    }
+  }
+
+  Polymer.Debouncer = Debouncer;
+})();
 </script>

--- a/src/utils/path.html
+++ b/src/utils/path.html
@@ -11,8 +11,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="boot.html">
 
 <script>
+(function() {
 
-  Polymer.Path = {
+  const Path = {
 
     isPath: function(path) {
       return path.indexOf('.') >= 0;
@@ -54,7 +55,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
              this.isDescendant(base, path);
     },
 
-    // Converts array-based paths to flattened path, optionally split into array
+    /**
+     * Converts array-based paths to flattened path, optionally split into array
+     * @param {string | Array<string>} path
+     * @param {boolean=} split
+     * @return {string | Array<string>}
+     */
     normalize: function(path, split) {
       if (Array.isArray(path)) {
         var parts = [];
@@ -70,6 +76,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    /**
+     * @param {Object} root
+     * @param {string | Array<string|number>} path
+     * @param {Object=} info
+     * @return {*}
+     */
     get: function(root, path, info) {
       var prop = root;
       var parts = this.normalize(path, true);
@@ -111,4 +123,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   };
 
+  Polymer.Path = Path;
+})();
 </script>

--- a/src/utils/path.html
+++ b/src/utils/path.html
@@ -56,12 +56,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Converts array-based paths to flattened path, optionally split into array
-     * @param {string | Array<string>} path
-     * @param {boolean=} split
-     * @return {string | Array<string>}
+     * Converts array-based paths to flattened path
+     * @param {string | !Array<string|number>} path
+     * @return {string}
      */
-    normalize: function(path, split) {
+    normalize: function(path) {
       if (Array.isArray(path)) {
         var parts = [];
         for (var i=0; i<path.length; i++) {
@@ -70,21 +69,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             parts.push(args[j]);
           }
         }
-        return split ? parts : parts.join('.');
+        return parts.join('.');
       } else {
-        return split ? path.toString().split('.') : path;
+        return path;
       }
     },
 
     /**
+     * Split a path into an array
+     * @param {string | !Array<string|number>} path
+     * @return {!Array<string>}
+     */
+    split: function(path) {
+      if (Array.isArray(path)) {
+        return this.normalize(path).split('.');
+      }
+      return path.toString().split('.');
+    },
+
+    /**
      * @param {Object} root
-     * @param {string | Array<string|number>} path
+     * @param {string | !Array<string|number>} path
      * @param {Object=} info
      * @return {*}
      */
     get: function(root, path, info) {
       var prop = root;
-      var parts = this.normalize(path, true);
+      var parts = this.split(path);
       // Loop over path parts[0..n-1] and dereference
       for (var i=0; i<parts.length; i++) {
         if (!prop) {
@@ -99,9 +110,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return prop;
     },
 
+    /**
+     * @param {Object} root
+     * @param {string | !Array<string|number>} path
+     * @param {*} value
+     * @return {string | undefined}
+     */
     set: function(root, path, value) {
       var prop = root;
-      var parts = this.normalize(path, true);
+      var parts = this.split(path);
       var last = parts[parts.length-1];
       if (parts.length > 1) {
         // Loop over path parts[0..n-2] and dereference

--- a/src/utils/polymer.dom.html
+++ b/src/utils/polymer.dom.html
@@ -37,9 +37,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     constructor(target, callback) {
       /** @type {MutationObserver} */
-      this.shadyChildrenObserver;
+      this.shadyChildrenObserver = null;
       /** @type {MutationObserver} */
-      this.nativeChildrenObserver;
+      this.nativeChildrenObserver = null;
       this.connected = false;
       this.target = target;
       this.callback = callback;

--- a/src/utils/polymer.dom.html
+++ b/src/utils/polymer.dom.html
@@ -36,6 +36,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   class EffectiveNodesObserver {
 
     constructor(target, callback) {
+      /** @type {MutationObserver} */
+      this.shadyChildrenObserver;
+      /** @type {MutationObserver} */
+      this.nativeChildrenObserver;
+      this.connected = false;
       this.target = target;
       this.callback = callback;
       this.effectiveNodes = [];

--- a/src/utils/unresolved.html
+++ b/src/utils/unresolved.html
@@ -17,12 +17,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   if (window.WebComponents) {
-    addEventListener('WebComponentsReady', resolve);
+    window.addEventListener('WebComponentsReady', resolve);
   } else {
     if (document.readyState === 'interactive' || document.readyState === 'complete') {
       resolve();
     } else {
-      addEventListener('DOMContentLoaded', resolve);
+      window.addEventListener('DOMContentLoaded', resolve);
     }
   }
 

--- a/src/utils/utils.html
+++ b/src/utils/utils.html
@@ -100,6 +100,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    /**
+     * @template T
+     * @param {T} mixin
+     * @return {T}
+     */
     dedupingMixin(mixin) {
       mixin = this.cachingMixin(mixin);
       return function(base) {
@@ -125,16 +130,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @method importHref
      * @param {string} href URL to document to load.
-     * @param {Function} onload Callback to notify when an import successfully
+     * @param {Function=} onload Callback to notify when an import successfully
      *   loaded.
-     * @param {Function} onerror Callback to notify when an import
+     * @param {Function=} onerror Callback to notify when an import
      *   unsuccessfully loaded.
-     * @param {boolean} optAsync True if the import should be loaded `async`.
+     * @param {boolean=} optAsync True if the import should be loaded `async`.
      *   Defaults to `false`.
      * @return {HTMLLinkElement} The link element for the URL to be loaded.
      */
     importHref(href, onload, onerror, optAsync) {
-      var l = document.createElement('link');
+      var l = /** @type {HTMLLinkElement} */(document.createElement('link'));
       l.rel = 'import';
       l.href = href;
 


### PR DESCRIPTION
With this PR, Polymer is now compatible with Closure Compiler's ADVANCED optimization setting.
However, Closure Compiler is not yet compatible with Polymer's use of ES6 class mixins, and currently warn.
Once that is implemented in Closure Compiler, we will likely see more warnings.