### PR TITLE
Introducing an `insertBefore` method on Templatize instances

### DIFF
--- a/lib/elements/dom-if.html
+++ b/lib/elements/dom-if.html
@@ -204,7 +204,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         if (!this.__instance) {
           this.__instance = new this.__ctor();
-          parentNode.insertBefore(this.__instance.root, this);
+          this.__instance.insertBefore(parentNode, this);
         } else {
           this.__syncHostProperties();
           let c$ = this.__instance.children;

--- a/lib/elements/dom-if.html
+++ b/lib/elements/dom-if.html
@@ -204,7 +204,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         if (!this.__instance) {
           this.__instance = new this.__ctor();
-          this.__instance.insertBefore(parentNode, this);
+          this.__instance.connect(parentNode, this);
         } else {
           this.__syncHostProperties();
           let c$ = this.__instance.children;

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -580,7 +580,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       let beforeRow = this.__instances[instIdx + 1];
       let beforeNode = beforeRow ? beforeRow.children[0] : this;
-      inst.insertBefore(this.parentNode, beforeNode);
+      inst.connect(this.parentNode, beforeNode);
       this.__instances[instIdx] = inst;
       return inst;
     }

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -580,7 +580,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       let beforeRow = this.__instances[instIdx + 1];
       let beforeNode = beforeRow ? beforeRow.children[0] : this;
-      this.parentNode.insertBefore(inst.root, beforeNode);
+      inst.insertBefore(this.parentNode, this);
       this.__instances[instIdx] = inst;
       return inst;
     }

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -580,7 +580,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       let beforeRow = this.__instances[instIdx + 1];
       let beforeNode = beforeRow ? beforeRow.children[0] : this;
-      inst.insertBefore(this.parentNode, this);
+      inst.insertBefore(this.parentNode, beforeNode);
       this.__instances[instIdx] = inst;
       return inst;
     }

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -54,12 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.__templatizeOwner.__hideTemplateChildren__) {
           this._showHideChildren(true);
         }
-        // Flush props only when props are passed if instance props exist
-        // or when there isn't instance props.
-        let options = this.__templatizeOptions;
-        if ((props && options.instanceProps) || !options.instanceProps) {
-          this._flushProperties();
-        }
       }
       /**
        * @private
@@ -76,6 +70,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         for (let hprop in this.__hostProps) {
           this._setPendingProperty(hprop, this.__dataHost['_host_' + hprop]);
         }
+      }
+      /**
+        Inserts the templatized dom into the given `parentNode` before
+        `refNode`.
+        @param {Node} parentNode node into which to insert dom
+        @param {Node} refNode node before which to insert dom
+      */
+      insertBefore(parentNode, refNode) {
+        parentNode.insertBefore(this.root, refNode);
+        this._flushProperties();
       }
       /**
        * Forwards a host property to this instance.  This method should be

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -77,9 +77,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         @param {Node} parentNode node into which to insert dom
         @param {Node} refNode node before which to insert dom
       */
-      insertBefore(parentNode, refNode) {
-        parentNode.insertBefore(this.root, refNode);
-        this._flushProperties();
+      connect(parentNode, refNode) {
+        if (!this.__dataClientsInitialized) {
+          this.__parentNode = parentNode;
+          this.__refNode = refNode;
+          this._flushProperties();
+        } else {
+          for (let i=0, l=this.children.length; i < l; i++) {
+            parentNode.insertBefore(this.children[i], refNode);
+          }
+        }
+      }
+
+      /**
+        Removes the templatized dom.
+      */
+      disconnect() {
+        for (let i=0, l=this.children.length; i < l; i++) {
+          let c = this.children[i];
+          c.parentNode.removeChild(c);
+        }
+      }
+
+      _readyClients() {
+        super._readyClients();
+        this.__parentNode.insertBefore(this.root, this.__refNode);
+        // no longer needed, don't hold reference
+        this.__parentNode = this.__refNode = null;
       }
       /**
        * Forwards a host property to this instance.  This method should be

--- a/test/smoke/ready-order.html
+++ b/test/smoke/ready-order.html
@@ -1,0 +1,72 @@
+ <!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+  <dom-module id="grandchild-element">
+  <script>
+      Polymer({
+        is: 'grandchild-element',
+        ready: function(){
+          console.log('grandchild-element ready');
+        }
+      });
+  </script>
+</dom-module>
+<dom-module id="child-element">
+  <template>
+    <grandchild-element></grandchild-element>
+    <h2>{{person}}</h2>
+  </template>
+  <script>
+      Polymer({
+        is: 'child-element',
+        properties: {
+          person: {
+            type: Object
+          }
+        },
+        ready: function(){
+          console.log('child-element ready');
+        }
+      });
+  </script>
+</dom-module>
+ <dom-module id="parent-element">
+  <template>
+     <template is="dom-repeat" items="[[childrenData]]">
+      <child-element person="[[item]]"></child-element>
+    </template>
+  </template>
+  <script>
+      Polymer({
+        is: 'parent-element',
+        properties: {
+          childrenData: {
+            type: Array,
+            value: function() { return ["Child name"]}
+          }
+        },
+        ready: function(){
+          console.log('parent-element ready');
+        }
+      });
+  </script>
+</dom-module>
+
+
+<parent-element></parent-element>
+
+</body>
+</html>

--- a/test/unit/templatize-elements.html
+++ b/test/unit/templatize-elements.html
@@ -135,7 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             prop: 'bar'
           }
         } : null);
-      this.parentNode.appendChild(this.instance.root);
+      this.instance.insertBefore(this.parentNode)
     }
   });
 
@@ -190,7 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             prop: 'bar'
           }
         } : null);
-      this.parentNode.appendChild(this.instance.root);
+      this.instance.insertBefore(this.parentNode);
     }
   });
 

--- a/test/unit/templatize-elements.html
+++ b/test/unit/templatize-elements.html
@@ -135,7 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             prop: 'bar'
           }
         } : null);
-      this.instance.insertBefore(this.parentNode)
+      this.instance.connect(this.parentNode)
     }
   });
 
@@ -190,7 +190,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             prop: 'bar'
           }
         } : null);
-      this.instance.insertBefore(this.parentNode);
+      this.instance.connect(this.parentNode);
     }
   });
 


### PR DESCRIPTION
Fixes #4447. This api should be used to insert instances into the dom. Using it ensures that sub elements are "readied" before host elements.