### PR TITLE
Improve importHref()

### DIFF
--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -400,7 +400,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         link = document.createElement('link');
         link.rel = 'import';
         link.href = href;
-        link.__loaded = false;
 
         if (optAsync) {
           link.setAttribute('async', '');

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -388,8 +388,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // In case of an error, remove the link from the document so that it
         // will be automatically created again the next time `importHref` is
         // called.
-        link.__loaded = true;
-        link.__error = true;
         if(link.parentNode) {
           document.head.removeChild(link);
         }

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -375,7 +375,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // In case of a successful load, cache the load event on the link so
         // that it can be used to short-circuit this method in the future when
         // it is called with the same href param.
-        link.__dynamicImportLoaded = true;
+
+        link.__loaded = true;
+        link.__error = false;
         if (onload != null) {
           return onload.call(self, event);
         }
@@ -386,7 +388,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // In case of an error, remove the link from the document so that it
         // will be automatically created again the next time `importHref` is
         // called.
-        document.head.removeChild(link);
+        link.__loaded = true;
+        link.__error = true;
+        if(link.parentNode) {
+          document.head.removeChild(link);
+        }
         if (onerror != null) {
           return onerror.call(self, event);
         }
@@ -396,24 +402,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         link = document.createElement('link');
         link.rel = 'import';
         link.href = href;
+        link.__loaded = false;
 
         if (optAsync) {
           link.setAttribute('async', '');
         }
-
-        link.addEventListener('load', loadListener);
-        link.addEventListener('error', errorListener);
-
         document.head.appendChild(link);
       }
+
+      link.addEventListener('load', loadListener);
+      link.addEventListener('error', errorListener);
 
       function cleanup() {
         link.removeEventListener('load', loadListener);
         link.removeEventListener('error', errorListener);
       }
 
-      if (link.__dynamicImportLoaded && (onload != null)) {
-        onload.call(self, event);
+      if (link.__error === true) {
+        link.dispatchEvent(new Event('error'));
+      } else if (link.__loaded === true && (link.import !== null)) {
+        link.dispatchEvent(new Event('load'));
       }
 
       return link;

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -374,10 +374,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         link = document.createElement('link');
         link.rel = 'import';
         link.__dynamicImport = true;
-      }
 
