### PR TITLE
Ensure `_registered` is called 1x for each element class using `LegacyElementMixin`

### DIFF
--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -131,8 +131,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     function GenerateClassFromInfo(info, Base) {
 
-      let registered = false;
-
       class PolymerGenerated extends Base {
 
         static get properties() {
@@ -163,13 +161,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         _registered() {
-          if (!registered) {
-            super._registered();
-            // call `registered` only if it was not called for *this* constructor
-            registered = true;
-            if (info.registered) {
-              info.registered.call(Object.getPrototypeOf(this));
-            }
+          super._registered();
+          if (info.registered) {
+            info.registered.call(Object.getPrototypeOf(this));
           }
         }
 

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -105,12 +105,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Overrides the default `Polymer.PropertyEffects` implementation to
-       * add support for one-time `registration` callback.
+       * add support for class initialization via the `_registered` callback.
+       * This is called only when the first instance of the element is created.
        *
        * @override
        */
       _initializeProperties() {
-        this._registered();
+        let proto = Object.getPrototypeOf(this);
+        if (!proto.hasOwnProperty('__hasRegisterFinished')) {
+          proto.__hasRegisterFinished = true;
+          this._registered();
+        }
         super._initializeProperties();
       }
 

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -329,11 +329,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       BehaviorRegistered.prototype.registeredCount = 0;
 
       customElements.define(BehaviorRegistered.is, BehaviorRegistered);
+
+      class BehaviorRegisteredExt extends BehaviorRegistered {
+        static get is() { return 'behavior-registered-ext'}
+      }
+
+      BehaviorRegisteredExt.prototype.registeredCount = 0;
+
+      customElements.define(BehaviorRegisteredExt.is, BehaviorRegisteredExt);
     });
     </script>
   </dom-module>
-
-  </script>
 
   <test-fixture id="single">
     <template>
@@ -362,6 +368,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="registered">
     <template>
       <behavior-registered></behavior-registered>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="registered-ext">
+    <template>
+      <behavior-registered-ext></behavior-registered-ext>
     </template>
   </test-fixture>
 <script>
@@ -415,6 +427,14 @@ suite('behavior.registered', function() {
 
   test('called once for each behavior with access to element prototype', function() {
     var el = fixture('registered');
+    assert.equal(el.registeredCount, 4);
+    assert.equal(el.registeredBehaviors.length, 3);
+    assert.equal(el.registeredBehaviors, el.behaviors);
+    assert.deepEqual(el.registeredProps, [true, true, true]);
+  });
+
+  test('extending element with behaviors with registered properly registers', function() {
+    var el = fixture('registered-ext');
     assert.equal(el.registeredCount, 4);
     assert.equal(el.registeredBehaviors.length, 3);
     assert.equal(el.registeredBehaviors, el.behaviors);


### PR DESCRIPTION
Fixes #4437 . Ensure `_registered` is called 1x for each element class using `LegacyElementMixin`. Ensure that a behaviors’s `registered` method is called for any extending class.
