### PR TITLE
Treat `null` as a primitive for dirty-checking purposes. Fixes #4208

### DIFF
--- a/src/mixins/property-accessors.html
+++ b/src/mixins/property-accessors.html
@@ -445,7 +445,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _shouldPropertyChange(property, value, old) {
         return (
-          // Strict equality check for primitives
+          // Strict equality check
           (old !== value &&
            // This ensures (old==NaN, value==NaN) always returns false
            (old === old || value === value))

--- a/src/mixins/property-effects.html
+++ b/src/mixins/property-effects.html
@@ -1543,7 +1543,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {boolean}
        */
       _shouldPropertyChange(property, value, old) {
-        if (typeof value == 'object') {
+        // Pull `old` for Objects from temp cache, but treat `null` as a primitive
+        if (typeof value == 'object' && value !== null) {
           old = this.__dataTemp[property];
         }
         return super._shouldPropertyChange(property, value, old);

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -93,6 +93,23 @@ suite('single-element binding effects', function() {
     assert.equal(el.observerCounts.valueChanged, 2, 'observer not called after property change');
   });
 
+  test('observer called only once for null', function() {
+    el.clearObserverCounts();
+    assert.equal(el.observerCounts.valueChanged, 0);
+    el.value = {};
+    assert.equal(el.observerCounts.valueChanged, 1);
+    el.value = null;
+    assert.equal(el.observerCounts.valueChanged, 2);
+    el.value = null;
+    assert.equal(el.observerCounts.valueChanged, 2);
+    el.value = {};
+    assert.equal(el.observerCounts.valueChanged, 3);
+    el.value = null;
+    assert.equal(el.observerCounts.valueChanged, 4);
+    el.value = null;
+    assert.equal(el.observerCounts.valueChanged, 4);
+  });
+
   test('computed value updates', function() {
     el.value = 44;
     assert.equal(el.computedvalue, 45, 'Computed value not correct');


### PR DESCRIPTION
Fixes #4208