### PR TITLE
add `behaviors` to instances too

### DIFF
--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!Array.isArray(behaviors)) {
         behaviors = [behaviors];
       }
-      let superBehaviors = klass.behaviors;
+      let superBehaviors = klass.prototype.behaviors;
       // get flattened, deduped list of behaviors *not* already on super class
       behaviors = flattenBehaviors(behaviors, null, superBehaviors);
       // mixin new behaviors
@@ -62,6 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (superBehaviors) {
         behaviors = superBehaviors.concat(behaviors);
       }
+      // Set behaviors on the prototype to be compatible with 1.x
       klass.prototype.behaviors = behaviors;
       return klass;
     }
@@ -320,8 +321,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         LegacyElementMixin(HTMLElement));
       // decorate klass with registration info
       klass.is = info.is;
-      // behaviors on prototype for BC...
-      klass.prototype.behaviors = klass.behaviors;
       // NOTE: while we could call `beforeRegister` here to maintain
       // some BC, the state of the element at this point is not as it was in 1.0
       // In 1.0, the method was called *after* mixing prototypes together

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -63,6 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         behaviors = superBehaviors.concat(behaviors);
       }
       klass.behaviors = behaviors;
+      klass.prototype.behaviors = behaviors;
       return klass;
     }
 

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -62,7 +62,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (superBehaviors) {
         behaviors = superBehaviors.concat(behaviors);
       }
-      klass.behaviors = behaviors;
       klass.prototype.behaviors = behaviors;
       return klass;
     }

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -62,7 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (superBehaviors) {
         behaviors = superBehaviors.concat(behaviors);
       }
-      // Set behaviors on the prototype to be compatible with 1.x
+      // Set behaviors on prototype for BC...
       klass.prototype.behaviors = behaviors;
       return klass;
     }

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -284,7 +284,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._createMethodObserver('propChanged2(prop)');
           this.registeredCount++;
           this.registeredProps = [this.prop1, this.prop2, this.prop3];
-          this.registeredBehaviors = this.constructor.behaviors;
+          this.registeredBehaviors = this.behaviors;
         },
         prop1: true,
         ready: function() {
@@ -383,8 +383,7 @@ suite('single behavior element', function() {
   });
 
   test('instance and class behaviors', function() {
-    assert.equal(el.constructor.behaviors.length, 1);
-    assert.deepEqual(el.behaviors, el.constructor.behaviors);
+    assert.equal(el.behaviors.length, 1);
   });
 
   test('listener from behavior', function() {
@@ -418,7 +417,7 @@ suite('behavior.registered', function() {
     var el = fixture('registered');
     assert.equal(el.registeredCount, 4);
     assert.equal(el.registeredBehaviors.length, 3);
-    assert.equal(el.registeredBehaviors, el.constructor.behaviors);
+    assert.equal(el.registeredBehaviors, el.behaviors);
     assert.deepEqual(el.registeredProps, [true, true, true]);
   });
 
@@ -453,8 +452,7 @@ suite('multi-behaviors element', function() {
   });
 
   test('instance and class behaviors', function() {
-    assert.equal(el.constructor.behaviors.length, 2);
-    assert.deepEqual(el.behaviors, el.constructor.behaviors);
+    assert.equal(el.behaviors.length, 2);
   });
 
   test('properties from behaviors', function() {
@@ -520,13 +518,13 @@ suite('multi-behaviors element', function() {
   test('behavior array is unique', function() {
     customElements.define('behavior-unique', Polymer.mixinBehaviors(
       [Polymer.BehaviorA, Polymer.BehaviorA], Polymer.Element));
-    assert.equal(document.createElement('behavior-unique').constructor.behaviors.length, 1);
+    assert.equal(document.createElement('behavior-unique').behaviors.length, 1);
   });
 
   test('duplicate behaviors keep first behavior', function() {
     customElements.define('behavior-unique-last-behavior', Polymer.mixinBehaviors(
       [Polymer.BehaviorA, Polymer.BehaviorB, Polymer.BehaviorC, Polymer.BehaviorA, Polymer.BehaviorB], Polymer.Element));
-    var behaviors = document.createElement('behavior-unique-last-behavior').constructor.behaviors;
+    var behaviors = document.createElement('behavior-unique-last-behavior').behaviors;
     assert.deepEqual(behaviors, [Polymer.BehaviorC, Polymer.BehaviorA, Polymer.BehaviorB]);
   });
 
@@ -540,7 +538,7 @@ suite('nested-behaviors element', function() {
   });
 
   test('nested-behavior dedups', function() {
-    assert.equal(el.constructor.behaviors.length, 4);
+    assert.equal(el.behaviors.length, 4);
   });
 
   test('nested-behavior overrides ordering', function() {

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -382,6 +382,11 @@ suite('single behavior element', function() {
     assert.equal(el.__label, 'foo');
   });
 
+  test('instance and class behaviors', function() {
+    assert.equal(el.constructor.behaviors.length, 1);
+    assert.deepEqual(el.behaviors, el.constructor.behaviors);
+  });
+
   test('listener from behavior', function() {
     el.fire('change', {value: 'bar'});
     assert.equal(el.__change, 'bar');
@@ -445,6 +450,11 @@ suite('multi-behaviors element', function() {
   test('ready from behaviors', function() {
     assert.equal(el.__readyA, true);
     assert.equal(el.__readyB, true);
+  });
+
+  test('instance and class behaviors', function() {
+    assert.equal(el.constructor.behaviors.length, 2);
+    assert.deepEqual(el.behaviors, el.constructor.behaviors);
   });
 
   test('properties from behaviors', function() {

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -382,7 +382,7 @@ suite('single behavior element', function() {
     assert.equal(el.__label, 'foo');
   });
 
-  test('instance and class behaviors', function() {
+  test('instance behaviors', function() {
     assert.equal(el.behaviors.length, 1);
   });
 
@@ -451,7 +451,7 @@ suite('multi-behaviors element', function() {
     assert.equal(el.__readyB, true);
   });
 
-  test('instance and class behaviors', function() {
+  test('instance behaviors', function() {
     assert.equal(el.behaviors.length, 2);
   });
 


### PR DESCRIPTION
Fixes #4396, https://github.com/PolymerElements/iron-a11y-keys-behavior/issues/69