### PR TITLE
added missing semicolon

### DIFF
--- a/src/utils/boot.html
+++ b/src/utils/boot.html
@@ -23,6 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return s;
       }
     }
-  }
+  };
   /* eslint-enable */
 </script>


### PR DESCRIPTION
Running Polymer through Crisper ( https://github.com/PolymerLabs/crisper ) throws "Uncaught TypeError: (intermediate value) is not a function"

```
window.Polymer = window.Polymer || {};
  window.Polymer.version = '2.0-preview';

  /* eslint-disable no-unused-vars */
  /*
  When using Closure Compiler, goog.reflect.objectProperty(property, object) is replaced by the munged name for object[property]
  We cannot alias this function, so we have to use a small shim that has the same behavior when not compiling.
  */
  var goog = {
    reflect: {
      objectProperty(s, o) {
        return s;
      }
    }
  }
  /* eslint-enable */
(function() {

  var modules = {};
  var lcModules = {};
  var findModule = function(id) {
    return modules[id] || lcModules[id.toLowerCase()];
  };

  /**
   * The `dom-module` element registers the dom it contains to the name given
```

added a semicolon to correctly terminate the statement