### PR TITLE
2.0 render status compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ id is to use `id`.
 * <a name="breaking-beforeRegister"></a>`element.beforeRegister`: This was originally added for metadata compatibility with ES6 classes. We now prefer users create ES6 classes by extending `Polymer.Element`, specifying metadata in the static `config` property. For legacy use via `Polymer({...})`, dynamic effects may now be added using the `registered` lifecycle method.
 * <a name="breaking-attributeFollows"></a>`element.attributeFollows`: Removed due to disuse.
 * <a name="breaking-classFollows"></a>`element.classFollows`: Removed due to disuse.
+* <a name="breaking-copyOwnProperty"></a>`element.copyOwnProperty`: Removed due to disuse.
 * <a name="breaking-listeners"></a>`listeners`: Removed ability to use `id.event` to add listeners to elements in local dom. Use declarative template event handlers instead.
 * <a name="breaking-protected"></a>Methods starting with `_` are not guaranteed to exist (most have been removed)
 
@@ -277,4 +278,3 @@ id is to use `id`.
 * <a name="breaking-attribute-property-timing"></a>Any attribute values will take priority over property values set prior to upgrade due to V1 `attributeChangedCallback` timing semantics.  In 1.x properties set prior to upgrade overrode attributes.
 * <a name="breaking-transpiling"></a>Polymer 2.0 uses ES2015 syntax, and can be run without transpilation in current Chrome, Safari 10, Safari Technology Preview, Firefox, and Edge.  Transpilation is required to run in IE11 and Safari 9.  We will be releasing tooling for development and production time to support this need in the future.
 * <a name="breaking-hostAttributes-class"></a>In Polymer 1.x, the `class` attribute was explicitly blacklisted from `hostAttributes` and never serialized. This is no longer the case using the 2.0 legacy API.
-* <a name="breaking-render-status"></a>`Polymer.RenderStatus.afterNextRender(context, callback, args)` is now called only with a `callback` argument (`Polymer.RenderStatus.afterNextRender(callback)`). The callback should be bound as needed with the correct context and arguments.

--- a/src/utils/render-status.html
+++ b/src/utils/render-status.html
@@ -54,14 +54,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!scheduled) {
         schedule();
       }
-      beforeRenderQueue.push(arguments);
+      beforeRenderQueue.push([context, callback, args]);
     },
 
     afterNextRender: function(context, callback, args) {
       if (!scheduled) {
         schedule();
       }
-      afterRenderQueue.push(arguments);
+      afterRenderQueue.push([context, callback, args]);
     }
 
   };

