### PR TITLE
Deselect item when array member changes. Fixes #4263

### DIFF
--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -139,7 +139,8 @@ is false, `selected` is a property representing the last selected item.  When
       }
 
       _updateSelection(multi, itemsInfo) {
-        if (itemsInfo.path == 'items') {
+        let path = itemsInfo.path;
+        if (path == 'items') {
           let newItems = itemsInfo.base || [];
           let lastItems = this.__lastItems;
           let lastMulti = this.__lastMulti;
@@ -154,6 +155,12 @@ is false, `selected` is a property representing the last selected item.  When
           this.__lastMulti = multi;
         } else if (itemsInfo.path == 'items.splices') {
           this._applySplices(itemsInfo.value.indexSplices);
+        } else {
+          let part = path.slice('items.'.length);
+          let idx = parseInt(part, 10);
+          if ((part.indexOf('.') < 0) && part == idx) {
+            this._deselectChangedIdx(idx);
+          }
         }
       }
 
@@ -251,6 +258,26 @@ is false, `selected` is a property representing the last selected item.  When
         return this.isSelected(this.items[idx]);
       }
 
+      _deselectChangedIdx(idx) {
+        let sidx = this._selectedIndexForItemIndex(idx);
+        if (sidx >= 0) {
+          let i = 0;
+          this._selectedMap.forEach((idx, item) => {
+            if (sidx == i++) {
+              this.deselect(item);
+              return;
+            }
+          });
+        }
+      }
+
+      _selectedIndexForItemIndex(idx) {
+        let selected = this.__dataLinkedPaths['items.' + idx];
+        if (selected) {
+          return parseInt(selected.slice('selected.'.length), 10);          
+        }
+      }
+
       /**
        * Deselects the given item if it is already selected.
        *
@@ -258,7 +285,20 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {*} item Item from `items` array to deselect
        */
       deselect(item) {
-        this.deselectIndex(this._selectedMap.get(item));
+        let idx = this._selectedMap.get(item);
+        if (idx >= 0) {
+          this._selectedMap.delete(item);
+          let sidx;
+          if (this.multi) {
+            sidx = this._selectedIndexForItemIndex(idx);
+          }
+          this._updateLinks();
+          if (this.multi) {
+            this.splice('selected', sidx, 1);
+          } else {
+            this.selected = this.selectedItem = null;
+          }
+        }
       }
 
       /**
@@ -268,18 +308,7 @@ is false, `selected` is a property representing the last selected item.  When
        * @param {number} idx Index from `items` array to deselect
        */
       deselectIndex(idx) {
-        if (this._selectedMap.delete(this.items[idx])) {
-          let sidx;
-          if (this.multi) {
-            sidx = parseInt(this.__dataLinkedPaths['items.' + idx].slice('selected.'.length), 10);
-          }
-          this._updateLinks();
-          if (this.multi) {
-            this.splice('selected', sidx, 1);
-          } else {
-            this.selected = this.selectedItem = null;
-          }
-        }
+        this.deselect(this.items[idx]);
       }
 
       /**

--- a/src/templatizer/array-selector.html
+++ b/src/templatizer/array-selector.html
@@ -141,6 +141,8 @@ is false, `selected` is a property representing the last selected item.  When
       _updateSelection(multi, itemsInfo) {
         let path = itemsInfo.path;
         if (path == 'items') {
+          // Case 1 - items array changed, so diff against previous array and
+          // deselect any removed items and adjust selected indices
           let newItems = itemsInfo.base || [];
           let lastItems = this.__lastItems;
           let lastMulti = this.__lastMulti;
@@ -154,8 +156,12 @@ is false, `selected` is a property representing the last selected item.  When
           this.__lastItems = newItems;
           this.__lastMulti = multi;
         } else if (itemsInfo.path == 'items.splices') {
+          // Case 2 - got specific splice information describing the array mutation:
+          // deselect any removed items and adjust selected indices
           this._applySplices(itemsInfo.value.indexSplices);
         } else {
+          // Case 3 - an array element was changed, so deselect the previous
+          // item for that index if it was previously selected
           let part = path.slice('items.'.length);
           let idx = parseInt(part, 10);
           if ((part.indexOf('.') < 0) && part == idx) {
@@ -230,6 +236,10 @@ is false, `selected` is a property representing the last selected item.  When
       clearSelection() {
         // Unbind previous selection
         this.__dataLinkedPaths = {};
+        // The selected map stores 3 pieces of information:
+        // key: items array object
+        // value: items array index
+        // order: selected array index
         this._selectedMap = new Map();
         // Initialize selection
         this.selected = this.multi ? [] : null
@@ -265,7 +275,6 @@ is false, `selected` is a property representing the last selected item.  When
           this._selectedMap.forEach((idx, item) => {
             if (sidx == i++) {
               this.deselect(item);
-              return;
             }
           });
         }

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -465,6 +465,21 @@ suite('multi selection', function() {
     assert.sameMembers(bind.$.multiBound.selected, []);
   });
 
+  test('reset item in array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.select(bind.items[2]);
+    bind.$.multiBound.select(bind.items[0]);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2], bind.items[0]]);
+    // set items to new objects; all should be removed (selection based on identity)
+    bind.set('items.0', {name: 'new'});
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[2]]);
+  });
+
 });
 
 suite('corner cases', function() {


### PR DESCRIPTION
### Reference Issue
Fixes #3226 

### Description
Normalizes behavior between resetting array and using path API: removing a previously selected item causes it to be deselected.