### PR TITLE
add properties, behaviors, observers, hostAttributes, listeners on prototype

### DIFF
--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -25,11 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       registered: true,
       attributeChanged: true,
       // meta objects
-      behaviors: true,
-      hostAttributes: true,
-      properties: true,
-      observers: true,
-      listeners: true
+      behaviors: true
     }
 
     /**

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -172,7 +172,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       behaviors: [
         Polymer.BehaviorA
-      ]
+      ],
+
+      properties: {},
+      observers: [],
+      hostAttributes: {},
+      listeners: {}
     });
 
     Polymer({
@@ -305,6 +310,14 @@ suite('single behavior element', function() {
 
   test('is on prototype', function() {
     assert.equal(el.is, 'single-behavior');
+  });
+
+  test('instance behaviors, properties, observers, hostAttributes, listeners', function() {
+    assert.isOk(el.behaviors);
+    assert.isOk(el.properties);
+    assert.isOk(el.observers);
+    assert.isOk(el.hostAttributes);
+    assert.isOk(el.listeners);
   });
 
   test('ready from behavior', function() {


### PR DESCRIPTION
As some legacy element relies on `properties, behaviors, observers, hostAttributes, listeners` set on the prototype, support these in the `PolymerGenerated` class.