--- a/src/utils/render-status.html
+++ b/src/utils/render-status.html
@@ -32,9 +32,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   function flushQueue(queue) {
-    for (let i=0; i<queue.length; i++) {
+    for (let i=0, q, context, callback, args; i<queue.length; i++) {
       try {
-        queue[i]();
+        q = queue[i];
+        context = q[0];
+        callback = q[1];
+        args = q[2];
+        callback.apply(context, args);
       } catch(e) {
         setTimeout(() => {
           throw e;
@@ -46,18 +50,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer.RenderStatus = {
 
-    beforeNextRender: function(cb) {
+    beforeNextRender: function(context, callback, args) {
       if (!scheduled) {
         schedule();
       }
-      beforeRenderQueue.push(cb);
+      beforeRenderQueue.push(arguments);
     },
 
-    afterNextRender: function(cb) {
+    afterNextRender: function(context, callback, args) {
       if (!scheduled) {
         schedule();
       }
-      afterRenderQueue.push(cb);
+      afterRenderQueue.push(arguments);
     }
 
   };

--- a/test/unit/custom-style-async.html
+++ b/test/unit/custom-style-async.html
@@ -48,7 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('async loaded custom-style applies', function(done) {
         host.importHref('custom-style-async-import.html', function() {
-          Polymer.RenderStatus.afterNextRender(function() {
+          Polymer.RenderStatus.afterNextRender(null, function() {
             assertComputed(host.$.client, '8px');
             done();
           });

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suiteSetup(function(done) {
           el = document.createElement('x-dynamic');
           document.body.appendChild(el);
-          Polymer.RenderStatus.afterNextRender(function() {
+          Polymer.RenderStatus.afterNextRender(null, function() {
             options = {node: el.$.inner};
             done();
           });

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function(done) {
         app = document.createElement('x-app');
         document.body.appendChild(app);
-        Polymer.RenderStatus.afterNextRender(done);
+        Polymer.RenderStatus.afterNextRender(null, done);
       });
 
       teardown(function() {
@@ -73,7 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suiteSetup(function(done) {
         outer = document.createElement('x-setup');
         document.body.appendChild(outer);
-        Polymer.RenderStatus.afterNextRender(function() {
+        Polymer.RenderStatus.afterNextRender(null, function() {
           inner = outer.$.inner;
           done();
         })
@@ -120,7 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('dynamic', function(done) {
           var el = document.createElement('x-dynamic');
-          Polymer.RenderStatus.afterNextRender(function() {
+          Polymer.RenderStatus.afterNextRender(null, function() {
             var obj = el.__polymerGestures;
             assert(!obj);
             el.setup();
@@ -208,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function(done) {
         el = document.createElement('x-prevent');
         document.body.appendChild(el);
-        Polymer.RenderStatus.afterNextRender(done);
+        Polymer.RenderStatus.afterNextRender(null, done);
       });
       teardown(function() {
         el.parentNode.removeChild(el);
@@ -255,7 +255,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         el.parentNode.removeChild(el);
         el = document.createElement('x-nested-prevent');
         document.body.appendChild(el);
-        Polymer.RenderStatus.afterNextRender(function() {
+        Polymer.RenderStatus.afterNextRender(null, function() {
           var child = el.$.child;
           var options = {bubbles: true, cancelable: true, composed: true};
 
@@ -305,7 +305,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function(done) {
         el = document.createElement('x-buttons');
         document.body.appendChild(el);
-        Polymer.RenderStatus.afterNextRender(done);
+        Polymer.RenderStatus.afterNextRender(null, done);
       });
 
       teardown(function() {
@@ -399,7 +399,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function(done) {
         el = document.createElement('x-document-listener');
         document.body.appendChild(el);
-        Polymer.RenderStatus.afterNextRender(function() {
+        Polymer.RenderStatus.afterNextRender(null, function() {
           el.setup();
           done();
         });
@@ -423,7 +423,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function(done) {
         el = document.createElement('x-buttons');
         document.body.appendChild(el);
-        Polymer.RenderStatus.afterNextRender(done);
+        Polymer.RenderStatus.afterNextRender(null, done);
       });
 
       teardown(function() {

--- a/test/unit/render-status.html
+++ b/test/unit/render-status.html
@@ -21,12 +21,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     class XFoo extends Polymer.LegacyElement {
       ready() {
         super.ready();
-        Polymer.RenderStatus.beforeNextRender(() => {
-          this.beforeNextRender();
-        });
-        Polymer.RenderStatus.afterNextRender(() => {
-          this.afterNextRender();
-        });
+        Polymer.RenderStatus.beforeNextRender(this, this.beforeNextRender,
+          ['before']);
+        Polymer.RenderStatus.afterNextRender(this, (a) => {
+          this.afterNextRender(a);
+        }, ['after']);
       }
 
       beforeNextRender() {}
@@ -44,7 +43,8 @@ suite('render-status', function() {
   test('beforeNextRender', function(done) {
     let el = document.createElement('x-foo');
     let beforeCalled;
-    el.beforeNextRender = function() {
+    el.beforeNextRender = function(a) {
+      assert.equal(a, 'before', 'before render argument incorrect');
       beforeCalled = true;
     }
     document.body.appendChild(el);
@@ -64,7 +64,8 @@ suite('render-status', function() {
       assert.notOk(afterCalled);
       raf = true;
     })
-    el.afterNextRender = function() {
+    el.afterNextRender = function(a) {
+      assert.equal(a, 'after', 'after render argument incorrect');
       afterCalled = true;
       assert.ok(raf);
       done();


### PR DESCRIPTION
Change `Polymer.RenderStatus.afterNexRender` to have the same signature as it does in Polymer 1.x.