### PR TITLE
Flush wrapper before template & default dom-if to sync (async optional).

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ Polymer 2.0 will continue to use a [shim](https://github.com/webcomponents/shady
 * <a name="breaking-inline-dynamic"></a>Setting/changing any function used in inline template annotations will cause the binding to re-compute its value using the new function and current property values
 ‘notify’ events not fired when value changes as result of binding from host
 * <a name="breaking-properties-deserialization"></a>In order for a property to be deserialized from its attribute, it must be declared in the `properties` metadata object
-* <a name="breaking-colleciton"></a>The `Polymer.Collection` and associated key-based path and splice notification for arrays has been eliminated.  See [explanation here](https://github.com/Polymer/polymer/pull/3970#issue-178203286) for more details.
+* <a name="breaking-collection"></a>The `Polymer.Collection` and associated key-based path and splice notification for arrays has been eliminated.  See [explanation here](https://github.com/Polymer/polymer/pull/3970#issue-178203286) for more details.
+* <a name="breaking-domif-sync"></a>The `dom-if` element now stamps its template synchronous to the `if` value changing. To achieve async behavior for (rare) cases where the `if` value may change multiple times in a turn, set the `async` attribute on the `dom-if` element.
 
 ### Removed API
 * <a name="breaking-instanceof"></a>`Polymer.instanceof` and `Polymer.isInstance`: no longer needed, use

--- a/src/templatizer/dom-if.html
+++ b/src/templatizer/dom-if.html
@@ -65,7 +65,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
            */
           restamp: {
             type: Boolean,
-            observer: '_debounceRender'
+          },
+
+          /**
+           * By default, `dom-if` will stamp (or hide/remove) nodes synchronous to
+           * its `if` value changing.  To cause it to stamp asynchronously at
+           * microtask timing, set `async` to true.  This should generally only
+           * be used if the `if` value may change multiple times in a turn,
+           * to debounce unnecessary work.
+           */
+          async: {
+            type: Boolean
           }
 
         }
@@ -80,9 +90,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     _debounceRender() {
-      this._renderDebouncer =
-        Polymer.Debouncer.debounce(this._renderDebouncer, this._render, undefined, this);
-      Polymer.Templatizer.enqueueDebouncer(this._renderDebouncer);
+      if (this.async) {
+        this._renderDebouncer =
+          Polymer.Debouncer.debounce(this._renderDebouncer, this._render, undefined, this);
+        Polymer.Templatizer.enqueueDebouncer(this._renderDebouncer);
+      } else {
+        this._render();
+      }
     }
 
     disconnectedCallback() {
@@ -102,11 +116,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     /**
-     * Forces the element to render its content. Normally rendering is
-     * asynchronous to a provoking change. This is done for efficiency so
-     * that multiple changes trigger only a single render. The render method
-     * should be called if, for example, template rendering is required to
-     * validate application state.
+     * Forces the element to render its content (and any nested templates) when
+     * the `async` flag is in use.
      */
     render() {
       Polymer.Templatizer.flush();
@@ -150,10 +161,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             observer.observe(this, {childList: true});
             return false;
           }
-          template.__domIf = this;
+          template.__wrapper = this;
           this._ctor = templatizer.templatize(template, {
             fwdHostPropToInstance: function(host, prop, value) {
-              let domif = template.__domIf;
+              let domif = template.__wrapper;
               if (domif._instance) {
                 domif._instance.forwardProperty(prop, value, host);
               }

--- a/src/templatizer/dom-repeat.html
+++ b/src/templatizer/dom-repeat.html
@@ -308,7 +308,7 @@ Then the `observe` property should be configured as follows:
           observer.observe(this, {childList: true});
           return false;
         }
-        template.__domRepeat = this;
+        template.__wrapper = this;
         // Template instance props that should be excluded from forwarding
         var instanceProps = {};
         instanceProps[this.as] = true;
@@ -317,14 +317,14 @@ Then the `observe` property should be configured as follows:
         this._ctor = templatizer.templatize(template, {
           instanceProps: instanceProps,
           fwdHostPropToInstance: function(template, prop, value) {
-            let repeater = template.__domRepeat;
+            let repeater = template.__wrapper;
             var i$ = repeater._instances;
             for (var i=0, inst; (i<i$.length) && (inst=i$[i]); i++) {
               inst.forwardProperty(prop, value, template);
             }
           },
           fwdInstancePropToHost: function(inst, prop, value) {
-            let repeater = inst.__template.__domRepeat;
+            let repeater = inst.__template.__wrapper;
             if (Polymer.Path.matches(repeater.as, prop)) {
               let idx = inst[repeater.itemsIndexAs];
               if (prop == repeater.as) {

--- a/src/templatizer/templatizer.html
+++ b/src/templatizer/templatizer.html
@@ -39,6 +39,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         new DataTemplate();
         PatchedHTMLTemplateElement._newInstance = null;
       }
+      _flushProperties() {
+        // If a wrapper was set, flush it first to ensure wrapper state is
+        // up-to-date before propagating _host_ properties, since changes to
+        // wrapper may effect forwarding logic
+        if (this.__wrapper && this.__wrapper.__dataPending) {
+          this.__wrapper._flushProperties();
+        }
+        super._flushProperties();
+      }
     }
 
     class Templatizer {

--- a/test/unit/dom-if-elements.html
+++ b/test/unit/dom-if-elements.html
@@ -195,11 +195,110 @@
   });
   Polymer({
     is: 'x-client',
-    statics: {
-      uid: 0
-    },
     ready: function() {
-      this.uid = this.statics.uid++;
+      this.uid = window.uid++;
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-guard-prop">
+  <template>
+    <template is="dom-if" if="{{bool}}" restamp>{{guarded(bool)}}</template>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-guard-prop',
+    created: function() {
+      this.guarded = sinon.spy(function(val) {
+        return val;
+      });
+    },
+    isTrue: function(val) {
+      return val;
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-guard-inline">
+  <template>
+    <template is="dom-if" if="{{isTrue(bool)}}" restamp>{{guarded(bool)}}</template>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-guard-inline',
+    created: function() {
+      this.guarded = sinon.spy(function(val) {
+        return val;
+      });
+    },
+    isTrue: function(val) {
+      return val;
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-guard-computed">
+  <template>
+    <template is="dom-if" if="{{switch}}" restamp>{{guarded(bool)}}</template>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-guard-computed',
+    properties: {
+      switch: {
+        computed: 'computeSwitch(bool)'
+      }
+    },
+    created: function() {
+      this.guarded = sinon.spy(function(val) {
+        return val;
+      });
+    },
+    computeSwitch: function(val) {
+      return val;
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-guard-object">
+  <template>
+    <template is="dom-if" if="{{obj.bool}}" restamp>{{guarded(obj.bool)}}</template>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-guard-object',
+    created: function() {
+      this.guarded = sinon.spy(function(val) {
+        return val;
+      });
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-guard-object-computed">
+  <template>
+    <template is="dom-if" if="{{switch}}" restamp>{{guarded(obj.bool)}}</template>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-guard-object-computed',
+    properties: {
+      switch: {
+        computed: 'computeSwitch(obj.bool)'
+      }
+    },
+    created: function() {
+      this.guarded = sinon.spy(function(val) {
+        return val;
+      });
+    },
+    computeSwitch: function(val) {
+      return val;
     }
   });
   </script>

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -137,7 +137,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 1', function() {
         individual.shouldStamp1 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 1, 'total stamped count incorrect');
         assert.equal(stamped[0].prop, 'prop1');
@@ -146,7 +145,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 2', function() {
         individual.shouldStamp2 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 2, 'total stamped count incorrect');
         assert.equal(stamped[0].prop, 'prop1');
@@ -157,7 +155,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 3', function() {
         individual.shouldStamp3 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(stamped[0].prop, 'prop1');
@@ -170,7 +167,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('hide 3', function() {
         individual.shouldStamp3 = false;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
@@ -180,7 +176,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('hide 2', function() {
         individual.shouldStamp2 = false;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
@@ -190,7 +185,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('hide 1', function() {
         individual.shouldStamp1 = false;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'none', 'stamped 1 display wrong');
@@ -200,7 +194,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 1', function() {
         individual.shouldStamp1 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
@@ -210,7 +203,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 2', function() {
         individual.shouldStamp2 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
@@ -220,7 +212,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('show 3', function() {
         individual.shouldStamp3 = true;
-        individual.render();
         var stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
@@ -451,17 +442,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         showing = structuredContainer.querySelector('.showing');
         assert.notOk(showing);
         structuredDomBind.item = {show: true};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.ok(showing);
         assert.equal(getComputedStyle(showing).display, 'block');
         structuredDomBind.item = {};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.ok(showing);
         assert.equal(getComputedStyle(showing).display, 'none');
         structuredDomBind.item = {show: true};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.ok(showing);
         assert.equal(getComputedStyle(showing).display, 'block');
@@ -471,19 +459,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var showing;
         structuredDomIf.restamp = true;
         structuredDomIf.if = false;
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.notOk(showing);
         structuredDomBind.item = {show: true};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.ok(showing);
         structuredDomBind.item = {};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.notOk(showing);
         structuredDomBind.item = {show: true};
-        structuredDomIf.render();
         showing = structuredContainer.querySelector('.showing');
         assert.ok(showing);
       });
@@ -500,12 +484,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), 'Stuff');
         x.$.domIf.if = false;
-        x.$.domIf.render();
         stamped = x.shadowRoot.childNodes;
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), '');
         x.$.domIf.if = true;
-        x.$.domIf.render();
         stamped = x.shadowRoot.childNodes;
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), 'Stuff');
@@ -521,13 +503,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), 'Stuff');
         x.$.domIf.if = false;
-        x.$.domIf.render();
         x.text = 'Hollaaaaa!';
         stamped = x.shadowRoot.childNodes;
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), '');
         x.$.domIf.if = true;
-        x.$.domIf.render();
         stamped = x.shadowRoot.childNodes;
         assert.equal(stamped.length, 12);
         assert.equal(stamped[7].textContent.trim(), 'Hollaaaaa!');
@@ -538,14 +518,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('attach/detach tests', function() {
 
-      test('remove, append domif', function(done) {
+      test('remove, append domif parent', function(done) {
+        window.uid = 0;
+        let outerContainer = document.getElementById('outerContainer');
         var domif = document.querySelector('#simple');
         domif.if = true;
-        outerContainer.removeChild(domif);
+        document.body.removeChild(outerContainer);
         setTimeout(function() {
           var clients = outerContainer.querySelectorAll('x-client');
-          assert.equal(clients.length, 0);
-          outerContainer.appendChild(domif);
+          assert.equal(clients.length, 3);
+          document.body.appendChild(outerContainer);
           setTimeout(function() {
             var clients = outerContainer.querySelectorAll('x-client');
             assert.equal(clients[0].uid, 0);
@@ -599,14 +581,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('move host with domif (clients persist)', function(done) {
+        window.uid = 0;
         var host = document.createElement('x-host');
         outerContainer.appendChild(host);
         setTimeout(function() {
           var clients = host.shadowRoot.querySelectorAll('x-client');
           // New clients created in host instance
-          assert.equal(clients[0].uid, 6);
-          assert.equal(clients[1].uid, 7);
-          assert.equal(clients[2].uid, 8);
+          assert.equal(clients[0].uid, 0);
+          assert.equal(clients[1].uid, 1);
+          assert.equal(clients[2].uid, 2);
           assert.equal(clients[1].previousElementSibling, clients[0]);
           assert.equal(clients[2].previousElementSibling, clients[1]);
           assert.equal(host.$.domif.previousElementSibling, clients[2]);
@@ -614,9 +597,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setTimeout(function() {
             var clients = host.shadowRoot.querySelectorAll('x-client');
             // Clients in removed host persist
-            assert.equal(clients[0].uid, 6);
-            assert.equal(clients[1].uid, 7);
-            assert.equal(clients[2].uid, 8);
+            assert.equal(clients[0].uid, 0);
+            assert.equal(clients[1].uid, 1);
+            assert.equal(clients[2].uid, 2);
             assert.equal(clients[1].previousElementSibling, clients[0]);
             assert.equal(clients[2].previousElementSibling, clients[1]);
             assert.equal(host.$.domif.previousElementSibling, clients[2]);
@@ -626,23 +609,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('remove, wait, append host with domif (clients persist)', function(done) {
+        window.uid = 0;
         var host = document.createElement('x-host');
         outerContainer.appendChild(host);
         setTimeout(function() {
           var clients = host.shadowRoot.querySelectorAll('x-client');
           // New clients created in host instance
-          assert.equal(clients[0].uid, 9);
-          assert.equal(clients[1].uid, 10);
-          assert.equal(clients[2].uid, 11);
+          assert.equal(clients[0].uid, 0);
+          assert.equal(clients[1].uid, 1);
+          assert.equal(clients[2].uid, 2);
           assert.equal(clients[1].previousElementSibling, clients[0]);
           assert.equal(clients[2].previousElementSibling, clients[1]);
           assert.equal(host.$.domif.previousElementSibling, clients[2]);
           outerContainer.removeChild(host);
           setTimeout(function() {
             // Clients in removed host persist
-            assert.equal(clients[0].uid, 9);
-            assert.equal(clients[1].uid, 10);
-            assert.equal(clients[2].uid, 11);
+            assert.equal(clients[0].uid, 0);
+            assert.equal(clients[1].uid, 1);
+            assert.equal(clients[2].uid, 2);
             assert.equal(clients[1].previousElementSibling, clients[0]);
             assert.equal(clients[2].previousElementSibling, clients[1]);
             assert.equal(host.$.domif.previousElementSibling, clients[2]);
@@ -650,9 +634,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             setTimeout(function() {
               // Clients in removed host persist
               var clients = host.shadowRoot.querySelectorAll('x-client');
-              assert.equal(clients[0].uid, 9);
-              assert.equal(clients[1].uid, 10);
-              assert.equal(clients[2].uid, 11);
+              assert.equal(clients[0].uid, 0);
+              assert.equal(clients[1].uid, 1);
+              assert.equal(clients[2].uid, 2);
               assert.equal(clients[1].previousElementSibling, clients[0]);
               assert.equal(clients[2].previousElementSibling, clients[1]);
               assert.equal(host.$.domif.previousElementSibling, clients[2]);
@@ -700,6 +684,125 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('non-upgrade case finds template', function() {
         assert.equal(nonUpgrade.textContent.trim(), 'stamped');
+      });
+
+    });
+
+    suite('ordering', function() {
+
+      test('restamp - sync thrashing if', function() {
+        window.uid = 0;
+        var host = document.createElement('x-host');
+        outerContainer.appendChild(host);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        var clients = host.shadowRoot.querySelectorAll('x-client');
+        assert.equal(clients[0].uid, 0);
+        assert.equal(clients[1].uid, 1);
+        assert.equal(clients[2].uid, 2);
+        host.$.domif.restamp = true;
+        host.$.domif.if = false;
+        host.$.domif.if = true;
+        host.$.domif.if = false;
+        host.$.domif.if = true;
+        clients = host.shadowRoot.querySelectorAll('x-client');
+        assert.equal(clients[0].uid, 6);
+        assert.equal(clients[1].uid, 7);
+        assert.equal(clients[2].uid, 8);
+      });
+
+      test('restamp - async thrashing if', function() {
+        window.uid = 0;
+        var host = document.createElement('x-host');
+        outerContainer.appendChild(host);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        var clients = host.shadowRoot.querySelectorAll('x-client');
+        assert.equal(clients[0].uid, 0);
+        assert.equal(clients[1].uid, 1);
+        assert.equal(clients[2].uid, 2);
+        host.$.domif.restamp = true;
+        host.$.domif.async = true;
+        host.$.domif.if = false;
+        host.$.domif.if = true;
+        host.$.domif.if = false;
+        host.$.domif.if = true;
+        clients = host.shadowRoot.querySelectorAll('x-client');
+        assert.equal(clients[0].uid, 0);
+        assert.equal(clients[1].uid, 1);
+        assert.equal(clients[2].uid, 2);
+        host.$.domif.render();
+        clients = host.shadowRoot.querySelectorAll('x-client');
+        assert.equal(clients[0].uid, 0);
+        assert.equal(clients[1].uid, 1);
+        assert.equal(clients[2].uid, 2);
+      });
+
+      test('effects in if not run when `if` goes false via property', function() {
+        var el = document.createElement('x-guard-prop');
+        document.body.appendChild(el);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        el.bool = true;
+        assert.equal(el.guarded.callCount, 1);
+        el.bool = false;
+        assert.equal(el.guarded.callCount, 1);
+        document.body.removeChild(el);
+      });
+
+      test('effects in if not run when `if` goes false via inline function', function() {
+        var el = document.createElement('x-guard-inline');
+        document.body.appendChild(el);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        el.bool = true;
+        assert.equal(el.guarded.callCount, 1);
+        el.bool = false;
+        assert.equal(el.guarded.callCount, 1);
+        document.body.removeChild(el);
+      });
+
+      test('effects in if not run when `if` goes false via computed property', function() {
+        var el = document.createElement('x-guard-computed');
+        document.body.appendChild(el);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        el.bool = true;
+        assert.equal(el.guarded.callCount, 1);
+        el.bool = false;
+        assert.equal(el.guarded.callCount, 1);
+        document.body.removeChild(el);
+      });
+
+      test('effects in if not run when `if` goes false via object sub-property', function() {
+        var el = document.createElement('x-guard-object');
+        document.body.appendChild(el);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        el.obj = {bool: true};
+        assert.equal(el.guarded.callCount, 1);
+        el.obj = {bool: false};
+        assert.equal(el.guarded.callCount, 1);
+        document.body.removeChild(el);
+      });
+
+      test('effects in if not run when `if` goes false via computed from object sub-property', function() {
+        var el = document.createElement('x-guard-object-computed');
+        document.body.appendChild(el);
+        if (customElements.flush) {
+          customElements.flush();
+        }
+        el.obj = {bool: true};
+        assert.equal(el.guarded.callCount, 1);
+        el.obj = {bool: false};
+        assert.equal(el.guarded.callCount, 1);
+        document.body.removeChild(el);
       });
 
     });

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -703,9 +703,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(clients[2].uid, 2);
         host.$.domif.restamp = true;
         host.$.domif.if = false;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = true;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = false;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = true;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         clients = host.shadowRoot.querySelectorAll('x-client');
         assert.equal(clients[0].uid, 6);
         assert.equal(clients[1].uid, 7);
@@ -726,9 +738,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         host.$.domif.restamp = true;
         host.$.domif.async = true;
         host.$.domif.if = false;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = true;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = false;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         host.$.domif.if = true;
+        if (customElements.flush) {
+          customElements.flush();
+        }
         clients = host.shadowRoot.querySelectorAll('x-client');
         assert.equal(clients[0].uid, 0);
         assert.equal(clients[1].uid, 1);


### PR DESCRIPTION
### Reference Issue
Fixes #2712

### Description
In order to ensure template wrapper elements like `<dom-if>` process their changes (e.g. changes to the `if` property) prior to `_host_...` properties being forwarded to instances, we override `_flushProperties` on  the `<template>` to explicitly flush the wrapper first.  In the context of `_flushClients`, if the template happens to go before the wrapper, the wrapper will be flushed first via this mechanism, and no-op later when `_flushClients` gets to it in its order.

Along with this change, `dom-if` stamps synchronously by default, and gains an `async` flag for backwards-compatible timing if needed for performance.  Async stamping is assumed to be much less necessary in 2.0 now that changes are batched.  Synchronously processing the `if` by default means that in the `restamp` case we ensures the instance is torn down before host properties are forwarded to it.

Considerations to discuss during review:
* Requiring sync & restamp to fix #2712 is not strictly necessary, however this dramatically simplifies things
  * Host property forwarding happens sync; squelching forwarding based on `if: false` means we may need to re-sync all (?) host properties in the case `if` becomes true again and the instance is reused (either due to `restamp: false` or if `if` becomes true again before the debouncer runs with `restamp: true`)
  * The current threading seems good: Host property forwarding is only squelched when there is no instance to forward to, but with `restamp: true` and the default sync behavior, the instance is removed before the forwarding occurs
* The wrapper check is added in the flush hot-path, but should be minimal
* Want to consider whether `templatize` should set `__wrapper`