### PR TITLE
2.x data improvements

### DIFF
--- a/src/elements/dom-bind.html
+++ b/src/elements/dom-bind.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (let n=this.root.firstChild; n; n=n.nextSibling) {
             this.__children[this.__children.length] = n;
           }
-          this._flushProperties(this);
+          this._flushProperties();
         }
         this.__insertChildren();
         this.dispatchEvent(new CustomEvent('dom-change', {bubbles: true}));

--- a/src/elements/dom-if.html
+++ b/src/elements/dom-if.html
@@ -213,7 +213,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.__instance._setPendingProperty(prop, this.__dataHost[prop]);
         }
         this.__invalidProps = null;
-        this.__instance._flushProperties(true);
+        this.__instance._flushProperties();
       }
     }
 

--- a/src/elements/dom-repeat.html
+++ b/src/elements/dom-repeat.html
@@ -601,7 +601,7 @@ Then the `observe` property should be configured as follows:
             let itemPath = this.as + (itemSubPath ? '.' + itemSubPath : '');
             // This is effectively `notifyPath`, but avoids some of the overhead
             // of the public API
-            inst._setPendingPropertyOrPath(itemPath, value, true);
+            inst._setPendingPropertyOrPath(itemPath, value, false, true);
             inst._flushProperties(true);
           }
         }

--- a/src/elements/dom-repeat.html
+++ b/src/elements/dom-repeat.html
@@ -516,7 +516,7 @@ Then the `observe` property should be configured as follows:
           inst._setPendingProperty(this.as, item);
           inst._setPendingProperty(this.indexAs, instIdx);
           inst._setPendingProperty(this.itemsIndexAs, itemIdx);
-          inst._flushProperties(true);
+          inst._flushProperties();
         } else {
           this.__insertInstance(item, instIdx, itemIdx);
         }
@@ -565,7 +565,7 @@ Then the `observe` property should be configured as follows:
         inst._setPendingProperty(this.as, item);
         inst._setPendingProperty(this.indexAs, instIdx);
         inst._setPendingProperty(this.itemsIndexAs, itemIdx);
-        inst._flushProperties(true);
+        inst._flushProperties();
       } else {
         inst = this.__stampInstance(item, instIdx, itemIdx);
       }
@@ -602,7 +602,7 @@ Then the `observe` property should be configured as follows:
             // This is effectively `notifyPath`, but avoids some of the overhead
             // of the public API
             inst._setPendingPropertyOrPath(itemPath, value, false, true);
-            inst._flushProperties(true);
+            inst._flushProperties();
           }
         }
         return true;

--- a/src/legacy/legacy-element-mixin.html
+++ b/src/legacy/legacy-element-mixin.html
@@ -76,12 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _registered() {}
 
