### PR TITLE
Read properties off of proto during configuration.

### DIFF
--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -43,6 +43,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   var usePolyfillProto = Polymer.Settings.usePolyfillProto;
 
+  // When true, `this.properties` is bad juju due to obsolete `properties`
+  // accessors on instances of HTMLElement
+  var avoidInstanceProperties =
+    Boolean(Object.getOwnPropertyDescriptor(document.body, 'properties'));
+
   Polymer.Base._addFeature({
 
     // storage for configuration
@@ -106,7 +111,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // property, and b.) the `properties` accessor is on instances rather
       // than `HTMLElement.prototype`; going under the instance to the prototype
       // avoids the problem.
-      this._configureProperties(this.__proto__.properties, config);
+      this._configureProperties(avoidInstanceProperties ?
+        this.__proto__.properties : this.properties, config);
       // TODO(sorvell): it *may* be faster to loop over _propertyInfo but
       // there are some test issues.
       //this._configureProperties(this._propertyInfo, config);

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -106,11 +106,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._configureProperties(this.behaviors[i].properties, config);
       }
       // prototypical behavior
-      // Read `properties` off of the prototype, as an concession to non-spec
-      // compliant browsers where a.) HTMLElement's have a non-spec `properties`
-      // property, and b.) the `properties` accessor is on instances rather
-      // than `HTMLElement.prototype`; going under the instance to the prototype
-      // avoids the problem.
+      // Read `properties` off of the prototype, as a concession to non-spec
+      // compliant browsers (e.g. Android UC Browser 11.2.0.915) where
+      // a.) HTMLElement's have a non-spec `properties` property, and
+      // b.) the `properties` accessor is on instances rather than
+      // `HTMLElement.prototype`; going under the instance to the prototype
+      // avoids the problem. Note can't always go to __proto__ due to IE10
+      // hence conditional, but IE10 doesn't suffer from the instance properties
+      // issue (happy coincidence of browser quirks).
       this._configureProperties(avoidInstanceProperties ?
         this.__proto__.properties : this.properties, config);
       // TODO(sorvell): it *may* be faster to loop over _propertyInfo but

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -101,7 +101,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._configureProperties(this.behaviors[i].properties, config);
       }
       // prototypical behavior
-      this._configureProperties(this.properties, config);
+      // Read `properties` off of the prototype, as an concession to non-spec
+      // compliant browsers where a.) HTMLElement's have a non-spec `properties`
+      // property, and b.) the `properties` accessor is on instances rather
+      // than `HTMLElement.prototype`; going under the instance to the prototype
+      // avoids the problem.
+      this._configureProperties(this.__proto__.properties, config);
       // TODO(sorvell): it *may* be faster to loop over _propertyInfo but
       // there are some test issues.
       //this._configureProperties(this._propertyInfo, config);

--- a/src/standard/configure.html
+++ b/src/standard/configure.html
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // When true, `this.properties` is bad juju due to obsolete `properties`
   // accessors on instances of HTMLElement
   var avoidInstanceProperties =
-    Boolean(Object.getOwnPropertyDescriptor(document.body, 'properties'));
+    Boolean(Object.getOwnPropertyDescriptor(document.documentElement, 'properties'));
 
   Polymer.Base._addFeature({
 


### PR DESCRIPTION
Fix for UC browser, which has non-spec `properties` property on instances.