### PR TITLE
Fix getContentChildNodes. Fixes #4315.

### DIFF
--- a/src/legacy/legacy-element.html
+++ b/src/legacy/legacy-element.html
@@ -288,8 +288,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Returns a list of nodes that are the effective childNodes. The effective
        * childNodes list is the same as the element's childNodes except that
-       * any `<content>` elements are replaced with the list of nodes distributed
-       * to the `<content>`, the result of its `getDistributedNodes` method.
+       * any `<slot>` elements are replaced with the list of nodes distributed
+       * to the `<slot>`, the result of its `getDistributedNodes` method.
        *
        * @method getEffectiveChildNodes
        * @return {Array<Node>} List of effctive child nodes.
@@ -371,35 +371,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-       * Returns a list of nodes distributed to this element's `<content>`.
+       * Returns a list of nodes distributed to this element's `<slot>`.
        *
-       * If this element contains more than one `<content>` in its local DOM,
-       * an optional selector may be passed to choose the desired content.
+       * If this element contains more than one `<slot>` in its local DOM,
+       * an optional selector may be passed that matches the desired slot.
        *
        * @method getContentChildNodes
        * @param {String=} slctr CSS selector to choose the desired
-       *   `<content>`.  Defaults to `content`.
-       * @return {Array<Node>} List of distributed nodes for the `<content>`.
+       *   `<slot>`.  Defaults to `slot`.
+       * @return {Array<Node>} List of distributed nodes for the `<slot>`.
        */
       getContentChildNodes(slctr) {
-        var content = this.root.querySelector(slctr || 'content');
-        return content ? content.getDistributedNodes() : [];
+        var content = this.root.querySelector(slctr || 'slot');
+        return content ? Polymer.dom(content).getDistributedNodes() : [];
       }
 
       /**
        * Returns a list of element children distributed to this element's
-       * `<content>`.
+       * `<slot>`.
        *
-       * If this element contains more than one `<content>` in its
-       * local DOM, an optional selector may be passed to choose the desired
-       * content.  This method differs from `getContentChildNodes` in that only
+       * If this element contains more than one `<slot>` in its
+       * local DOM, an optional selector may be passed that matches the desired
+       * slot.  This method differs from `getContentChildNodes` in that only
        * elements are returned.
        *
        * @method getContentChildNodes
        * @param {String=} slctr CSS selector to choose the desired
-       *   `<content>`.  Defaults to `content`.
+       *   `<slot>`.  Defaults to `slot`.
        * @return {Array<HTMLElement>} List of distributed nodes for the
-       *   `<content>`.
+       *   `<slot>`.
        */
       getContentChildren(slctr) {
         return this.getContentChildNodes(slctr).filter(function(n) {


### PR DESCRIPTION
 Fix an error in getContentChildNodes (and associated methods that use it, like getContentChildren).

Also update some related API doc for 2.0.

### Reference Issue

Fixes #4315.
