### PR TITLE
Reset the `active` state once the callback runs

### DIFF
--- a/src/utils/debounce.html
+++ b/src/utils/debounce.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     setConfig(asyncModule, cb) {
       this._asyncModule = asyncModule;
       this._callback = cb;
-      this._timer = this._asyncModule.run(this._callback);
+      this._timer = this._asyncModule.run(this.flush);
     },
 
     /**

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -113,6 +113,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('flush debouncer', function(done) {
+        var callback = sinon.spy();
+        var job = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, callback);
+
+        setTimeout(function() {
+          job.flush();
+          assert.isTrue(callback.calledOnce, 'callback should be called once');
+          done();
+        });
+      });
+
       test('different debouncers and multiple micro tasks', function(done) {
         var callback = sinon.spy();
         var job1 = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, callback);


### PR DESCRIPTION
I noticed that a debouncer's callback can run twice because it doesn't reset the `active` state once it runs the first time.  I had this issue fixed in my local branch, but forgot to push it to the PR that was merged last week.