### PR TITLE
Only add event.model for instances that introduce scoped instance props

### DIFF
--- a/src/elements/dom-repeat.html
+++ b/src/elements/dom-repeat.html
@@ -315,6 +315,7 @@ Then the `observe` property should be configured as follows:
         instanceProps[this.indexAs] = true;
         instanceProps[this.itemsIndexAs] = true;
         this.__ctor = Polymer.Templatize.templatize(template, this, {
+          parentModel: true,
           instanceProps: instanceProps,
           forwardHostProp: function(prop, value) {
             var i$ = this.__instances;

--- a/src/legacy/templatizer-behavior.html
+++ b/src/legacy/templatizer-behavior.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       templatize(template) {
         this._templatizerTemplate = template;
         this.ctor = Polymer.Templatize.templatize(template, this, {
+          parentModel: this._parentModel,
           instanceProps: this._instanceProps,
           forwardHostProp: this._forwardHostPropV2,
           notifyInstanceProp: this._notifyInstancePropV2

--- a/src/utils/templatize.html
+++ b/src/utils/templatize.html
@@ -78,11 +78,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       _addEventListenerToNode(node, eventName, handler) {
-        if (this._methodHost) {
+        if (this._methodHost && this.__templatizeOptions.instanceProps) {
+          // If this instance adds instance props, decorate events with
+          // `model` as this template instance
           this._methodHost._addEventListenerToNode(node, eventName, (e) => {
             e.model = this;
             handler(e);
           });
+        } else {
+          // Otherwise delegate to the template's host (which could be)
+          // another template instance
+          let templateHost = this.__dataHost.__dataHost;
+          if (templateHost) {
+            templateHost._addEventListenerToNode(node, eventName, handler);
+          }
         }
       }
       _showHideChildren(hide) {

--- a/src/utils/templatize.html
+++ b/src/utils/templatize.html
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let children = this.children = [];
         for (let n = this.root.firstChild; n; n=n.nextSibling) {
           children.push(n);
-          n._templateInstance = this;
+          n.__templatizeInstance = this;
         }
         if (this.__templatizeOwner.__hideTemplateChildren__) {
           this._showHideChildren(true);
@@ -78,9 +78,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       _addEventListenerToNode(node, eventName, handler) {
-        if (this._methodHost && this.__templatizeOptions.instanceProps) {
-          // If this instance adds instance props, decorate events with
-          // `model` as this template instance
+        if (this._methodHost && this.__templatizeOptions.parentModel) {
+          // If this instance should be considered a parent model, decorate
+          // events this template instance as `model`
           this._methodHost._addEventListenerToNode(node, eventName, (e) => {
             e.model = this;
             handler(e);
@@ -136,6 +136,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           super._setUnmanagedPropertyToNode(node, prop, value);
         }
+      }
+      /**
+       * Find the parent model of this template instance.  The parent model
+       * is either another templatize instance that had option `parentModel: true`,
+       * or else the host element.
+       *
+       * @return {Polymer.PropertyEffectsInterface} The parent model of this instance
+       */
+      get parentModel() {
+        let model = this.__parentModel;
+        if (!model) {
+          let options;
+          model = this
+          do {
+            // A template instance's `__dataHost` is a <template>
+            // `model.__dataHost.__dataHost` is the template's host
+            model = model.__dataHost.__dataHost;
+          } while ((options = model.__templatizeOptions) && !options.parentModel)
+          this.__parentModel = model;
+        }
+        return model;
       }
     }
 
@@ -281,10 +302,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       modelForElement(host, el) {
         let model;
         while (el) {
-          // An element with a _templateInstance marks the top boundary
+          // An element with a __templatizeInstance marks the top boundary
           // of a scope; walk up until we find one, and then ensure that
           // its __dataHost matches `this`, meaning this dom-repeat stamped it
-          if ((model = el._templateInstance)) {
+          if ((model = el.__templatizeInstance)) {
             // Found an element stamped by another template; keep walking up
             // from its __dataHost
             if (model.__dataHost != host) {
@@ -294,7 +315,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           } else {
             // Still in a template scope, keep going up until
-            // a _templateInstance is found
+            // a __templatizeInstance is found
             el = el.parentNode;
           }
         }

--- a/test/unit/dom-repeat-elements.html
+++ b/test/unit/dom-repeat-elements.html
@@ -472,3 +472,34 @@ window.data = [
     });
   </script>
 </dom-module>
+
+<dom-module id="x-repeat-with-if">
+  <template>
+    <template is="dom-repeat" items="{{items}}" id="outer">
+      <template is="dom-if" if>
+        <template is="dom-repeat" items="{{item.items}}" id="inner">
+          <template is="dom-if" if>
+            <button on-click="handleClick">{{item.prop}}</button>
+          </template>
+        </template>
+      </template>
+    </template>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-repeat-with-if',
+      properties: {
+        items: {
+          value: () => [
+            {items: [{prop:'a'}, {prop: 'b'}]},
+            {items: [{prop:'c'}, {prop: 'd'}]}
+          ]
+        }
+      },
+      created() {
+        // cache target so it's available in spy after event stack returns
+        this.handleClick = sinon.spy((event) => event._target = event.target);
+      }
+    });
+  </script>
+</dom-module>

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -5064,7 +5064,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.body.appendChild(el);
         Polymer.flush();
         let buttons = el.shadowRoot.querySelectorAll('button');
-        let outer = el.shadowRoot.getElementById('outer');
+        let outer = el.shadowRoot.querySelector('#outer');
         let event;
 
         // First

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -5059,6 +5059,57 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(model.itemc.prop, 'prop-1-1-3');
       });
 
+      test('event.model', function() {
+        let el = document.createElement('x-repeat-with-if');
+        document.body.appendChild(el);
+        Polymer.flush();
+        let buttons = el.shadowRoot.querySelectorAll('button');
+        let outer = el.shadowRoot.getElementById('outer');
+        let event;
+
+        // First
+        assert.equal(buttons[0].textContent, 'a');
+        buttons[0].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        assert.equal(el.handleClick.callCount, 1);
+        event = el.handleClick.getCalls()[0].args[0];
+        assert.equal(event._target, buttons[0]);
+        assert.equal(event.model.item, el.items[0].items[0]);
+        assert.equal(event.model.item.prop, 'a');
+        assert.equal(outer.modelForElement(event._target).item, el.items[0]);
+
+        // Second
+        assert.equal(buttons[1].textContent, 'b');
+        buttons[1].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        assert.equal(el.handleClick.callCount, 2);
+        event = el.handleClick.getCalls()[1].args[0];
+        assert.equal(event._target, buttons[1]);
+        assert.equal(event.model.item, el.items[0].items[1]);
+        assert.equal(event.model.item.prop, 'b');
+        assert.equal(outer.modelForElement(event._target).item, el.items[0]);
+
+        // Third
+        assert.equal(buttons[2].textContent, 'c');
+        buttons[2].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        assert.equal(el.handleClick.callCount, 3);
+        event = el.handleClick.getCalls()[2].args[0];
+        assert.equal(event._target, buttons[2]);
+        assert.equal(event.model.item, el.items[1].items[0]);
+        assert.equal(event.model.item.prop, 'c');
+        assert.equal(outer.modelForElement(event._target).item, el.items[1]);
+
+        // Fourth
+        assert.equal(buttons[3].textContent, 'd');
+        buttons[3].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        assert.equal(el.handleClick.callCount, 4);
+        event = el.handleClick.getCalls()[3].args[0];
+        assert.equal(event._target, buttons[3]);
+        assert.equal(event.model.item, el.items[1].items[1]);
+        assert.equal(event.model.item.prop, 'd');
+        assert.equal(outer.modelForElement(event._target).item, el.items[1]);
+
+        document.body.removeChild(el);
+      });
+
       test('indexForElement', function() {
         var dom = unconfigured1.root;
         var stamped1 = dom.querySelectorAll('*:not(template):not(dom-repeat)');

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -5076,6 +5076,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event.model.item, el.items[0].items[0]);
         assert.equal(event.model.item.prop, 'a');
         assert.equal(event.model.parentModel.item, el.items[0]);
+        assert.equal(event.model.parentModel.parentModel, el);
         assert.equal(outer.modelForElement(event._target).item, el.items[0]);
 
         // Second
@@ -5087,6 +5088,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event.model.item, el.items[0].items[1]);
         assert.equal(event.model.item.prop, 'b');
         assert.equal(event.model.parentModel.item, el.items[0]);
+        assert.equal(event.model.parentModel.parentModel, el);
         assert.equal(outer.modelForElement(event._target).item, el.items[0]);
 
         // Third
@@ -5098,6 +5100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event.model.item, el.items[1].items[0]);
         assert.equal(event.model.item.prop, 'c');
         assert.equal(event.model.parentModel.item, el.items[1]);
+        assert.equal(event.model.parentModel.parentModel, el);
         assert.equal(outer.modelForElement(event._target).item, el.items[1]);
 
         // Fourth
@@ -5109,6 +5112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event.model.item, el.items[1].items[1]);
         assert.equal(event.model.item.prop, 'd');
         assert.equal(event.model.parentModel.item, el.items[1]);
+        assert.equal(event.model.parentModel.parentModel, el);
         assert.equal(outer.modelForElement(event._target).item, el.items[1]);
 
         document.body.removeChild(el);

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -5059,7 +5059,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(model.itemc.prop, 'prop-1-1-3');
       });
 
-      test('event.model', function() {
+      test('event.model && parentModel', function() {
         let el = document.createElement('x-repeat-with-if');
         document.body.appendChild(el);
         Polymer.flush();
@@ -5075,6 +5075,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event._target, buttons[0]);
         assert.equal(event.model.item, el.items[0].items[0]);
         assert.equal(event.model.item.prop, 'a');
+        assert.equal(event.model.parentModel.item, el.items[0]);
         assert.equal(outer.modelForElement(event._target).item, el.items[0]);
 
         // Second
@@ -5085,6 +5086,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event._target, buttons[1]);
         assert.equal(event.model.item, el.items[0].items[1]);
         assert.equal(event.model.item.prop, 'b');
+        assert.equal(event.model.parentModel.item, el.items[0]);
         assert.equal(outer.modelForElement(event._target).item, el.items[0]);
 
         // Third
@@ -5095,6 +5097,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event._target, buttons[2]);
         assert.equal(event.model.item, el.items[1].items[0]);
         assert.equal(event.model.item.prop, 'c');
+        assert.equal(event.model.parentModel.item, el.items[1]);
         assert.equal(outer.modelForElement(event._target).item, el.items[1]);
 
         // Fourth
@@ -5105,6 +5108,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(event._target, buttons[3]);
         assert.equal(event.model.item, el.items[1].items[1]);
         assert.equal(event.model.item.prop, 'd');
+        assert.equal(event.model.parentModel.item, el.items[1]);
         assert.equal(outer.modelForElement(event._target).item, el.items[1]);
 
         document.body.removeChild(el);

--- a/test/unit/templatize-elements.html
+++ b/test/unit/templatize-elements.html
@@ -102,6 +102,7 @@
     go: function(withProps) {
       var template = this.querySelector('template');
       var ctor = Polymer.Templatize.templatize(template, this, {
+        parentModel: true,
         instanceProps: {
           obj: true,
           prop: true,
@@ -154,6 +155,7 @@
         this.instance.notifyPath(info.path, info.value);
       }
     },
+    _parentModel: true,
     _instanceProps: {
       obj: true,
       prop: true,

--- a/test/unit/templatize.html
+++ b/test/unit/templatize.html
@@ -147,6 +147,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(event.model.outerProp, 'foo');
       host.outerProp = 'bar';
       assert.equal(event.model.outerProp, 'bar');
+      assert.equal(event.model.parentModel, host);
     });
 
   });


### PR DESCRIPTION
Delegate `_addEventListenerToNode` if the instance didn't mark itself as a `parentModel` in templatizer options (e.g. `dom-if` instances with no instance props do not form a useful `e.model`, so `parentNode` is not set for `dom-if`, allowing these instances to be skipped).  This ensures `dom-if` instances never shadow a `dom-repeat`'s model on the event.

This also improves on the 1.x API in that `event.model.parentModel` points to any outer template model, or the element host.

Fixes #4170 