### PR TITLE
Don't override the goog namespace if it already exists

### DIFF
--- a/lib/utils/boot.html
+++ b/lib/utils/boot.html
@@ -39,13 +39,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   When using Closure Compiler, goog.reflect.objectProperty(property, object) is replaced by the munged name for object[property]
   We cannot alias this function, so we have to use a small shim that has the same behavior when not compiling.
   */
-  window.goog = {
-    reflect: {
-      objectProperty(s, o) {
-        return s;
-      }
+  window.goog = window.goog || {};
+  window.goog.reflect = window.goog.reflect || {
+    objectProperty(s, o) {
+      return s;
     }
-  }
+  };
   /* eslint-enable */
 
 })();


### PR DESCRIPTION
When used on the same site as closure-library, the `goog` namespace is overwritten by the reflection shim.

Alternatively, you have the option to use the specially named `JSCompiler_renameProperty` function which has the exact same functionality. The compiler recognizes either signature but `JSCompiler_renameProperty` is much less likely to be used by other projects. It's specific to soy templates mainly.