-      if (optAsync) {
-        link.setAttribute('async', '');
+        if (optAsync) {
+          link.setAttribute('async', '');
+        }
       }
 
       var loadListener = function(event) {

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -376,7 +376,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // that it can be used to short-circuit this method in the future when
         // it is called with the same href param.
         link.__dynamicImportLoaded = true;
-
         if (onload != null) {
           return onload.call(self, event);
         }
@@ -396,6 +395,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (link == null) {
         link = document.createElement('link');
         link.rel = 'import';
+        link.href = href;
 
         if (optAsync) {
           link.setAttribute('async', '');
@@ -403,6 +403,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         link.addEventListener('load', loadListener);
         link.addEventListener('error', errorListener);
+
+        document.head.appendChild(link);
       }
 
       function cleanup() {
@@ -410,13 +412,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         link.removeEventListener('error', errorListener);
       }
 
-      if (link.parentNode == null) {
-        link.href = href;
-        document.head.appendChild(link);
-      } else if (link.__dynamicImportLoaded || !link.__dynamicImport) {
-        if (onload != null) {
-          return onload.call(self, event);
-        }
+      if (link.__dynamicImportLoaded && (onload != null)) {
+        onload.call(self, event);
       }
 
       return link;

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -367,50 +367,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {HTMLLinkElement} The link element for the URL to be loaded.
      */
     importHref: function(href, onload, onerror, optAsync) {
-      var link = document.createElement('link');
-      link.rel = 'import';
-      link.href = href;
-      var list = Polymer.Base.importHref.imported = 
-        Polymer.Base.importHref.imported || {};
-      var cached = list[link.href];
-      var imprt = cached || link;
+      var link = document.head.querySelector('[href="' + href + '"]');
       var self = this;
-      var loadListener = function(e) {
-        e.target.__firedLoad = true;
-        e.target.removeEventListener('load', loadListener);
-        e.target.removeEventListener('error', errorListener);
-        return onload.call(self, e);
-      };
-      var errorListener = function(e) {
-        e.target.__firedError = true;
-        e.target.removeEventListener('load', loadListener);
-        e.target.removeEventListener('error', errorListener);
-        return onerror.call(self, e);
-      };
-      if (onload) {
-        imprt.addEventListener('load', loadListener);
+
+      if (link == null) {
+        link = document.createElement('link');
+        link.rel = 'import';
+        link.__dynamicImport = true;
       }
-      if (onerror) {
-        imprt.addEventListener('error', errorListener);
+
+      if (optAsync) {
+        link.setAttribute('async', '');
       }
-      // if already loaded/erroed, fire 'fake' load/error event
-      if (cached) {
-        if (cached.__firedLoad) {
-          cached.dispatchEvent(new Event('load'));
+
+      var loadListener = function(event) {
+        link.removeEventListener('load', loadListener);
+        link.removeEventListener('error', errorListener);
+        // In case of a successful load, cache the load event on the link so
+        // that it can be used to short-circuit this method in the future when
+        // it is called with the same href param.
+        link.__dynamicImportLoaded = true;
+
+        if (onload != null) {
+          return onload.call(self, event);
         }
-        if (cached.__firedError) {
-          cached.dispatchEvent(new Event('error'));
+      };
+      var errorListener = function(event) {
+        link.removeEventListener('load', loadListener);
+        link.removeEventListener('error', errorListener);
+        // In case of an error, remove the link from the document so that it
+        // will be automatically created again the next time `importHref` is
+        // called.
+        document.head.removeChild(link);
+        if (onerror != null) {
+          return onerror.call(self, event);
         }
-      // otherwise put in dom!
-      } else {
-        list[link.href] = link;
-        optAsync = Boolean(optAsync);
-        if (optAsync) {
-          link.setAttribute('async', '');
-        }
+      };
+
+      link.addEventListener('load', loadListener);
+      link.addEventListener('error', errorListener);
+
+      if (link.parentNode == null) {
+        link.href = href;
         document.head.appendChild(link);
+      } else if (link.__dynamicImportLoaded || !link.__dynamicImport) {
+        link.dispatchEvent(new Event('load'));
       }
-      return imprt;
+
+      return link;
     },
 
     /**
@@ -460,17 +464,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /*
     We patch importHref under the CE polyfill for 2 separate reasons:
     (1) performance optimization: CE registrations upgrade the entire document
-    tree including imports. Therefore if an import is loaded every element 
-    registered will upgrade the entire doc tree. This is $ and is optimized 
+    tree including imports. Therefore if an import is loaded every element
+    registered will upgrade the entire doc tree. This is $ and is optimized
     via batching to occur once at startup (before WebComponentsReady). We
-    override importHref here so that we can batch upgrades until after the 
+    override importHref here so that we can batch upgrades until after the
     import has loded, leveraging the same batching optimization.
     (2) the CE polyfill upgrades elements in HI in the wrong order. They upgrade
-    after all scripts in the import have run rather than being interleaved with 
-    them. Therefore, any script that depends on a previous custom element in 
+    after all scripts in the import have run rather than being interleaved with
+    them. Therefore, any script that depends on a previous custom element in
     the import will fail. By deferring upgrades until after async imports load
-    we reduce the chance of a problem because upgrade time dependencies are 
-    no longer an issue. (e.g. `dom-module` is a registration time dependency 
+    we reduce the chance of a problem because upgrade time dependencies are
+    no longer an issue. (e.g. `dom-module` is a registration time dependency
     when `lazyRegister` is not used and it is specially handled in `dom-module`;
     `custom-style` is an upgrade time dependency native css properties are used).
 

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -370,16 +370,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var link = document.head.querySelector('[href="' + href + '"]');
       var self = this;
 
-      if (link == null) {
-        link = document.createElement('link');
-        link.rel = 'import';
-        link.__dynamicImport = true;
-
-        if (optAsync) {
-          link.setAttribute('async', '');
-        }
-      }
-
       var loadListener = function(event) {
         cleanup();
         // In case of a successful load, cache the load event on the link so
@@ -391,6 +381,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return onload.call(self, event);
         }
       };
+
       var errorListener = function(event) {
         cleanup();
         // In case of an error, remove the link from the document so that it
@@ -402,19 +393,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       };
 
+      if (link == null) {
+        link = document.createElement('link');
+        link.rel = 'import';
+
+        if (optAsync) {
+          link.setAttribute('async', '');
+        }
+
+        link.addEventListener('load', loadListener);
+        link.addEventListener('error', errorListener);
+      }
+
       function cleanup() {
         link.removeEventListener('load', loadListener);
         link.removeEventListener('error', errorListener);
       }
 
-      link.addEventListener('load', loadListener);
-      link.addEventListener('error', errorListener);
-
       if (link.parentNode == null) {
         link.href = href;
         document.head.appendChild(link);
       } else if (link.__dynamicImportLoaded || !link.__dynamicImport) {
-        link.dispatchEvent(new Event('load'));
+        if (onload != null) {
+          return onload.call(self, event);
+        }
       }
 
       return link;

--- a/src/standard/utils.html
+++ b/src/standard/utils.html
@@ -381,8 +381,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       var loadListener = function(event) {
-        link.removeEventListener('load', loadListener);
-        link.removeEventListener('error', errorListener);
+        cleanup();
         // In case of a successful load, cache the load event on the link so
         // that it can be used to short-circuit this method in the future when
         // it is called with the same href param.
@@ -393,8 +392,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       };
       var errorListener = function(event) {
-        link.removeEventListener('load', loadListener);
-        link.removeEventListener('error', errorListener);
+        cleanup();
         // In case of an error, remove the link from the document so that it
         // will be automatically created again the next time `importHref` is
         // called.
@@ -403,6 +401,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return onerror.call(self, event);
         }
       };
+
+      function cleanup() {
+        link.removeEventListener('load', loadListener);
+        link.removeEventListener('error', errorListener);
+      }
 
       link.addEventListener('load', loadListener);
       link.addEventListener('error', errorListener);

--- a/test/unit/dynamic-import.html
+++ b/test/unit/dynamic-import.html
@@ -40,6 +40,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       var url = 'dynamic-imports/dynamic-element.html';
 
+      test('importHref does not cache failed results', function(done) {
+        Polymer.Base.importHref('does_not_exist.html', function() {
+          throw new Error('Load handler should not be called.');
+        }, function() {
+          var link = document.head
+              .querySelector('[href="does_not_exist.html"]');
+          assert.isNotOk(link, 'The link should not exist');
+          done();
+        });
+      });
+
+      test('importHref caches successful results', function(done) {
+        var targetUrl = 'dynamic-imports/async-import.html';
+
+        Polymer.Base.importHref(targetUrl, function(event) {
+          var targetOne = event.target;
+          Polymer.Base.importHref(targetUrl, function(event) {
+            var targetTwo = event.target;
+
+            assert.isOk(targetOne, 'Event target should be available');
+            assert.strictEqual(targetOne, targetTwo,
+                'Link element references should be identical');
+            done();
+          }, done);
+        }, done);
+      });
+
       test('importHref sync loads by default', function(done) {
         Polymer.Base.importHref(url, function(e) {
           assert.isFalse(e.target.hasAttribute('async'),

--- a/test/unit/dynamic-import.html
+++ b/test/unit/dynamic-import.html
@@ -38,44 +38,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('async/sync loading', function() {
 
-      var url = 'dynamic-imports/dynamic-element.html';
+      test('importHref sync loads by default', function() {
+        var url = 'dynamic-imports/dynamic-element.html';
 
-      test('importHref does not cache failed results', function(done) {
-        Polymer.Base.importHref('does_not_exist.html', function() {
-          throw new Error('Load handler should not be called.');
-        }, function() {
-          var link = document.head
-              .querySelector('[href="does_not_exist.html"]');
-          assert.isNotOk(link, 'The link should not exist');
-          done();
-        });
-      });
+        var link = document.createElement('link');
+        link.rel = 'import';
+        link.href = url;
 
-      test('importHref caches successful results', function(done) {
-        var targetUrl = 'dynamic-imports/async-import.html';
-
-        Polymer.Base.importHref(targetUrl, function(event) {
-          var targetOne = event.target;
-          Polymer.Base.importHref(targetUrl, function(event) {
-            var targetTwo = event.target;
-
-            assert.isOk(targetOne, 'Event target should be available');
-            assert.strictEqual(targetOne, targetTwo,
-                'Link element references should be identical');
-            done();
-          }, done);
-        }, done);
-      });
-
-      test('importHref sync loads by default', function(done) {
-        Polymer.Base.importHref(url, function(e) {
-          assert.isFalse(e.target.hasAttribute('async'),
-                        'sync load is default');
-          done();
-        });
+        Polymer.Base.importHref(url);
+        var el = document.querySelector('link[href="' + url + '"]');
+        assert.isFalse(el.hasAttribute('async'), 'sync load is default');
       });
 
       test('importHref sync called again, triggers load', function(done) {
+        var url = 'dynamic-imports/sync-twice.html';
+
         Polymer.Base.importHref(url, function() {
           Polymer.Base.importHref(url, function() {
             done();
@@ -94,36 +71,117 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('importHref does not leak event listeners on load', function(done) {
         var errorSpy = sinon.spy();
-        var loadSpy = sinon.spy(function(e) {
-          var target = e.target;
-          target.dispatchEvent(new Event('error'));
-          assert.isFalse(errorSpy.called, 'doesn\'t trigger the error event listener');
-          setTimeout(function() {
-            loadSpy.reset();
-            target.dispatchEvent(new Event('load'));
-            assert.isFalse(loadSpy.called, 'doesn\'t trigger the load event listener');
-            done();
+        var createLoadSpy = function() {
+          var loadSpy = sinon.spy.create(function(e, target) {
+            target = e.target || target;
+            target.dispatchEvent(new Event('error'));
+            assert.isFalse(errorSpy.called, 'doesn\'t trigger the error event listener');
+            setTimeout(function() {
+              loadSpy.reset();
+              target.dispatchEvent(new Event('load'), target);
+              assert.isFalse(loadSpy.called, 'doesn\'t trigger the load event listener');
+              done();
+            });
           });
-        });
-
-        Polymer.Base.importHref('dynamic-imports/async-import.html', loadSpy, errorSpy, true);
+          return loadSpy;
+        }
+        Polymer.Base.importHref('dynamic-imports/async-import.html', createLoadSpy(), errorSpy, true);
       });
 
       test('importHref does not leak event listeners on error', function(done) {
         var loadSpy = sinon.spy();
-        var errorSpy = sinon.spy(function(e) {
-          var target = e.target;
-          target.dispatchEvent(new Event('load'));
-          assert.isFalse(loadSpy.called, 'doesn\'t trigger the load event listener');
-          setTimeout(function() {
-            errorSpy.reset();
-            target.dispatchEvent(new Event('error'));
-            assert.isFalse(errorSpy.called, 'doesn\'t trigger the error event listener');
+        var createErrorSpy = function() {
+          var errorSpy = sinon.spy(function(e, target) {
+            target = e.target || target;
+            target.dispatchEvent(new Event('load'));
+            assert.isFalse(loadSpy.called, 'doesn\'t trigger the load event listener');
+            setTimeout(function() {
+              errorSpy.reset();
+              target.dispatchEvent(new Event('error'));
+              assert.isFalse(errorSpy.called, 'doesn\'t trigger the error event listener');
+              done();
+            });
+          });
+          return errorSpy;
+        }
+
+        Polymer.Base.importHref('dynamic-imports/async-import-invalid.html', loadSpy, createErrorSpy(), true);
+      });
+
+      test('trigger load event of the second request of a resource when loading was not complete yet', function(done) {
+        var url = 'dynamic-imports/dynamic-notready.html'
+        Polymer.Base.importHref(url);
+        Polymer.Base.importHref(url, function() {
+          done();
+        });
+      });
+
+      test('trigger load event of the second request of a resource when loading was already completed', function(done) {
+        var url = 'dynamic-imports/dynamic-lazy.html';
+        var imprt = Polymer.Base.importHref(url);
+
+        var onLoad = function() {
+          imprt.removeEventListener('load', onLoad);
+          Polymer.Base.importHref(url, function() {
             done();
           });
-        });
+        }
 
-        Polymer.Base.importHref('dynamic-imports/async-import-invalid.html', loadSpy, errorSpy, true);
+        imprt.addEventListener('load', onLoad);        
+      });
+
+      test('triggers the callback only once even when the element was requested again later', function(done) {
+        var url = 'dynamic-imports/dynamic-once.html';
+        var count = 0;
+        Polymer.Base.importHref(url, function() {
+          count++;
+          if(count === 1) {
+            Polymer.Base.importHref(url, function() {
+              setTimeout(function() {
+                assert.equal(count, 1, 'the first callback should only be called once');
+                done();
+              }, 0);
+            });
+          }
+        });
+      });
+
+      test('importHref does not cache failed results', function(done) {
+
+        var a, b;
+
+        a = Polymer.Base.importHref('does_not_exist.html', function() {
+          throw new Error('Load handler should not be called.');
+        }, function() {
+          b = Polymer.Base.importHref('does_not_exist.html', function() {
+            throw new Error('Load handler should still not be called.');
+          }, function() {
+
+            setTimeout(function() {
+              assert.notEqual(a, b);
+              done();
+            }, 0);
+
+          });
+          
+        });
+      });
+
+      test('importHref does cache successful results', function(done) {
+
+        var url = 'dynamic-imports/dynamic-cached.html'
+        var a, b;
+
+        a = Polymer.Base.importHref(url, function() {
+          b = Polymer.Base.importHref(url, function() {
+
+            setTimeout(function() {
+              assert.equal(a, b);
+              done();
+            }, 0);
+
+          });
+        });
       });
 
     });

--- a/test/unit/dynamic-imports/dynamic-cached.html
+++ b/test/unit/dynamic-imports/dynamic-cached.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/dynamic-element.html
+++ b/test/unit/dynamic-imports/dynamic-element.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ready: function() {
       var url = this.resolveUrl('outer-element.html');
       this.importHref(url, function() {
+
         this.$.outer = document.createElement('outer-element');
         Polymer.dom(this.root).appendChild(this.$.outer);
         this._hasContent = true;

--- a/test/unit/dynamic-imports/dynamic-import-cached.html
+++ b/test/unit/dynamic-imports/dynamic-import-cached.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/dynamic-lazy.html
+++ b/test/unit/dynamic-imports/dynamic-lazy.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/dynamic-notready.html
+++ b/test/unit/dynamic-imports/dynamic-notready.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/dynamic-once.html
+++ b/test/unit/dynamic-imports/dynamic-once.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/sync-import.html
+++ b/test/unit/dynamic-imports/sync-import.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->

--- a/test/unit/dynamic-imports/sync-twice.html
+++ b/test/unit/dynamic-imports/sync-twice.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->


### PR DESCRIPTION
- uses altering test assets to ensure tests do not affect each other
- ensure importHref always returns a link element
- ensure onload() and onerror() functions are only called once when the same element was loaded again

Blocked by https://github.com/webcomponents/webcomponentsjs/pull/655 because the load event is invoked twice when a failed import attempt is repeated.

duplicate of #4209 that points against master instead of the branch behind #4200 ([refactor-import-href](https://github.com/Polymer/polymer/tree/refactor-import-href))