### PR TITLE
Fixes #4357. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,12 @@ id is to use `id`.
 * <a name="breaking-attribute-property-timing"></a>Any attribute values will take priority over property values set prior to upgrade due to V1 `attributeChangedCallback` timing semantics.  In 1.x properties set prior to upgrade overrode attributes.
 * <a name="breaking-transpiling"></a>Polymer 2.0 uses ES2015 syntax, and can be run without transpilation in current Chrome, Safari 10, Safari Technology Preview, Firefox, and Edge.  Transpilation is required to run in IE11 and Safari 9.  We will be releasing tooling for development and production time to support this need in the future.
 * <a name="breaking-hostAttributes-class"></a>In Polymer 1.x, the `class` attribute was explicitly blacklisted from `hostAttributes` and never serialized. This is no longer the case using the 2.0 legacy API.
+* <a name="breaking-url-changes"></a>In Polymer 1.x, the class attribute was explicitly blacklisted from hostAttributes and never serialized. This is no longer the case using the 2.0 legacy API. *In Polymer 1.x, URLs in element attributes and styles inside element templates were re-written to be relative to the HTMLImport that loaded the document. Based on user feedback, we are changing this behavior. Two new properties are being added to Polymer.Element: importPath and rootPath. The importPath property is a static on the element that defaults to the element HTMLImport document URL and is overridable. The rootPath property is set to the value of Polymer.rootPtah which is globally settable and defaults to the main document URL. URL's in styles are re-written to be relative to the importPath property. Inside element templates, URLs in element attributes are no longer re-written. Instead, they should be bound using importPath and rootPath where appropriate. For example:
+  A Polymer 1.x template that included:
+  ```html
+  <img src="foo.jpg">
+  ```
+  Should be this in Polymer 2.x:
+  ```html
+  <img src$="[[importPath]]foo.jpg">
+  ```

--- a/README.md
+++ b/README.md
@@ -277,12 +277,18 @@ id is to use `id`.
 * <a name="breaking-attribute-property-timing"></a>Any attribute values will take priority over property values set prior to upgrade due to V1 `attributeChangedCallback` timing semantics.  In 1.x properties set prior to upgrade overrode attributes.
 * <a name="breaking-transpiling"></a>Polymer 2.0 uses ES2015 syntax, and can be run without transpilation in current Chrome, Safari 10, Safari Technology Preview, Firefox, and Edge.  Transpilation is required to run in IE11 and Safari 9.  We will be releasing tooling for development and production time to support this need in the future.
 * <a name="breaking-hostAttributes-class"></a>In Polymer 1.x, the `class` attribute was explicitly blacklisted from `hostAttributes` and never serialized. This is no longer the case using the 2.0 legacy API.
-* <a name="breaking-url-changes"></a>In Polymer 1.x, the class attribute was explicitly blacklisted from hostAttributes and never serialized. This is no longer the case using the 2.0 legacy API. *In Polymer 1.x, URLs in element attributes and styles inside element templates were re-written to be relative to the HTMLImport that loaded the document. Based on user feedback, we are changing this behavior. Two new properties are being added to Polymer.Element: importPath and rootPath. The importPath property is a static on the element that defaults to the element HTMLImport document URL and is overridable. The rootPath property is set to the value of Polymer.rootPtah which is globally settable and defaults to the main document URL. URL's in styles are re-written to be relative to the importPath property. Inside element templates, URLs in element attributes are no longer re-written. Instead, they should be bound using importPath and rootPath where appropriate. For example:
+* <a name="breaking-url-changes"></a>In Polymer 1.x, URLs in attributes and styles inside element templates were re-written to be relative to the element HTMLImport. Based on user feedback, we are changing this behavior.
+
+  Two new properties are being added to `Polymer.Element`: `importPath` and `rootPath`. The `importPath` property is a static getter on the element class that defaults to the element HTMLImport document URL and is overridable. It may be useful to override `importPath` when an element `template` is not retrieved from a `dom-module` or the element is not defined using an HTMLImport. The `rootPath` property is set to the value of `Polymer.rootPath` which is globally settable and defaults to the main document URL. It may be useful to set `Polymer.rootPath` to provide a stable application mount path when using client side routing. URL's in styles are re-written to be relative to the `importPath` property. Inside element templates, URLs in element attributes are *no longer* re-written. Instead, they should be bound using `importPath` and `rootPath` where appropriate. For example:
+  
   A Polymer 1.x template that included:
+  
   ```html
   <img src="foo.jpg">
   ```
-  Should be this in Polymer 2.x:
+  
+  in Polymer 2.x should be:
+  
   ```html
   <img src$="[[importPath]]foo.jpg">
   ```

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -88,8 +88,9 @@
         // element's location; accomodate polyfilled HTMLImports
         const owner = window.HTMLImports && HTMLImports.importForElement ?
           HTMLImports.importForElement(this) || document : this.ownerDocument;
-        this.__assetpath = Polymer.ResolveUrl.resolveUrl(
+        const url = Polymer.ResolveUrl.resolveUrl(
           this.getAttribute('assetpath') || '', owner.baseURI);
+        this.__assetpath = Polymer.ResolveUrl.pathFromUrl(url);
       }
       return this.__assetpath;
     }

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -492,6 +492,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *       return memoizedTemplate;
        *     }
        *   }
+       *
+       * @returns {HTMLTemplateElement|string}
        */
       static get template() {
         if (!this.hasOwnProperty(goog.reflect.objectProperty('_template', this))) {
@@ -511,7 +513,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * used to create bindings relative to the import path.
        * Defaults to the path matching the url containing a `dom-module` element
        * matching this element's static `is` property.
-       * Note, this path does not contain a trailing `/`.
+       * Note, this path should contain a trailing `/`.
+       *
+       * @returns {string}
        */
       static get importPath() {
         if (!this.hasOwnProperty(goog.reflect.objectProperty('_importPath', this))) {
@@ -520,7 +524,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Object.getPrototypeOf(this.prototype).constructor.importPath;
         }
         return this._importPath;
-
       }
 
       constructor() {
@@ -551,7 +554,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // avoid dependence on `is` for polyfilling styling.
         if (this._template && !this._template.__polymerFinalized) {
           this._template.__polymerFinalized = true;
-          finalizeTemplate(this.__proto__, this._template, importPath + '/',
+          const baseURI =
+            importPath ? Polymer.ResolveUrl.resolveUrl(importPath) : '';
+          finalizeTemplate(this.__proto__, this._template, baseURI,
             this.localName);
         }
         super._initializeProperties();
@@ -704,7 +709,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {string} Rewritten URL relative to base
        */
       resolveUrl(url, base) {
-        return Polymer.ResolveUrl.resolveUrl(url, base || this.importPath + '/');
+        if (!base && this.importPath) {
+          base = Polymer.ResolveUrl.resolveUrl(this.importPath);
+        }
+        return Polymer.ResolveUrl.resolveUrl(url, base);
       }
 
     }

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -392,13 +392,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * style scoping.
      * @param {HTMLElement} proto
      * @param {HTMLTemplateElement} template
+     * @param {string} baseURI URL against which to resolve urls in
+     * style element cssText.
      * @param {string} is
      * @param {string} ext
      * @private
      */
-    function finalizeTemplate(proto, template, is, ext) {
+    function finalizeTemplate(proto, template, baseURI, is, ext) {
       // support `include="module-name"`
-      let cssText = Polymer.StyleGather.cssFromTemplate(template) +
+      let cssText =
+        Polymer.StyleGather.cssFromTemplate(template, baseURI) +
         Polymer.StyleGather.cssFromModuleImports(is);
       if (cssText) {
         let style = document.createElement('style');
@@ -501,6 +504,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this._template;
       }
 
+      /**
+       * Path matching the url from which the element was imported.
+       * This path is used to resolve url's in template style cssText.
+       * The `importPath` property is also set on element instances and can be
+       * used to create bindings relative to the import path.
+       * Defaults to the path matching the url containing a `dom-module` element
+       * matching this element's static `is` property.
+       * Note, this path does not contain a trailing `/`.
+       */
+      static get importPath() {
+        if (!this.hasOwnProperty(goog.reflect.objectProperty('_importPath', this))) {
+            const module = Polymer.DomModule.import(this.is);
+            this._importPath = module ? module.assetpath : '' ||
+            Object.getPrototypeOf(this.prototype).constructor.importPath;
+        }
+        return this._importPath;
+
+      }
+
       constructor() {
         super();
         Polymer.telemetry.instanceCount++;
@@ -524,13 +546,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _initializeProperties() {
         this.constructor.finalize();
+        const importPath = this.constructor.importPath;
         // note: finalize template when we have access to `localName` to
         // avoid dependence on `is` for polyfilling styling.
         if (this._template && !this._template.__polymerFinalized) {
           this._template.__polymerFinalized = true;
-          finalizeTemplate(this.__proto__, this._template, this.localName);
+          finalizeTemplate(this.__proto__, this._template, importPath + '/',
+            this.localName);
         }
         super._initializeProperties();
+        // set path defaults
+        this.rootPath = Polymer.rootPath;
+        this.importPath = importPath;
         // apply property defaults...
         let p$ = propertyDefaultsForClass(this.constructor);
         if (!p$) {
@@ -673,15 +700,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {string} url URL to resolve.
        * @param {string=} base Optional base URL to resolve against, defaults
-       * to the element template's ownerDocument baseURI.
-       * @return {string} Rewritten URL relative to the import
+       * to the element's `importPath`
+       * @return {string} Rewritten URL relative to base
        */
       resolveUrl(url, base) {
-        if (!base) {
-          const module = Polymer.DomModule.import(this.constructor.is);
-          base = module ? module.assetpath : document.baseURI;
-        }
-        return Polymer.ResolveUrl.resolveUrl(url, base);
+        return Polymer.ResolveUrl.resolveUrl(url, base || this.importPath + '/');
       }
 
     }

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -850,7 +850,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {Function} effectFn Function to run when arguments change
    * @param {*=} methodInfo
    * @param {Object=} dynamicFns Map indicating whether method names should
-   *   be included as a dependency to the effect.
+   *   be included as a dependency to the effect. Note, defaults to true
+   *   if the signature is statci (sig.static is true).
    * @private
    */
   function createMethodEffect(model, sig, type, effectFn, methodInfo, dynamicFns) {

--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -201,7 +201,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     parseChildNodesAnnotations(element, note, list, stripWhiteSpace, ownerDocument);
     if (element.attributes) {
       parseNodeAttributeAnnotations(element, note);
-      Polymer.ResolveUrl.resolveAttrs(element, ownerDocument);
     }
     if (note.bindings.length || note.events.length || note.id) {
       list.push(note);

--- a/lib/utils/boot.html
+++ b/lib/utils/boot.html
@@ -8,6 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script>
+(function() {
+
+  const userPolymer = window.Polymer;
 
   /**
    * @namespace Polymer
@@ -18,6 +21,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   window.Polymer = function(info) {
     return window.Polymer._polymerFn(info);
   }
+
+  // support user settings on the Polymer object
+  if (userPolymer) {
+    Object.assign(Polymer, userPolymer);
+  }
+
   // To be plugged by legacy implementation if loaded
   window.Polymer._polymerFn = function() {
     throw new Error('Load polymer.html to use the Polymer() function.');
@@ -29,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   When using Closure Compiler, goog.reflect.objectProperty(property, object) is replaced by the munged name for object[property]
   We cannot alias this function, so we have to use a small shim that has the same behavior when not compiling.
   */
-  var goog = {
+  window.goog = {
     reflect: {
       objectProperty(s, o) {
         return s;
@@ -37,4 +46,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
   /* eslint-enable */
+
+})();
 </script>

--- a/lib/utils/resolve-url.html
+++ b/lib/utils/resolve-url.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     let CSS_URL_RX = /(url\()([^)]*)(\))/g;
     let ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
     let workingURL;
-    let tempDoc;
+    let resolveDoc;
     /**
      * Resolves the given URL against the provided `baseUri'.
      *
@@ -40,22 +40,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // silently fail
         }
       }
+      if (!baseURI) {
+        baseURI = document.baseURI || window.location.href;
+      }
       if (workingURL) {
         return (new URL(url, baseURI)).href;
       }
       // Fallback to creating an anchor into a disconnected document.
-      let doc = tempDoc;
-      if (!doc) {
-        doc = document.implementation.createHTMLDocument('temp');
-        tempDoc = doc;
-        doc.base = doc.createElement('base');
-        doc.head.appendChild(doc.base);
-        doc.anchor = doc.createElement('a');
-        doc.body.appendChild(doc.anchor);
+      if (!resolveDoc) {
+        resolveDoc = document.implementation.createHTMLDocument('temp');
+        resolveDoc.base = resolveDoc.createElement('base');
+        resolveDoc.head.appendChild(resolveDoc.base);
+        resolveDoc.anchor = resolveDoc.createElement('a');
+        resolveDoc.body.appendChild(resolveDoc.anchor);
       }
-      doc.base.href = baseURI;
-      doc.anchor.href = url;
-      return doc.anchor.href || url;
+      resolveDoc.base.href = baseURI;
+      resolveDoc.anchor.href = url;
+      return resolveDoc.anchor.href || url;
 
     }
 
@@ -77,15 +78,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     /**
-     * Returns a path from a given `url`. The path has the last
-     * `/...` striped from the url.
+     * Returns a path from a given `url`. The path includes the trailing
+     * `/` from the url.
      *
      * @memberof Polymer.ResolveUrl
      * @param {string} url Input URL to transform
      * @return {string} resolved path
      */
     function pathFromUrl(url) {
-      return url.substring(0, url.lastIndexOf('/'));
+      return url.substring(0, url.lastIndexOf('/') + 1);
     }
 
     /**

--- a/lib/utils/resolve-url.html
+++ b/lib/utils/resolve-url.html
@@ -13,98 +13,80 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   (function() {
 
+    let CSS_URL_RX = /(url\()([^)]*)(\))/g;
+    let ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
+    let workingURL;
+    let tempDoc;
+    /**
+     * Resolves the given URL against the provided `baseUri'.
+     *
+     * @memberof Polymer.ResolveUrl
+     * @param {string} url Input URL to resolve
+     * @param {string} baseURI Base URI to resolve the URL against
+     * @return {string} resolved URL
+     */
+    function resolveUrl(url, baseURI) {
+      if (url && ABS_URL.test(url)) {
+        return url;
+      }
+      // Lazy feature detection.
+      if (workingURL === undefined) {
+        workingURL = false;
+        try {
+          const u = new URL('b', 'http://a');
+          u.pathname = 'c%20d';
+          workingURL = (u.href === 'http://a/c%20d');
+        } catch (e) {
+          // silently fail
+        }
+      }
+      if (workingURL) {
+        return (new URL(url, baseURI)).href;
+      }
+      // Fallback to creating an anchor into a disconnected document.
+      let doc = tempDoc;
+      if (!doc) {
+        doc = document.implementation.createHTMLDocument('temp');
+        tempDoc = doc;
+        doc.base = doc.createElement('base');
+        doc.head.appendChild(doc.base);
+        doc.anchor = doc.createElement('a');
+        doc.body.appendChild(doc.anchor);
+      }
+      doc.base.href = baseURI;
+      doc.anchor.href = url;
+      return doc.anchor.href || url;
+
+    }
+
     /**
      * Resolves any relative URL's in the given CSS text against the provided
      * `ownerDocument`'s `baseURI`.
      *
      * @memberof Polymer.ResolveUrl
      * @param {string} cssText CSS text to process
-     * @param {Document} ownerDocument Owner document to base URL's on
+     * @param {string} baseURI Base URI to resolve the URL against
      * @return {string} Processed CSS text with resolved URL's
      */
-    function resolveCss(cssText, ownerDocument) {
+    function resolveCss(cssText, baseURI) {
       return cssText.replace(CSS_URL_RX, function(m, pre, url, post) {
         return pre + '\'' +
-          resolve(url.replace(/["']/g, ''), ownerDocument) +
+          resolveUrl(url.replace(/["']/g, ''), baseURI) +
           '\'' + post;
       });
     }
 
     /**
-     * Resolves any relative URL's in `src` or `style` attributes of the given
-     * `element` against the provided `ownerDocument`'s `baseURI`.
+     * Returns a path from a given `url`. The path has the last
+     * `/...` striped from the url.
      *
      * @memberof Polymer.ResolveUrl
-     * @param {HTMLElement} element Element whose attributes will be processed
-     * @param {Document} ownerDocument Owner document to base URL's on
+     * @param {string} url Input URL to transform
+     * @return {string} resolved path
      */
-    function resolveAttrs(element, ownerDocument) {
-      for (var name in URL_ATTRS) {
-        var a$ = URL_ATTRS[name];
-        for (var i=0, l=a$.length, a, at, v; (i<l) && (a=a$[i]); i++) {
-          if (name === '*' || element.localName === name) {
-            at = element.attributes[a];
-            v = at && at.value;
-            if (v && (v.search(BINDING_RX) < 0)) {
-              at.value = (a === 'style') ?
-                resolveCss(v, ownerDocument) :
-                resolve(v, ownerDocument);
-            }
-          }
-        }
-      }
+    function pathFromUrl(url) {
+      return url.substring(0, url.lastIndexOf('/'));
     }
-
-    /**
-     * Resolves the given URL against the provided `ownerDocument`'s `baseURI'.
-     *
-     * Does not modify `#` links or absolute URL's.
-     *
-     * @private
-     */
-    function resolve(url, ownerDocument) {
-      // do not resolve '#' links, they are used for routing
-      if (url && ABS_URL.test(url)) {
-        return url;
-      }
-      var resolver = getUrlResolver(ownerDocument);
-      resolver.href = url;
-      return resolver.href || url;
-    }
-
-    var tempDoc;
-    var tempDocBase;
-
-    /**
-     * Resolves the given URL against the provided `baseUri'.
-     *
-     * @memberof Polymer.ResolveUrl
-     * @param {string} url Input URL to resolve
-     * @param {string} baseUri Base URI to resolve the URL against
-     * @param {type} name Description
-     */
-    function resolveUrl(url, baseUri) {
-      if (!tempDoc) {
-        tempDoc = document.implementation.createHTMLDocument('temp');
-        tempDocBase = tempDoc.createElement('base');
-        tempDoc.head.appendChild(tempDocBase);
-      }
-      tempDocBase.href = baseUri;
-      return resolve(url, tempDoc);
-    }
-
-    function getUrlResolver(ownerDocument) {
-      return ownerDocument.__urlResolver ||
-        (ownerDocument.__urlResolver = ownerDocument.createElement('a'));
-    }
-
-    var CSS_URL_RX = /(url\()([^)]*)(\))/g;
-    var URL_ATTRS = {
-      '*': ['href', 'src', 'style', 'url'],
-      form: ['action']
-    };
-    var ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
-    var BINDING_RX = /\{\{|\[\[/;
 
     /**
      * Module with utilities for resolving relative URL's.
@@ -114,11 +96,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @summary Module with utilities for resolving relative URL's.
      */
     Polymer.ResolveUrl = {
-      // exports
       resolveCss: resolveCss,
-      resolveAttrs: resolveAttrs,
-      resolveUrl: resolveUrl
+      resolveUrl: resolveUrl,
+      pathFromUrl: pathFromUrl
     };
+
+    // NOTE: baseURI is not supported on IE?
+    Polymer.rootPath = pathFromUrl(document.baseURI || window.location.href);
 
   })();
 

--- a/lib/utils/style-gather.html
+++ b/lib/utils/style-gather.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // include css from the first template in the module
         let t = m.querySelector('template');
         if (t) {
-          cssText += this.cssFromTemplate(t);
+          cssText += this.cssFromTemplate(t, m.assetpath + '/');
         }
         // module imports: <link rel="import" type="css">
         cssText += this.cssFromModuleImports(moduleId);
@@ -86,9 +86,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.StyleGather
      * @param {HTMLTemplateElement} template Template to gather styles from
+     * @param {string} baseURI Base URI to resolve the URL against
      * @return {string} Concatenated CSS content from specified template
      */
-    cssFromTemplate(template) {
+    cssFromTemplate(template, baseURI) {
       let cssText = '';
       // if element is a template, get content from its .content
       let e$ = template.content.querySelectorAll('style');
@@ -101,8 +102,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           cssText += this.cssFromModules(include);
         }
         e.parentNode.removeChild(e);
-        cssText +=
-          Polymer.ResolveUrl.resolveCss(e.textContent, template.ownerDocument);
+        cssText += Polymer.ResolveUrl.resolveCss(e.textContent, baseURI);
       }
       return cssText;
     },
@@ -131,7 +131,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // but the import pseudo-doc can be used directly.
           let container = importDoc.body ? importDoc.body : importDoc;
           cssText +=
-            Polymer.ResolveUrl.resolveCss(container.textContent, importDoc);
+            Polymer.ResolveUrl.resolveCss(container.textContent,
+              importDoc.baseURI);
         }
       }
       return cssText;

--- a/lib/utils/style-gather.html
+++ b/lib/utils/style-gather.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // include css from the first template in the module
         let t = m.querySelector('template');
         if (t) {
-          cssText += this.cssFromTemplate(t, m.assetpath + '/');
+          cssText += this.cssFromTemplate(t, m.assetpath);
         }
         // module imports: <link rel="import" type="css">
         cssText += this.cssFromModuleImports(moduleId);
@@ -102,7 +102,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           cssText += this.cssFromModules(include);
         }
         e.parentNode.removeChild(e);
-        cssText += Polymer.ResolveUrl.resolveCss(e.textContent, baseURI);
+        cssText += baseURI ?
+          Polymer.ResolveUrl.resolveCss(e.textContent, baseURI) : e.textContent;
       }
       return cssText;
     },

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -19,6 +19,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <x-resolve></x-resolve>
 
+  <dom-module id="x-late">
+    <template>
+      <style>
+        :host {
+          background: url('foo.png');
+        }
+      </style>
+      <img id="root" src$="[[rootPath]]/foo.png">
+      <img id="import" src$="[[importPath]]/foo.png">
+    </template>
+  </dom-module>
+
   <dom-module id="x-resolve">
   </dom-module>
 
@@ -44,7 +56,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.match(el.$.div.getAttribute('style'), rx, 'style url not relative to main document');
         assert.match(el.$.img.src, rx, 'src url not relative to main document');
         assert.match(el.$.a.href, rx, 'href url not relative to main document');
-        assert.match(el.$.zonk.getAttribute('url'), rx, 'url url not relative to main document');
+        assert.match(el.$.import.getAttribute('url'), rx, 'url url not relative to main document');
+        assert.match(el.$.resolveUrl.getAttribute('url'), rx, 'url url not relative to main document');
+        assert.notMatch(el.$.root.getAttribute('url'), rx, 'url url not relative to main document');
         assert.notMatch(el.$.rel.href, rx, 'relative href url not relative to main document');
         assert.match(el.$.rel.href, /\?123$/, 'relative href does not preserve query string');
         assert.equal(el.$.action.getAttribute('action'), 'foo.z', 'action attribute relativized for incorrect element type');
@@ -52,6 +66,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.$.hash.getAttribute('href'), '#foo.z', 'hash-only url should not be resolved');
         assert.equal(el.$.absolute.getAttribute('href'), '/foo.z', 'absolute urls should not be resolved');
         assert.equal(el.$.protocol.getAttribute('href'), 'data:foo.z', 'urls with other protocols should not be resolved');
+        document.body.removeChild(el);
+      });
+
+      test('url changes via setting importPath/rootPath on element instance', function() {
+        var el = document.createElement('p-r');
+        document.body.appendChild(el);
+        el.rootPath = 'instanceRoot';
+        el.importPath = 'instanceImport';
+        var matchRoot = /instanceRoot\//;
+        var matchImport = /instanceImport\//;
+        assert.match(el.$.div.getAttribute('style'), matchImport);
+        assert.match(el.$.import.getAttribute('url'), matchImport);
+        assert.match(el.$.root.getAttribute('url'), matchRoot);
+        document.body.removeChild(el);
+      });
+
+      test('url changes via setting importPath/rootPath when defining element', function() {
+        Polymer.rootPath = 'http://defineRoot';
+        class XLate extends Polymer.Element {
+          static get is() { return 'x-late'}
+          static get importPath() { return 'http://defineImport'}
+        }
+        customElements.define(XLate.is, XLate);
+        var el = document.createElement('x-late');
+        document.body.appendChild(el);
+        var matchRoot = /http\:\/\/defineRoot\//i;
+        var matchImport = /http\:\/\/defineImport\//i;
+        var style = el.shadowRoot.querySelector('style') || document.querySelector('style[scope=x-late]');
+        assert.match(style.textContent, matchImport);
+        assert.match(el.$.import.getAttribute('src'), matchImport);
+        assert.match(el.$.root.getAttribute('src'), matchRoot);
+        document.body.removeChild(el);
       });
 
       test('resolveUrl api', function() {

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -26,8 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           background: url('foo.png');
         }
       </style>
-      <img id="root" src$="[[rootPath]]/foo.png">
-      <img id="import" src$="[[importPath]]/foo.png">
+      <img id="root" src$="[[rootPath]]foo.png">
+      <img id="import" src$="[[importPath]]foo.png">
     </template>
   </dom-module>
 
@@ -72,8 +72,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('url changes via setting importPath/rootPath on element instance', function() {
         var el = document.createElement('p-r');
         document.body.appendChild(el);
-        el.rootPath = 'instanceRoot';
-        el.importPath = 'instanceImport';
+        el.rootPath = 'instanceRoot/';
+        el.importPath = 'instanceImport/';
         var matchRoot = /instanceRoot\//;
         var matchImport = /instanceImport\//;
         assert.match(el.$.div.getAttribute('style'), matchImport);
@@ -83,16 +83,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('url changes via setting importPath/rootPath when defining element', function() {
-        Polymer.rootPath = 'http://defineRoot';
+        Polymer.rootPath = 'defineRoot/';
         class XLate extends Polymer.Element {
           static get is() { return 'x-late'}
-          static get importPath() { return 'http://defineImport'}
+          static get importPath() { return 'defineImport/'}
         }
         customElements.define(XLate.is, XLate);
         var el = document.createElement('x-late');
         document.body.appendChild(el);
-        var matchRoot = /http\:\/\/defineRoot\//i;
-        var matchImport = /http\:\/\/defineImport\//i;
+        var matchRoot = /defineRoot\//i;
+        var matchImport = /defineImport\//i;
         var style = el.shadowRoot.querySelector('style') || document.querySelector('style[scope=x-late]');
         assert.match(style.textContent, matchImport);
         assert.match(el.$.import.getAttribute('src'), matchImport);

--- a/test/unit/shady-dynamic.html
+++ b/test/unit/shady-dynamic.html
@@ -159,7 +159,11 @@ HTMLImports.whenReady(function() {
 
 <dom-module id="x-echo">
   <template><slot></slot></template>
-  <script>Polymer({is: 'x-echo'});</script>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-echo'});
+  });
+  </script>
 </dom-module>
 
 <dom-module id="x-simple">
@@ -219,7 +223,11 @@ HTMLImports.whenReady(function() {
     Foo: [<slot name="foo"></slot>]
     Bar: [<slot name="bar"></slot>]
   </template>
-  <script>Polymer({is: 'x-select-attr'});</script>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-select-attr'});
+  });
+  </script>
 </dom-module>
 
 <dom-module id="x-compose-select-attr">
@@ -229,7 +237,11 @@ HTMLImports.whenReady(function() {
       <x-attr2 id="attr2"></x-attr2>
     </x-select-attr>
   </template>
-  <script>Polymer({is: 'x-compose-select-attr'});</script>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-compose-select-attr'});
+  });
+  </script>
 </dom-module>
 
 
@@ -367,7 +379,11 @@ HTMLImports.whenReady(function() {
 
 <dom-module id="x-commented">
   <template><span>[</span><!--comment--><slot></slot></span><span>]</span></slot></template>
-  <script>Polymer({is: 'x-commented'});</script>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({is: 'x-commented'});
+  });
+  </script>
 </dom-module>
 
 

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -913,7 +913,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var e2 = document.createElement('x-produce-use-property');
     document.body.appendChild(e2);
     var e2t = e2.$.hosted.$.hosted;
-    if (styled.shadowRoot) {
+    if (styled.shadowRoot && window.ShadyDOM) {
       assert.equal(document.querySelectorAll('style').length, l+1);
     }
     assertComputed(e1t, '6px');
@@ -922,14 +922,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     e2.updateStyles({'--scope-var': '8px solid purple'});
     assertComputed(e1t, '8px');
     assertComputed(e2t, '8px');
-    if (styled.shadowRoot) {
+    if (styled.shadowRoot && window.ShadyDOM) {
       assert.equal(document.querySelectorAll('style').length, l+1);
     }
     e1.updateStyles({'--scope-var': null});
     e2.updateStyles({'--scope-var': null});
     assertComputed(e1t, '6px');
     assertComputed(e2t, '6px');
-    if (styled.shadowRoot) {
+    if (styled.shadowRoot && window.ShadyDOM) {
       assert.equal(document.querySelectorAll('style').length, l+1);
     }
   })

--- a/test/unit/sub/resolveurl-elements.html
+++ b/test/unit/sub/resolveurl-elements.html
@@ -15,15 +15,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background-image: url(foo.z);
       }
     </style>
-    <div id="div" class="logo" style$="background-image: url('[[importPath]]/foo.z');"></div>
-    <img id="img" src$="[[importPath]]/foo.z">
-    <a id="a" href$="[[importPath]]/foo.z">Foo</a>
-    <zonk id="import" url$="[[importPath]]/foo.z"></zonk>
+    <div id="div" class="logo" style$="background-image: url('[[importPath]]foo.z');"></div>
+    <img id="img" src$="[[importPath]]foo.z">
+    <a id="a" href$="[[importPath]]foo.z">Foo</a>
+    <zonk id="import" url$="[[importPath]]foo.z"></zonk>
     <zonk id="resolveUrl" url$="[[resolveUrl('foo.z')]]"></zonk>
-    <zonk id="root" url$="[[rootPath]]/foo.z"></zonk>
-    <a id="rel" href$="[[importPath]]/../foo.z?123">Foo</a>
+    <zonk id="root" url$="[[rootPath]]foo.z"></zonk>
+    <a id="rel" href$="[[importPath]]../foo.z?123">Foo</a>
     <a id="action" action="foo.z">Foo</a>
-    <form id="formAction" action$="[[importPath]]/foo.z"></form>
+    <form id="formAction" action$="[[importPath]]foo.z"></form>
     <a id="hash" href="#foo.z">Foo</a>
     <a id="absolute" href="/foo.z">Foo</a>
     <a id="protocol" href="data:foo.z">Foo</a>

--- a/test/unit/sub/resolveurl-elements.html
+++ b/test/unit/sub/resolveurl-elements.html
@@ -8,20 +8,22 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<dom-module id="p-r" encapsulate>
+<dom-module id="p-r">
   <template>
     <style>
       .logo {
         background-image: url(foo.z);
       }
     </style>
-    <div id="div" class="logo" style="background-image: url(foo.z);"></div>
-    <img id="img" src="foo.z">
-    <a id="a" href="foo.z">Foo</a>
-    <zonk id="zonk" url="foo.z"></zonk>
-    <a id="rel" href="../foo.z?123">Foo</a>
+    <div id="div" class="logo" style$="background-image: url('[[importPath]]/foo.z');"></div>
+    <img id="img" src$="[[importPath]]/foo.z">
+    <a id="a" href$="[[importPath]]/foo.z">Foo</a>
+    <zonk id="import" url$="[[importPath]]/foo.z"></zonk>
+    <zonk id="resolveUrl" url$="[[resolveUrl('foo.z')]]"></zonk>
+    <zonk id="root" url$="[[rootPath]]/foo.z"></zonk>
+    <a id="rel" href$="[[importPath]]/../foo.z?123">Foo</a>
     <a id="action" action="foo.z">Foo</a>
-    <form id="formAction" action="foo.z"></form>
+    <form id="formAction" action$="[[importPath]]/foo.z"></form>
     <a id="hash" href="#foo.z">Foo</a>
     <a id="absolute" href="/foo.z">Foo</a>
     <a id="protocol" href="data:foo.z">Foo</a>


### PR DESCRIPTION
Adds `importPath` and `rootPath` properties to Polymer.Element. The `importPath` property defaults to the path part of the url containing the dom-module matching the element's static `is` property. The `rootPath` property is set to the `Polymer.rootPath` property and defaults to the path part of the main document url. These properties can be used in bindings to url's. The `importPath` property is used to scope url's in element styles. [Note, this depends on this [html-imports pr](https://github.com/webcomponents/html-imports/pull/44) ].