-      _flushProperties() {
-        if (!this.__dataInitialized) {
-          this._ensureAttributes();
-          this._applyListeners();
-        }
-        super._flushProperties();
+      ready() {
+        this._ensureAttributes();
+        this._applyListeners();
+        super.ready();
       }
 
       /**

--- a/src/legacy/legacy-element-mixin.html
+++ b/src/legacy/legacy-element-mixin.html
@@ -76,10 +76,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _registered() {}
 
-      ready() {
-        this._ensureAttributes();
-        this._applyListeners();
-        super.ready();
+      _flushProperties(fromAbove) {
+        if (!this.__dataInitialized) {
+          this._ensureAttributes();
+          this._applyListeners();
+        }
+        super._flushProperties(fromAbove);
       }
 
       /**

--- a/src/legacy/legacy-element-mixin.html
+++ b/src/legacy/legacy-element-mixin.html
@@ -76,12 +76,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _registered() {}
 
-      _flushProperties(fromAbove) {
+      _flushProperties() {
         if (!this.__dataInitialized) {
           this._ensureAttributes();
           this._applyListeners();
         }
-        super._flushProperties(fromAbove);
+        super._flushProperties();
       }
 
       /**

--- a/src/mixins/element-mixin.html
+++ b/src/mixins/element-mixin.html
@@ -332,11 +332,13 @@ Polymer.ElementMixin = Polymer.dedupingMixin(function(base) {
 
     constructor() {
       super();
-      // note: `this.constructor.prototype` is wrong in Safari so make sure to
-      // use `__proto__`
       Polymer.telemetry.instanceCount++;
-      // add self to host's pending client list
-      hostStack.registerHost(this);
+      // Stamp template
+      if (this._template) {
+        this.root = this._stampTemplate(this._template);
+      } else {
+        this.root = this;
+      }
     }
 
     _initializeProperties() {
@@ -353,7 +355,7 @@ Polymer.ElementMixin = Polymer.dedupingMixin(function(base) {
           var value = typeof info.value == 'function' ?
             info.value.call(this) :
             info.value;
-          if (this._hasReadOnlyEffect(p)) {
+          if (this._hasPropertyEffect(p)) {
             this._setProperty(p, value)
           } else {
             this[p] = value;
@@ -362,17 +364,11 @@ Polymer.ElementMixin = Polymer.dedupingMixin(function(base) {
       }
     }
 
-    // reserved for canonical behavior
     connectedCallback() {
       if (window.ShadyCSS) {
         window.ShadyCSS.styleElement(this);
       }
-      if (hostStack.isEmpty()) {
-        // note, this should never recurse to root elements; this will
-        // need new ShadyCSS api
-        // (see https://github.com/webcomponents/shadycss/issues/42)
-        this._flushProperties();
-      }
+      this._flushProperties();
     }
 
     disconnectedCallback() {}
@@ -380,14 +376,7 @@ Polymer.ElementMixin = Polymer.dedupingMixin(function(base) {
     ready() {
       super.ready();
       if (this._template) {
-        hostStack.beginHosting(this);
-        this.root = this._stampTemplate(this._template);
-        this._flushProperties();
         this.root = this._attachDom(this.root);
-        hostStack.endHosting(this);
-      } else {
-        this.root = this;
-        this._flushProperties();
       }
     }
 
@@ -463,34 +452,6 @@ Polymer.ElementMixin = Polymer.dedupingMixin(function(base) {
 
   return PolymerElement;
 });
-
-let hostStack = {
-
-  stack: [],
-
-  isEmpty() {
-    return !this.stack.length;
-  },
-
-  registerHost(inst) {
-    if (this.stack.length) {
-      let host = this.stack[this.stack.length-1];
-      host._enqueueClient(inst);
-    }
-  },
-
-  beginHosting(inst) {
-    this.stack.push(inst);
-  },
-
-  endHosting(inst) {
-    let stackLen = this.stack.length;
-    if (stackLen && this.stack[stackLen-1] == inst) {
-      this.stack.pop();
-    }
-  }
-
-}
 
 // telemetry
 Polymer.telemetry = {

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -235,24 +235,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function runNotifyEffects(inst, notifyProps, props, oldProps, hasPaths) {
     // Notify
     let fxs = inst.__notifyEffects;
-    if (fxs || hasPaths) {
-      let notified;
-      let id = dedupeId++;
-      // Try normal notify effects; if none, fall back to try path notification
-      for (let prop in notifyProps) {
-        if (notifyProps[prop]) {
-          if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, hasPaths)) {
-            notified = true;
-          } else if (hasPaths && notifyPath(inst, prop, props)) {
-            notified = true;
-          }
+    let notified;
+    let id = dedupeId++;
+    // Try normal notify effects; if none, fall back to try path notification
+    for (let prop in notifyProps) {
+      if (notifyProps[prop]) {
+        if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, hasPaths)) {
+          notified = true;
+        } else if (hasPaths && notifyPath(inst, prop, props)) {
+          notified = true;
         }
       }
-      // Flush host if we actually notified and host was batching
-      let host;
-      if (notified && (host = inst.__dataHost) && host._flushProperties) {
-        host._flushProperties();
-      }
+    }
+    // Flush host if we actually notified and host was batching
+    let host;
+    if (notified && (host = inst.__dataHost) && host._flushProperties) {
+      host._flushProperties();
     }
   }
 
@@ -461,22 +459,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function computeLinkedPaths(inst, changedProps, hasPaths) {
     let links;
     if (hasPaths && (links = inst.__dataLinkedPaths)) {
+      const cache = inst.__dataTemp;
       let link;
       for (let a in links) {
         let b = links[a];
         for (let path in changedProps) {
           if (Polymer.Path.isDescendant(a, path)) {
             link = Polymer.Path.translate(a, b, path);
-            inst._setPendingProperty(link, changedProps[path], true);
+            cache[link] = changedProps[link] = changedProps[path];
+            let notifyProps = inst.__dataToNotify || (inst.__dataToNotify = {});
+            notifyProps[link] = true;
           } else if (Polymer.Path.isDescendant(b, path)) {
             link = Polymer.Path.translate(b, a, path);
-            inst._setPendingProperty(link, changedProps[path], true);
+            cache[link] = changedProps[link] = changedProps[path];
+            let notifyProps = inst.__dataToNotify || (inst.__dataToNotify = {});
+            notifyProps[link] = true;
           }
         }
-      }
-      if (inst.__dataPending) {
-        mixin(changedProps, inst.__dataPending);
-        inst.__dataPending = null;
       }
     }
   }
@@ -1712,13 +1711,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // if (window.debug) { debugger; }
         // ----------------------------
         let hasPaths = this.__dataHasPaths;
+        this.__dataHasPaths = false;
         // Compute properties
         runComputedEffects(this, changedProps, oldProps, hasPaths);
         // Compute linked paths
         computeLinkedPaths(this, changedProps, hasPaths);
-        // Capture notify properties prior to possible reentry (propagate, observe)
+        // Clear notify properties prior to possible reentry (propagate, observe),
+        // but after computing effects have a chance to add to them
         let notifyProps = this.__dataToNotify;
-        this.__dataToNotify = this.__dataHasPaths = false;
+        this.__dataToNotify = null;
         // Propagate properties to clients
         runEffects(this, this.__propagateEffects, changedProps, oldProps, hasPaths);
         // Flush clients
@@ -1728,7 +1729,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Observe properties
         runEffects(this, this.__observeEffects, changedProps, oldProps, hasPaths);
         // Notify properties to host
-        runNotifyEffects(this, notifyProps, changedProps, oldProps, hasPaths);
+        if (notifyProps) {
+          runNotifyEffects(this, notifyProps, changedProps, oldProps, hasPaths);
+        }
         // ----------------------------
         // window.debug && console.groupEnd(this.localName + '#' + this.id + ': ' + c);
         // ----------------------------

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -122,12 +122,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object=} oldProps Bag of previous values for changed properties
    * @private
    */
-  function runEffects(inst, effects, props, oldProps, fromAbove, hasPaths) {
+  function runEffects(inst, effects, props, oldProps, hasPaths) {
     if (effects) {
       let ran;
       let id = dedupeId++;
       for (let prop in props) {
-        if (runEffectsForProperty(inst, effects, id, prop, props, oldProps, fromAbove, hasPaths)) {
+        if (runEffectsForProperty(inst, effects, id, prop, props, oldProps, hasPaths)) {
           ran = true;
         }
       }
@@ -146,7 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {*} old Previous value of changed property
    * @private
    */
-  function runEffectsForProperty(inst, effects, dedupeId, prop, props, oldProps, fromAbove, hasPaths) {
+  function runEffectsForProperty(inst, effects, dedupeId, prop, props, oldProps, hasPaths) {
     let ran;
     let rootProperty = hasPaths ? Polymer.Path.root(prop) : prop;
     let fxs = effects[rootProperty];
@@ -154,7 +154,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       for (let i=0, l=fxs.length, fx; (i<l) && (fx=fxs[i]); i++) {
         if ((!fx.info || fx.info.lastRun !== dedupeId) &&
             (!hasPaths || pathMatchesTrigger(prop, fx.trigger))) {
-          fx.fn(inst, prop, props, oldProps, fx.info, fromAbove, hasPaths);
+          fx.fn(inst, prop, props, oldProps, fx.info, hasPaths);
           if (fx.info) {
             fx.info.lastRun = dedupeId;
           }
@@ -232,23 +232,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} oldProps Bag of previous values for changed properties
    * @private
    */
-  function runNotifyEffects(inst, props, oldProps, fromAbove, firstFromAbove, hasPaths) {
+  function runNotifyEffects(inst, notifyProps, props, oldProps, hasPaths) {
     // Notify
     let fxs = inst.__notifyEffects;
     if (fxs || hasPaths) {
       let notified;
       let id = dedupeId++;
       // Try normal notify effects; if none, fall back to try path notification
-      for (let prop in props) {
-        // The first flush is `fromAbove: false`, but we avoid notifying props bound from above.
-        // Defaults & constructor assignments are captured in __data.__proto__, and subsequent
-        // values are set into a bag changed from that for differentiation here
-        if (firstFromAbove && fxs[prop] && inst.__data.hasOwnProperty(prop)) {
-          continue;
-        } else if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, fromAbove, hasPaths)) {
-          notified = true;
-        } else if (hasPaths && notifyPath(inst, prop, props)) {
-          notified = true;
+      for (let prop in notifyProps) {
+        if (notifyProps[prop]) {
+          if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, hasPaths)) {
+            notified = true;
+          } else if (hasPaths && notifyPath(inst, prop, props)) {
+            notified = true;
+          }
         }
       }
       // Flush host if we actually notified and host was batching
@@ -289,6 +286,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @private
    */
   function dispatchNotifyEvent(inst, eventName, value, path) {
+    window.eventCount = (window.eventCount || 0) + 1;
+    window.eventCounts = window.eventCounts || {};
+    window.eventCounts[eventName] = (window.eventCounts[eventName] || 0) + 1;
     let detail = {
       value: value,
       queueProperty: true
@@ -312,7 +312,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} info Effect metadata
    * @private
    */
-  function runNotifyEffect(inst, property, props, oldProps, info, fromAbove, hasPaths) {
+  function runNotifyEffect(inst, property, props, oldProps, info, hasPaths) {
     let rootProperty = hasPaths ? Polymer.Path.root(property) : property;
     let path = rootProperty != property ? property : null;
     let value = path ? Polymer.Path.get(inst, path) : inst.__data[property];
@@ -377,7 +377,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     let detail = event.detail;
     if (detail && detail.queueProperty) {
       if (!inst.__readOnly || !inst.__readOnly[path]) {
-        inst._setPendingPropertyOrPath(path, value, Boolean(detail.path));
+        inst._setPendingPropertyOrPath(path, value, true, Boolean(detail.path));
       }
     } else {
       inst.set(path, value);
@@ -417,23 +417,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Element} inst The instance the effect will be run on
    * @param {Object} changedProps Bag of changed properties
    * @param {Object} oldProps Bag of previous values for changed properties
-   * @return {Object | null | undefined} Bag of newly computed properties from "computed" effects
    */
-  function runComputedEffects(inst, changedProps, oldProps, fromAbove, hasPaths) {
+  function runComputedEffects(inst, changedProps, oldProps, hasPaths) {
     let computeEffects = inst.__computeEffects;
     if (computeEffects) {
       let inputProps = changedProps;
-      let computedProps;
-      while (runEffects(inst, computeEffects, inputProps, oldProps, fromAbove, hasPaths)) {
+      while (runEffects(inst, computeEffects, inputProps, oldProps, hasPaths)) {
         mixin(oldProps, inst.__dataOld);
         mixin(changedProps, inst.__dataPending);
-        computedProps = mixin(computedProps || {}, inst.__dataPending);
         inputProps = inst.__dataPending;
         inst.__dataPending = null;
       }
-      return computedProps;
-    } else {
-      return undefined;
     }
   }
 
@@ -453,7 +447,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var result = runMethodEffect(inst, property, props, oldProps, info);
     var computedProp = info.methodInfo;
     if (inst.__propertyEffects && inst.__propertyEffects[computedProp]) {
-      inst._setPendingProperty(computedProp, result);
+      inst._setPendingProperty(computedProp, result, true);
     } else {
       inst[computedProp] = result;
     }
@@ -465,34 +459,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @param {Element} inst The instance whose props are changing
    * @param {Object} changedProps Bag of changed properties
-   * @param {Object | undefined} computedProps Bag of properties newly computed this turn
-   *   via "computed" effects; any linked paths generated via this method
-   *   will be added both to the set of `changedProps` as well as to the
-   *   set of `computedProps`; this is because the `fromAbove: true` case will
-   *   notify only from the `computedProps` bag.
-   * @return {Object | undefined}
    * @private
    */
-  function computeLinkedPaths(inst, changedProps, computedProps, hasPaths) {
+  function computeLinkedPaths(inst, changedProps, hasPaths) {
     let links;
     if (hasPaths && (links = inst.__dataLinkedPaths)) {
-      const cache = inst.__dataTemp;
-      computedProps = computedProps || {};
       let link;
       for (let a in links) {
         let b = links[a];
         for (let path in changedProps) {
           if (Polymer.Path.isDescendant(a, path)) {
             link = Polymer.Path.translate(a, b, path);
-            cache[link] = changedProps[link] = computedProps[link] = changedProps[path];
+            inst._setPendingProperty(link, changedProps[path], true);
           } else if (Polymer.Path.isDescendant(b, path)) {
             link = Polymer.Path.translate(b, a, path);
-            cache[link] = changedProps[link] = computedProps[link] = changedProps[path];
+            inst._setPendingProperty(link, changedProps[path], true);
           }
         }
       }
+      if (inst.__dataPending) {
+        mixin(changedProps, inst.__dataPending);
+        inst.__dataPending = null;
+      }
     }
-    return computedProps;
   }
 
   // -- bindings ----------------------------------------------
@@ -552,7 +541,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} info Effect metadata
    * @private
    */
-  function runBindingEffect(inst, path, props, oldProps, info, fromAbove, hasPaths) {
+  function runBindingEffect(inst, path, props, oldProps, info, hasPaths) {
     let value;
     let node = inst._templateNodes[info.index];
     // Subpath notification: transform path and set to client
@@ -562,7 +551,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         node.__propertyEffects && node.__propertyEffects[info.name]) {
       let value = props[path];
       path = Polymer.Path.translate(info.value, info.name, path);
-      if (node._setPendingPropertyOrPath(path, value, true)) {
+      if (node._setPendingPropertyOrPath(path, value, false, true)) {
         inst._enqueueClient(node);
       }
     } else {
@@ -874,11 +863,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         node.__dataHost = inst;
         if (note.bindings) {
           setupCompoundBinding(note, node);
-        }
-        // Start capturing pre-bound data to avoid notifications for these properties
-        if (node.__notifyEffects) {
-          node.__dataFirstFromAbove = true;
-          node.__data = Object.create(node.__data);
         }
       }
     }
@@ -1226,7 +1210,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         hostStack.registerHost(this);
         this.__dataInitialized = false;
         this.__dataPendingClients = null;
-        this.__dataFromAbove = false;
+        this.__dataToNotify = null;
         this.__dataLinkedPaths = null;
         this.__dataHasPaths = false;
         // May be set on instance prior to upgrade
@@ -1249,6 +1233,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__data = Object.create(props);
         this.__dataPending = Object.create(props);
         this.__dataOld = {};
+      }
+
+      __initalizeInstanceProperties(props) {
+        this.__dataOld = this.__dataOld || {};
+        this.__dataPending = this.__dataPending || {};
+        let readOnly = this.__readOnly;
+        for (let prop in props) {
+          if (!readOnly || !readOnly[prop]) {
+            this.__data[prop] = this.__dataPending[prop] = props[prop];
+          }
+        }
       }
 
       // Prototype setup ----------------------------------------
@@ -1390,7 +1385,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   the pending changes bag.
        * @protected
        */
-      _setPendingPropertyOrPath(path, value, isPathNotification) {
+      _setPendingPropertyOrPath(path, value, shouldNotify, isPathNotification) {
         let rootProperty = Polymer.Path.root(Array.isArray(path) ? path[0] : path);
         let hasEffect = this.__propertyEffects && this.__propertyEffects[rootProperty];
         let isPath = (rootProperty !== path);
@@ -1414,7 +1409,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
             this.__dataHasPaths = true;
           }
-          return this._setPendingProperty(path, value);
+          return this._setPendingProperty(path, value, shouldNotify);
         } else {
           if (isPath) {
             Polymer.Path.set(this, path, value);
@@ -1484,7 +1479,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @override
        */
-      _setPendingProperty(property, value) {
+      _setPendingProperty(property, value, shouldNotify) {
         let isPath = this.__dataHasPaths && Polymer.Path.isPath(property);
         let prevProps = isPath ? this.__dataTemp : this.__data;
         if (this._shouldPropertyChange(property, value, prevProps[property])) {
@@ -1508,7 +1503,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           // All changes go into pending property bag, passed to _propertiesChanged
           this.__dataPending[property] = value;
+          // Track properties that should notify separately
+          if (isPath || (this.__notifyEffects && this.__notifyEffects[property])) {
+            this.__dataToNotify = this.__dataToNotify || {};
+            this.__dataToNotify[property] = shouldNotify;
+          }
           return true;
+        }
+      }
+
+      /**
+       * Overrides base implementation to ensure all accessors set `shouldNotify`
+       * to true, for per-property notification tracking.
+       *
+       * @override
+       */
+      _setProperty(property, value) {
+        if (this._setPendingProperty(property, value, true)) {
+          this._invalidateProperties();
         }
       }
 
@@ -1580,7 +1592,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (let i=0; i < clients.length; i++) {
             let client = clients[i];
             if (!client.__dataInitialized || client.__dataPending) {
-              client._flushProperties(true);
+              client._flushProperties();
             }
           }
         }
@@ -1603,7 +1615,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // wildcard observers currently only pass the first changed path
             // in the `info` object, and you could do some odd things batching
             // paths, e.g. {'foo.bar': {...}, 'foo': null}
-            this._setPendingPropertyOrPath(path, props[path]);
+            this._setPendingPropertyOrPath(path, props[path], true);
           }
         }
         this._invalidateProperties();
@@ -1616,24 +1628,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * If this is the first time properties are being flushed, the `ready`
        * callback will be called.
        *
-       * Also adds an optional `fromAbove` argument to indicate when properties
-       * are being flushed by a host during data propagation. This information
-       * is used to avoid sending upwards notification events in response to
-       * downward data flow.  This is a performance optimization, but also
-       * critical to avoid infinite looping when an object is notified, since
-       * the default implementation of `_shouldPropertyChange` always returns
-       * true for Objects, and without would result in a notify-propagate-notify
-       * loop.
-       *
-       * @param {boolean=} fromAbove When true, sets `this.__dataFromAbove` to
-       *   `true` for the duration of the call to `_propertiesChanged`.
        * @override
        */
-      _flushProperties(fromAbove) {
+      _flushProperties() {
         if (!this.__dataInitialized) {
           this.ready()
         } else if (this.__dataPending || this.__dataPendingClients) {
-          this.__dataFromAbove = fromAbove;
           super._flushProperties();
           if (!this.__dataCounter) {
             // Clear temporary cache at end of turn
@@ -1660,17 +1660,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ready() {
         // Update instance properties that shadowed proto accessors; these take
         // priority over any defaults set in `properties` or constructor
-        let props = this.__dataInstanceProps;
-        if (props) {
-          Object.assign(this, props);
+        let instanceProps = this.__dataInstanceProps;
+        if (instanceProps) {
+          this.__initalizeInstanceProperties(instanceProps);
         }
         // Enable acceessors
         this.__dataInitialized = true;
         // Run normal flush
         this._flushProperties();
-        // Stop capturing pre-bound data (cleared in _propertiesChanged, but
-        // this is a backstop in case _flushProperties fast-paths)
-        this.__dataFirstFromAbove = false;
       }
 
       /**
@@ -1708,30 +1705,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @override
        */
       _propertiesChanged(currentProps, changedProps, oldProps) {
-        let hasPaths = this.__dataHasPaths;
-        let fromAbove = this.__dataFromAbove;
-        let firstFromAbove = this.__dataFirstFromAbove;
-        this.__dataHasPaths = this.__dataFromAbove = this.__dataFirstFromAbove = false;
         // ----------------------------
         // let c = Object.getOwnPropertyNames(changedProps || {});
         // window.debug && console.group(this.localName + '#' + this.id + ': ' + c);
         // if (window.debug) { debugger; }
         // ----------------------------
+        let hasPaths = this.__dataHasPaths;
         // Compute properties
-        let computedProps = runComputedEffects(this, changedProps, oldProps, fromAbove, hasPaths);
+        runComputedEffects(this, changedProps, oldProps, hasPaths);
         // Compute linked paths
-        computedProps = computeLinkedPaths(this, changedProps, computedProps, hasPaths);
+        computeLinkedPaths(this, changedProps, hasPaths);
+        // Capture notify properties prior to possible reentry (propagate, observe)
+        let notifyProps = this.__dataToNotify;
+        this.__dataToNotify = this.__dataHasPaths = false;
         // Propagate properties to clients
-        runEffects(this, this.__propagateEffects, changedProps, oldProps, fromAbove, hasPaths);
+        runEffects(this, this.__propagateEffects, changedProps, oldProps, hasPaths);
         // Flush clients
         this._flushClients();
         // Reflect properties
-        runEffects(this, this.__reflectEffects, changedProps, oldProps, fromAbove, hasPaths);
+        runEffects(this, this.__reflectEffects, changedProps, oldProps, hasPaths);
         // Observe properties
-        runEffects(this, this.__observeEffects, changedProps, oldProps, fromAbove, hasPaths);
+        runEffects(this, this.__observeEffects, changedProps, oldProps, hasPaths);
         // Notify properties to host
-        let notifyProps = fromAbove ? computedProps : changedProps;
-        runNotifyEffects(this, notifyProps, oldProps, fromAbove, firstFromAbove, hasPaths);
+        runNotifyEffects(this, notifyProps, changedProps, oldProps, hasPaths);
         // ----------------------------
         // window.debug && console.groupEnd(this.localName + '#' + this.id + ': ' + c);
         // ----------------------------
@@ -1855,7 +1851,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.Path.set(root, path, value);
         } else {
           if (!this.__readOnly || !this.__readOnly[/** @type {string} */(path)]) {
-            if (this._setPendingPropertyOrPath(path, value)) {
+            if (this._setPendingPropertyOrPath(path, value, true)) {
               this._invalidateProperties();
             }
           }
@@ -2026,7 +2022,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           propPath = /** @type{string} */(path);
         }
-        if (this._setPendingPropertyOrPath(propPath, value, true)) {
+        if (this._setPendingPropertyOrPath(propPath, value, true, true)) {
           this._invalidateProperties();
         }
       }

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -286,9 +286,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @private
    */
   function dispatchNotifyEvent(inst, eventName, value, path) {
-    window.eventCount = (window.eventCount || 0) + 1;
-    window.eventCounts = window.eventCounts || {};
-    window.eventCounts[eventName] = (window.eventCounts[eventName] || 0) + 1;
     let detail = {
       value: value,
       queueProperty: true
@@ -1190,6 +1187,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     return name[0].toUpperCase() + name.substring(1);
   }
 
+  /**
+   * Sets the provided properties into pending data on the instance.
+   *
+   * @param {HTMLElement} inst Instance to apply data to
+   * @param {object} props Bag of instance properties to set
+   */
+  function initalizeInstanceProperties(inst, props) {
+    inst.__dataOld = inst.__dataOld || {};
+    inst.__dataPending = inst.__dataPending || {};
+    let readOnly = inst.__readOnly;
+    for (let prop in props) {
+      if (!readOnly || !readOnly[prop]) {
+        inst.__data[prop] = inst.__dataPending[prop] = props[prop];
+      }
+    }
+  }
+
   Polymer.PropertyEffects = Polymer.dedupingMixin(function(superClass) {
 
     const mixin = Polymer.TemplateStamp(Polymer.PropertyAccessors(superClass));
@@ -1231,17 +1245,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__data = Object.create(props);
         this.__dataPending = Object.create(props);
         this.__dataOld = {};
-      }
-
-      __initalizeInstanceProperties(props) {
-        this.__dataOld = this.__dataOld || {};
-        this.__dataPending = this.__dataPending || {};
-        let readOnly = this.__readOnly;
-        for (let prop in props) {
-          if (!readOnly || !readOnly[prop]) {
-            this.__data[prop] = this.__dataPending[prop] = props[prop];
-          }
-        }
       }
 
       // Prototype setup ----------------------------------------
@@ -1660,7 +1663,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // priority over any defaults set in `properties` or constructor
         let instanceProps = this.__dataInstanceProps;
         if (instanceProps) {
-          this.__initalizeInstanceProperties(instanceProps);
+          initalizeInstanceProperties(this, instanceProps);
         }
         // Enable acceessors
         this.__dataInitialized = true;

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -27,6 +27,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   const CaseMap = Polymer.CaseMap;
   const mixin = Polymer.mixin;
 
+  // For tracking nested clients that will require flushing
+  let hostStack = {
+
+    stack: [],
+
+    isEmpty() {
+      return !this.stack.length;
+    },
+
+    registerHost(inst) {
+      if (this.stack.length) {
+        let host = this.stack[this.stack.length-1];
+        host._enqueueClient(inst);
+      }
+    },
+
+    beginHosting(inst) {
+      this.stack.push(inst);
+    },
+
+    endHosting(inst) {
+      let stackLen = this.stack.length;
+      if (stackLen && this.stack[stackLen-1] == inst) {
+        this.stack.pop();
+      }
+    }
+
+  }
+
   // Monotonically increasing unique ID used for de-duping effects triggered
   // from multiple properties in the same turn
   let dedupeId = 0;
@@ -203,7 +232,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Object} oldProps Bag of previous values for changed properties
    * @private
    */
-  function runNotifyEffects(inst, props, oldProps, fromAbove, hasPaths) {
+  function runNotifyEffects(inst, props, oldProps, fromAbove, firstFromAbove, hasPaths) {
     // Notify
     let fxs = inst.__notifyEffects;
     if (fxs || hasPaths) {
@@ -211,7 +240,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let id = dedupeId++;
       // Try normal notify effects; if none, fall back to try path notification
       for (let prop in props) {
-        if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, fromAbove, hasPaths)) {
+        // The first flush is `fromAbove: false`, but we avoid notifying props bound from above.
+        // Defaults & constructor assignments are captured in __data.__proto__, and subsequent
+        // values are set into a bag changed from that for differentiation here
+        if (firstFromAbove && fxs[prop] && inst.__data.hasOwnProperty(prop)) {
+          continue;
+        } else if (fxs && runEffectsForProperty(inst, fxs, id, prop, props, oldProps, fromAbove, hasPaths)) {
           notified = true;
         } else if (hasPaths && notifyPath(inst, prop, props)) {
           notified = true;
@@ -390,7 +424,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     if (computeEffects) {
       let inputProps = changedProps;
       let computedProps;
-      while (runEffects(inst, computeEffects, inputProps, fromAbove, hasPaths)) {
+      while (runEffects(inst, computeEffects, inputProps, oldProps, fromAbove, hasPaths)) {
         mixin(oldProps, inst.__dataOld);
         mixin(changedProps, inst.__dataPending);
         computedProps = mixin(computedProps || {}, inst.__dataPending);
@@ -841,6 +875,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (note.bindings) {
           setupCompoundBinding(note, node);
         }
+        // Start capturing pre-bound data to avoid notifications for these properties
+        if (node.__notifyEffects) {
+          node.__dataFirstFromAbove = true;
+          node.__data = Object.create(node.__data);
+        }
       }
     }
     if (inst._bindListeners) {
@@ -1184,6 +1223,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _initializeProperties() {
         super._initializeProperties();
+        hostStack.registerHost(this);
         this.__dataInitialized = false;
         this.__dataPendingClients = null;
         this.__dataFromAbove = false;
@@ -1193,12 +1233,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__dataCompoundStorage = this.__dataCompoundStorage || null;
         this.__dataHost = this.__dataHost || null;
         this.__dataTemp = {};
-        // update instance properties
+        // Capture instance properties; these will be set into accessors
+        // during first flush. Don't set them here, since we want
+        // these to overwrite defaults/constructor assignments
         for (let p in this.__propertyEffects) {
           if (this.hasOwnProperty(p)) {
-            let value = this[p];
+            this.__dataInstanceProps = this.__dataInstanceProps || {};
+            this.__dataInstanceProps[p] = this[p];
             delete this[p];
-            this[p] = value;
           }
         }
       }
@@ -1589,9 +1631,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _flushProperties(fromAbove) {
         if (!this.__dataInitialized) {
-          this.ready();
-        }
-        if (this.__dataPending || this.__dataPendingClients) {
+          this.ready()
+        } else if (this.__dataPending || this.__dataPendingClients) {
           this.__dataFromAbove = fromAbove;
           super._flushProperties();
           if (!this.__dataCounter) {
@@ -1617,7 +1658,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @public
        */
       ready() {
+        // Update instance properties that shadowed proto accessors; these take
+        // priority over any defaults set in `properties` or constructor
+        let props = this.__dataInstanceProps;
+        if (props) {
+          Object.assign(this, props);
+        }
+        // Enable acceessors
         this.__dataInitialized = true;
+        // Run normal flush
+        this._flushProperties();
+        // Stop capturing pre-bound data (cleared in _propertiesChanged, but
+        // this is a backstop in case _flushProperties fast-paths)
+        this.__dataFirstFromAbove = false;
       }
 
       /**
@@ -1639,7 +1692,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _stampTemplate(template) {
+        hostStack.beginHosting(this);
         let dom = super._stampTemplate(template);
+        hostStack.endHosting(this);
         setupBindings(this);
         return dom;
       }
@@ -1655,7 +1710,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _propertiesChanged(currentProps, changedProps, oldProps) {
         let hasPaths = this.__dataHasPaths;
         let fromAbove = this.__dataFromAbove;
-        this.__dataHasPaths = this.__dataFromAbove = false;
+        let firstFromAbove = this.__dataFirstFromAbove;
+        this.__dataHasPaths = this.__dataFromAbove = this.__dataFirstFromAbove = false;
         // ----------------------------
         // let c = Object.getOwnPropertyNames(changedProps || {});
         // window.debug && console.group(this.localName + '#' + this.id + ': ' + c);
@@ -1674,7 +1730,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Observe properties
         runEffects(this, this.__observeEffects, changedProps, oldProps, fromAbove, hasPaths);
         // Notify properties to host
-        runNotifyEffects(this, fromAbove ? computedProps : changedProps, oldProps, fromAbove, hasPaths);
+        let notifyProps = fromAbove ? computedProps : changedProps;
+        runNotifyEffects(this, notifyProps, oldProps, fromAbove, firstFromAbove, hasPaths);
         // ----------------------------
         // window.debug && console.groupEnd(this.localName + '#' + this.id + ': ' + c);
         // ----------------------------

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -339,7 +339,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Handler function for 2-way notification events. Receives context
    * information captured in the `addNotifyListener` closure from the
-   * `_bindListeners` metadata.
+   * `__notifyListeners` metadata.
    *
    * Sets the value of the notified property to the host property or path.  If
    * the event contained path information, translate that path to the host
@@ -801,7 +801,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   /**
-   * Sets up a prototypical `_bindListeners` metadata array to be used at
+   * Sets up a prototypical `__notifyListeners` metadata array to be used at
    * instance time to add event listeners for 2-way bindings.
    *
    * @param {Object} model Prototype (instances not currently supported)
@@ -816,12 +816,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @private
    */
   function addAnnotatedListener(model, index, property, path, event, negate) {
-    if (!model._bindListeners) {
-      model._bindListeners = [];
-    }
     let eventName = event ||
       (CaseMap.camelToDashCase(property) + '-changed');
-    model._bindListeners.push({
+    model.__notifyListeners = model.__notifyListeners || [];
+    model.__notifyListeners.push({
       index: index,
       property: property,
       path: path,
@@ -832,13 +830,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /**
    * Adds all 2-way binding notification listeners to a host based on
-   * `_bindListeners` metadata recorded by prior calls to`addAnnotatedListener`
+   * `__notifyListeners` metadata recorded by prior calls to`addAnnotatedListener`
    *
    * @param {Object} inst Host element instance
    * @private
    */
-  function setupBindListeners(inst) {
-    let b$ = inst._bindListeners;
+  function setupNotifyListeners(inst) {
+    let b$ = inst.__notifyListeners;
     for (let i=0, l=b$.length, info; (i<l) && (info=b$[i]); i++) {
       let node = inst._templateNodes[info.index];
       addNotifyListener(node, inst, info);
@@ -866,8 +864,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
     }
-    if (inst._bindListeners) {
-      setupBindListeners(inst);
+    if (inst.__notifyListeners) {
+      setupNotifyListeners(inst);
     }
   }
 
@@ -2168,6 +2166,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _bindTemplate(template, dynamicFns) {
         // Clear any existing propagation effects inherited from superClass
         this.__propagateEffects = {};
+        this.__notifyListeners = [];
         let notes = this._parseTemplateAnnotations(template);
         processAnnotations(notes);
         for (let i=0, note; (i<notes.length) && (note=notes[i]); i++)  {

--- a/src/utils/templatize.html
+++ b/src/utils/templatize.html
@@ -176,10 +176,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (template.__dataProto) {
           Polymer.mixin(template.__data, template.__dataProto);
         }
-        // Clear any pending data since we're eliding a flush for performance
-        template.__dataOld = {};
+        // Clear any pending data for performance
         template.__dataTemp = {};
-        template.__dataPending = {};
+        template.__dataPending = null;
+        template.__dataOld = null;
+        template._flushProperties(true);
       }
     }
 

--- a/src/utils/templatize.html
+++ b/src/utils/templatize.html
@@ -56,7 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // or when there isn't instance props.
         let options = this.__templatizeOptions;
         if ((props && options.instanceProps) || !options.instanceProps) {
-          this._flushProperties(true);
+          this._flushProperties();
         }
       }
       _configureProperties(props) {
@@ -180,7 +180,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         template.__dataTemp = {};
         template.__dataPending = null;
         template.__dataOld = null;
-        template._flushProperties(true);
+        template._flushProperties();
       }
     }
 

--- a/src/utils/templatize.html
+++ b/src/utils/templatize.html
@@ -64,16 +64,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (props) {
           for (let iprop in options.instanceProps) {
             if (iprop in props) {
-              this[iprop] = props[iprop];
+              this._setPendingProperty(iprop, props[iprop]);
             }
           }
         }
         for (let hprop in this.__hostProps) {
-          this[hprop] = this.__dataHost['_host_' + hprop];
+          this._setPendingProperty(hprop, this.__dataHost['_host_' + hprop]);
         }
       }
       forwardHostProp(prop, value) {
-        if (this._setPendingPropertyOrPath(prop, value, true)) {
+        if (this._setPendingPropertyOrPath(prop, value, false, true)) {
           this.__dataHost._enqueueClient(this);
         }
       }
@@ -212,19 +212,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function createNotifyInstancePropEffect(instProp, userNotifyInstanceProp) {
-      return function notifyInstanceProp(inst, prop, props, oldProps, info, fromAbove) {
-        if (!fromAbove) {
-          userNotifyInstanceProp.call(inst.__templatizeOwner,
-            inst, prop, props[prop]);
-        }
+      return function notifyInstanceProp(inst, prop, props) {
+        userNotifyInstanceProp.call(inst.__templatizeOwner,
+          inst, prop, props[prop]);
       }
     }
 
     function createNotifyHostPropEffect() {
-      return function notifyHostProp(inst, prop, props, oldProps, info, fromAbove) {
-        if (!fromAbove) {
-          inst.__dataHost._setPendingPropertyOrPath('_host_' + prop, props[prop], true);
-        }
+      return function notifyHostProp(inst, prop, props) {
+        inst.__dataHost._setPendingPropertyOrPath('_host_' + prop, props[prop], true, true);
       }
     }
 

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -494,10 +494,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(el.$.lazy.prop, 'foo');
       assert.isTrue(el.$.lazy.propChanged.calledOnce);
       assert.equal(el.$.lazy.readOnlyProp, 'readOnly');
-      // BREAKME(sorvell): attributes deserialized to properties
-      // now override any properties set before upgrade.
-      // This is due to v1 changes to attribute timing.
-      assert.equal(el.$.lazy.hadAttrProp, 'attrValue');
+      assert.equal(el.$.lazy.hadAttrProp, 'foo');
       assert.isTrue(el.$.lazy.hadAttrPropChanged.calledOnce);
       document.body.removeChild(el);
     });

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -327,9 +327,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function testValueAndChangeHandler(e, value) {
     assert.equal(e.content, value, 'Property does not equal configured value');
     assert.equal(e.changeHandlerCount, 1, 'property `change` Change handler not run when default value set');
-    // TODO(sorvell): replace when fromAbove correctly tracks per property.
     assert.equal(e.objectChangeHandlerCount, 1, 'property `object` Change handler not run when default value set');
-    assert.ok(e.objectChangeHandlerCount, 'property `object` Change handler not run when default value set');
   }
 
   function testConfigure(e, value, objectValue) {

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -5083,24 +5083,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(repeater3.itemForElement(stamped1[4]).prop, 'prop-1-1-3');
       });
 
-      test.skip('keyForElement', function() {
-        var dom = unconfigured1.root;
-        var stamped1 = dom.querySelectorAll('*:not(template):not(dom-repeat)');
-        var repeater1 = dom.querySelector('dom-repeat[as=itema]');
-        var repeater2 = dom.querySelector('dom-repeat[as=itemb]');
-        var repeater3 = dom.querySelector('dom-repeat[as=itemc]');
-        var items1 = unconfigured1.items;
-        var items2 = unconfigured1.items[0].items;
-        var items3 = unconfigured1.items[0].items[0].items;
-        var coll1 = Polymer.Collection.from(items1);
-        var coll2 = Polymer.Collection.from(items2);
-        var coll3 = Polymer.Collection.from(items3);
-
-        assert.equal(repeater1.keyForElement(stamped1[4]), coll1.getKey(items1[0]));
-        assert.equal(repeater2.keyForElement(stamped1[4]), coll2.getKey(items2[0]));
-        assert.equal(repeater3.keyForElement(stamped1[4]), coll3.getKey(items3[2]));
-      });
-
       test('renderedItemCount', function() {
          var repeater1 = primitive.$.repeater1;
          primitive.items = [ 'a', 'b', 'c', 'd', 'e' ];

--- a/test/unit/inheritance.html
+++ b/test/unit/inheritance.html
@@ -27,6 +27,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           color: black;
         }
       </style>
+      <!-- dummy nodes with notes be removed by subclass -->
+      <i i=[[i]]></i>
+      <i i=[[i]]></i>
+      <i i=[[i]]></i>
+      <i i=[[i]]></i>
+      <i i=[[i]]></i>
+      <input id="input" value="{{foo::input}}" on-custom="handleCustomEvent">
       <span>base element: <code>foo = [[foo]]</code></span>
     </template>
 
@@ -38,6 +45,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return {
             properties: { foo: { type: String, value: 5 } }
           }
+        }
+        constructor() {
+          super();
+          this.handleCustomEvent = sinon.spy();
         }
       }
       customElements.define(BaseEl.is, BaseEl);
@@ -96,6 +107,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var div = document.createElement('div');
           div.textContent = 'child';
           template.content.appendChild(div);
+          // Move input to the end
+          template.content.appendChild(template.content.querySelector('#input'));
+          // Remove all the <i>'s, such that the total number of nodes in
+          // this template is less than the super
+          Array.from(template.content.querySelectorAll('i'))
+            .forEach(i=>i.parentNode.removeChild(i));
           return template;
         }
       }
@@ -155,13 +172,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(childEl.innerHTML, baseEl.innerHTML);
       }
 
-
       // And it's something that we expect.
       var code = child.shadowRoot.querySelector('code');
       assert.equal(code.innerHTML, 'foo = 5');
 
       // And the base style is the same.
       assert.equal(getComputedStyle(base).color, getComputedStyle(child).color);
+
+      // Id map works as expected
+      assert.equal(child.$.input.localName, 'input');
+      assert.equal(child.$.input.id, 'input');
+
+      // 2-way bindings work as expected
+      child.$.input.value = 'changed';
+      child.$.input.dispatchEvent(new CustomEvent('input'));
+      assert.equal(child.foo, 'changed');
+
+      // Declarative event listeners work as expected
+      assert.equal(child.handleCustomEvent.callCount, 0);
+      child.$.input.dispatchEvent(new CustomEvent('custom'));
+      assert.equal(child.handleCustomEvent.callCount, 1);
     });
 
     test('child with properties has updated base template', function() {
@@ -200,6 +230,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // And the base style is the same.
       assert.equal(getComputedStyle(base).color, getComputedStyle(child).color);
+
+      // Id map works as expected
+      assert.equal(child.$.input.localName, 'input');
+      assert.equal(child.$.input.id, 'input');
+
+      // 2-way bindings work as expected
+      child.$.input.value = 'changed';
+      child.$.input.dispatchEvent(new CustomEvent('input'));
+      assert.equal(child.foo, 'changed');
+
+      // Declarative event listeners work as expected
+      assert.equal(child.handleCustomEvent.callCount, 0);
+      child.$.input.dispatchEvent(new CustomEvent('custom'));
+      assert.equal(child.handleCustomEvent.callCount, 1);
     });
   });
   </script>

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -256,9 +256,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.__foo = foo;
           }
 
-          ready() {
+          _ensureAttributes() {
             this._ensureAttribute('element', 'element');
-            super.ready();
+            super._ensureAttributes();
           }
       });
     });

--- a/test/unit/path-effects-elements.html
+++ b/test/unit/path-effects-elements.html
@@ -5,7 +5,13 @@
       notifyingValue: {
         type: Number,
         notify: true
+      },
+      computed: {
+        computed: 'compute(notifyingValue)'
       }
+    },
+    compute: function(val) {
+      return '[' + val + ']';
     }
   });
 </script>
@@ -22,11 +28,14 @@
         obj: {
           type: Object,
           notify: true
+        },
+        computed: {
+          computed: 'compute(obj.value)'
         }
       },
       observers: [
         'objSubpathChanged(obj.*)',
-        'objValueChanged(obj.value)'
+        'objValueChanged(obj.value)',
       ],
       created: function() {
         this.resetObservers();
@@ -34,6 +43,9 @@
       resetObservers: function() {
         this.objSubpathChanged = sinon.spy();
         this.objValueChanged = sinon.spy();
+      },
+      compute: function(val) {
+        return '[' + val + ']';
       }
     });
   </script>
@@ -50,6 +62,9 @@
         obj: {
           type: Object,
           notify: true
+        },
+        computed: {
+          computed: 'compute(obj.value)'
         }
       },
       observers: [
@@ -65,6 +80,9 @@
         if (this.$) {
           this.$.compose.resetObservers();
         }
+      },
+      compute: function(val) {
+        return '[' + val + ']';
       }
     });
   </script>
@@ -86,6 +104,9 @@
         },
         computedFromPaths: {
           computed: 'computeFromPaths(a, nested.b, nested.obj.c)'
+        },
+        computed: {
+          computed: 'compute(nested.obj.value)'
         }
       },
       observers: [
@@ -132,6 +153,9 @@
       },
       computeFromPaths: function(a, b, c) {
         return a + b + c;
+      },
+      compute: function(val) {
+        return '[' + val + ']';
       }
     });
   </script>
@@ -159,7 +183,7 @@
 </script>
 
 <dom-module id="x-reentry-host">
-  <template> 
+  <template>
     <x-reentry-client obj="{{obj}}" prop="{{prop}}"></x-reentry-client>
   </template>
   <script>
@@ -192,7 +216,7 @@
 </script>
 
 <dom-module id="x-path-host">
-  <template> 
+  <template>
     <x-path-client id="client" obj="{{obj}}"></x-path-client>
   </template>
   <script>

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -50,6 +50,7 @@ suite('basic path bindings', function() {
   });
 
   function verifyObserverOutput(nestingLevel, nested) {
+    assert.equal(el.computed, '[' + nested.obj.value + ']');
     assert.equal(el.nestedChanged.callCount, nestingLevel == 0 ? 1 : 0);
     if (nestingLevel == 0) {
       assert.equal(el.nestedChanged.firstCall.args[0], nested);
@@ -65,19 +66,26 @@ suite('basic path bindings', function() {
     assert.equal(el.nestedObjValueChanged.firstCall.args[0], nested.obj.value);
     assert.equal(el.nestedSubpathChanged.callCount, 1);
     assert.equal(el.nestedSubpathChanged.firstCall.args[0].base, nested);
+    assert.equal(el.$.compose.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.compose.objSubpathChanged.callCount, 1);
     assert.equal(el.$.compose.objSubpathChanged.firstCall.args[0].base, nested.obj);
     assert.equal(el.$.compose.objValueChanged.callCount, 1);
     assert.equal(el.$.compose.objValueChanged.firstCall.args[0], nested.obj.value);
+    assert.equal(el.$.forward.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.forward.objSubpathChanged.callCount, 1);
     assert.equal(el.$.forward.objSubpathChanged.firstCall.args[0].base, nested.obj);
     assert.equal(el.$.forward.objValueChanged.callCount, 1);
     assert.equal(el.$.forward.objValueChanged.firstCall.args[0], nested.obj.value);
+    assert.equal(el.$.basic.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.basic.notifyingValue, 42);
     assert.equal(el.$.basic.notifyingValue, 42);
+    assert.equal(el.$.compose.$.basic1.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.compose.$.basic1.notifyingValue, 42);
+    assert.equal(el.$.compose.$.basic2.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.compose.$.basic2.notifyingValue, 42);
+    assert.equal(el.$.forward.$.compose.$.basic1.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.forward.$.compose.$.basic1.notifyingValue, 42);
+    assert.equal(el.$.forward.$.compose.$.basic2.computed, '[' + nested.obj.value + ']');
     assert.equal(el.$.forward.$.compose.$.basic2.notifyingValue, 42);
     assert.equal(el.$.basic.getAttribute('attrvalue'), '42');
     assert.equal(el.$.compose.$.basic1.getAttribute('attrvalue'), '42');
@@ -411,9 +419,10 @@ suite('path effects', function() {
         c: 66
       }
     };
+    var a = 1;
     // Do the thing
     el.setProperties({
-      a: 1,
+      a: a,
       nested: nested
     })
     // Verify
@@ -423,6 +432,15 @@ suite('path effects', function() {
     assert.equal(el.multiplePathsChanged.firstCall.args[2], 66);
     assert.equal(el.computedFromPaths, 100);
     assert.equal(el.$.boundChild.computedFromPaths, 100);
+
+    el.set('a', a + 10);
+    assert.equal(el.$.boundChild.computedFromPaths, 110);
+
+    el.set('nested.b', nested.b + 10);
+    assert.equal(el.$.boundChild.computedFromPaths, 120);
+
+    el.set('nested.obj.c', nested.obj.c + 10);
+    assert.equal(el.$.boundChild.computedFromPaths, 130);
   });
 
   test('array.splices notified', function() {

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -561,17 +561,6 @@ suite('2-way binding effects between elements', function() {
     assert.equal(el.boundreadonlyvalue, 46, 'property bound to read-only property should change from change to bound value');
   });
 
-  // TODO(kschaaf): want to avoid firing notifying events from
-  // bound hosts when unnecessary
-  test.skip('listener for value-changed fires when value changed from host', function() {
-    var listener = sinon.spy();
-    el.$.basic1.addEventListener('notifyingvalue-changed', listener);
-    el.boundnotifyingvalue = 678;
-    assert.equal(el.$.basic1.notifyingvalue, 678);
-    assert.isTrue(listener.calledOnce);
-    assert.equal(listener.getCalls()[0].args[0].detail.value, 678);
-  });
-
   test('negated binding update negates value for parent', function() {
     assert.equal(el.negatedValue, false);
     assert.equal(el.$.basic4.notifyingvalue, true);

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -884,7 +884,7 @@ HTMLImports.whenReady(function() {
         assertComputed(styledWide.$.priority, '1px');
       });
 
-      test.skip('styles shimmed in registration order', function() {
+      test('styles shimmed in registration order', function() {
         var regList = customElements.defineOrder;
         function regIndex(styleScope) {
           for (var i=0, r; (r=regList[i]); i++) {


### PR DESCRIPTION
* Data pre-bound to notifying properties at startup will no longer notify (maintain 1.0 perf optimization)
* Ensure properties set on instance before upgrade take precedence over attributes/defaults
* Remove fromAbove in flush. Add shouldNotify in setPendingProperty.
* Fix arguments to `runComputedEffects` Fixes #4329
* Clear __notifyListeners when binding template. Fixes #4098.