### PR TITLE
Failing unit test to demonstrate shadycss#69

### DIFF
--- a/test/runner.html
+++ b/test/runner.html
@@ -68,7 +68,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/logging.html',
       'unit/mixin-utils.html',
       'unit/mixin-behaviors.html',
-      'unit/render-status.html'
+      'unit/render-status.html',
+      'unit/apply-shim-shared.html'
     ];
 
     // http://eddmann.com/posts/cartesian-product-in-javascript/

--- a/test/unit/apply-shim-shared.html
+++ b/test/unit/apply-shim-shared.html
@@ -93,18 +93,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.match(sharedEle2Style.cssText, /background:\s*var\(--shared-ele_-_background\)/);
     };
 
-    test('combined', function ()
+    test('both assertions in a single test', function ()
     {
       assertProp();
       assertMix();
     });
 
-    test('ensure correct styles applied', function ()
+    test('ensure property rules are set', function ()
     {
       assertProp();
     });
 
-    test('ensure correct styles applied2', function ()
+    test('ensure shared element styles are applied from mixin', function ()
     {
       assertMix();
     });

--- a/test/unit/apply-shim-shared.html
+++ b/test/unit/apply-shim-shared.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../polymer.html">
+<body>
+
+<dom-module id="shared-ele">
+  <template>
+    <style>
+      :host {
+        @apply --shared-ele;
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <script>Polymer({is: 'shared-ele'})</script>
+</dom-module>
+
+<dom-module id="my-ele1">
+  <template>
+    <style>
+      shared-ele {
+        --shared-ele: {
+          color: red;
+        }
+      }
+    </style>
+    <shared-ele>ele1</shared-ele>
+  </template>
+  <script>Polymer({is: 'my-ele1'})</script>
+</dom-module>
+
+<dom-module id="my-ele2">
+  <template>
+    <style>
+      shared-ele {
+        --shared-ele: {
+          background: green;
+        }
+      }
+    </style>
+    <shared-ele>ele2</shared-ele>
+  </template>
+  <script>Polymer({is: 'my-ele2'})</script>
+</dom-module>
+
+<test-fixture id="mixins">
+  <template>
+    <my-ele1></my-ele1>
+    <my-ele2></my-ele2>
+  </template>
+</test-fixture>
+
+<script>
+
+  suite('mixins applied across instances', function ()
+  {
+    let el, ele1, ele2, sharedEle1, sharedEle2;
+    setup(function ()
+          {
+            el = fixture('mixins');
+            ele1 = el[0];
+            sharedEle1 = ele1.shadowRoot.querySelector('shared-ele');
+
+            ele2 = el[1];
+            sharedEle2 = ele2.shadowRoot.querySelector('shared-ele');
+          });
+
+    let assertProp = function ()
+    {
+      let myEle1Style = ele1.shadowRoot.querySelector('style').sheet.rules[0];
+      let myEle2Style = ele2.shadowRoot.querySelector('style').sheet.rules[0];
+      assert.match(myEle1Style.cssText, /--shared-ele_-_color:\s*red;/);
+      assert.match(myEle2Style.cssText, /--shared-ele_-_background:\s*green;/);
+    };
+    let assertMix = function ()
+    {
+      let sharedEle1Style = sharedEle1.shadowRoot.querySelector('style').sheet.rules[0];
+      let sharedEle2Style = sharedEle2.shadowRoot.querySelector('style').sheet.rules[0];
+      assert.match(sharedEle1Style.cssText, /color:\s*var\(--shared-ele_-_color\)/);
+      assert.match(sharedEle2Style.cssText, /background:\s*var\(--shared-ele_-_background\)/);
+    };
+
+    test('combined', function ()
+    {
+      assertProp();
+      assertMix();
+    });
+
+    test('ensure correct styles applied', function ()
+    {
+      assertProp();
+    });
+
+    test('ensure correct styles applied2', function ()
+    {
+      assertMix();
+    });
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Regarding http://github.com/webcomponents/shadycss/issues/69

I created a unit test within shadycss which passed.  So I wrote the same test against polymer which fails.

This appears to be a time based issue.  I have abstracted the assertions into two functions to show this.
`assertProp` - ensure the mixin style is exploded into properties correctly
`assertMix` - ensure the applied styles are correctly set from the properties

the test named `both assertions in a single test` fails if run first, but passes if run last.