### PR TITLE
Fixes #4447

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -549,6 +549,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _initializeProperties() {
         Polymer.telemetry.instanceCount++;
+        hostStack.registerHost(this);
         this.constructor.finalize();
         const importPath = this.constructor.importPath;
         // note: finalize template when we have access to `localName` to
@@ -598,7 +599,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (window.ShadyCSS) {
           window.ShadyCSS.styleElement(this);
         }
-        this._flushProperties();
+        if (!this.__dataInitialized) {
+          this._flushProperties();
+        }
       }
 
       /**
@@ -616,7 +619,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       ready() {
         if (this._template) {
+          hostStack.beginHosting(this);
           this.root = this._stampTemplate(this._template);
+          hostStack.endHosting(this);
         }
         super.ready();
       }
@@ -744,6 +749,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return PolymerElement;
   });
+
+  /**
+   * Helper api for enqueing client dom created by a host element.
+   *
+   * By default elements are flushed via `_flushProperties` when
+   * `connectedCallback` is called. Elements attach their client dom to
+   * themselves at `ready` time which results from this first flush.
+   * This provides an ordering guarantee that the client dom an element
+   * creates is flushed before the element itself (i.e. client `ready`
+   * fires before host `ready`).
+   *
+   * However, if `_flushProperties` is called *before* an element is connected,
+   * as for example `Templatize` does, this ordering guarantee cannot be
+   * satisfied because no elements are connected. (Note: Bound elements that
+   * receive data do become enqueued clients and are properly ordered but
+   * unbound elements are not.)
+   *
+   * To maintain the desired "client before host" ordering guarantee for this
+   * case we rely on the "host stack. Client nodes registers themselves with
+   * the creating host element when created. This ensures that all client dom
+   * is readied in the proper order, maintaining the desired guarantee.
+   *
+   * @private
+   */
+  let hostStack = {
+
+    stack: [],
+
+    registerHost(inst) {
+      if (this.stack.length) {
+        let host = this.stack[this.stack.length-1];
+        host._enqueueClient(inst);
+      }
+    },
+
+    beginHosting(inst) {
+      this.stack.push(inst);
+    },
+
+    endHosting(inst) {
+      let stackLen = this.stack.length;
+      if (stackLen && this.stack[stackLen-1] == inst) {
+        this.stack.pop();
+      }
+    }
+
+  }
 
   /**
    * Provides basic tracking of element definitions (registrations) and

--- a/test/runner.html
+++ b/test/runner.html
@@ -46,6 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/case-map.html',
       'unit/configure.html',
       'unit/ready-attached-order.html',
+      'unit/ready-attached-order-class.html',
       'unit/attributes.html',
       'unit/async.html',
       'unit/behaviors.html',

--- a/test/smoke/ordering-test.html
+++ b/test/smoke/ordering-test.html
@@ -40,8 +40,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     connectedCallback() {
       console.group(this.localName, 'connected');
-      super.connectedCallback();
       console.warn(this.localName, 'connected (user)', this.shadowRoot);
+      super.connectedCallback();
       console.groupEnd(this.localName, 'connected');
     }
     _flushProperties() {
@@ -79,8 +79,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     connectedCallback() {
       console.group(this.localName, 'connected');
-      super.connectedCallback();
       console.warn(this.localName, 'connected (user)', this.shadowRoot);
+      super.connectedCallback();
       console.groupEnd(this.localName, 'connected');
     }
     _flushProperties() {
@@ -113,8 +113,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     connectedCallback() {
       console.group(this.localName, 'connected');
-      super.connectedCallback();
       console.warn(this.localName, 'connected (user)', this.shadowRoot);
+      super.connectedCallback();
       console.groupEnd(this.localName, 'connected');
     }
     _flushProperties() {

--- a/test/unit/ready-attached-order-class.html
+++ b/test/unit/ready-attached-order-class.html
@@ -26,30 +26,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   window.clearTestLists();
 
-  window.readyBehavior = {
-    properties: {
-      prop: {
-        value: true,
-        observer: '_propChanged'
-      },
-    },
-    _propChanged: function() {
-      this.observerShadowRoot = Boolean(this.shadowRoot);
-    },
-    ready: function() {
-      this._readied = true;
-      this.readyList = window.actualReadyList.slice();
-      this.readyShadowRoot = Boolean(this.shadowRoot);
-      window.actualReadyList.push(this);
-    },
+  window.readyMixin = function(base) {
+    return class readyMixin extends base {
+      static get properties() {
+        return {
+          prop: {
+            value: true,
+            observer: '_propChanged'
+          }
+        }
+      }
 
-    attached: function() {
-      this.attachedShadowRoot = Boolean(this.shadowRoot);
-      this.attachedTime$Keys = Object.keys(this.$);
-      this.attachedList = window.actualAttachedList.slice();
-      window.actualAttachedList.push(this);
-      if (!this._readied) {
-        window.actualReadyBeforeAtachedList.push(this);
+      _propChanged() {
+        this.observerShadowRoot = Boolean(this.shadowRoot);
+      }
+      ready() {
+        super.ready();
+        this._readied = true;
+        this.readyList = window.actualReadyList.slice();
+        this.readyShadowRoot = Boolean(this.shadowRoot);
+        window.actualReadyList.push(this);
+      }
+
+      connectedCallback() {
+        this._eventList = [];
+        this.addEventListener('e', (e) => {
+          this._eventList.push(e.composedPath()[0]);
+        });
+        super.connectedCallback();
+        this.dispatchEvent(new Event('e', {composed: true, bubbles: true}))
+        this.attachedShadowRoot = Boolean(this.shadowRoot);
+        this.attachedTime$Keys = Object.keys(this.$);
+        this.attachedList = window.actualAttachedList.slice();
+        window.actualAttachedList.push(this);
+        if (!this._readied) {
+          window.actualReadyBeforeAtachedList.push(this);
+        }
       }
     }
   };
@@ -61,10 +73,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   HTMLImports.whenReady(function() {
-    Polymer({
-      is: 'x-zot',
-      behaviors: [window.readyBehavior]
-    });
+    class El extends window.readyMixin(Polymer.Element) {
+      static get is() { return 'x-zot' }
+    }
+    customElements.define(El.is, El);
   });
   </script>
 </dom-module>
@@ -75,10 +87,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   HTMLImports.whenReady(function() {
-    Polymer({
-      is: 'x-bar',
-      behaviors: [window.readyBehavior]
-    });
+    class El extends window.readyMixin(Polymer.Element) {
+      static get is() { return 'x-bar' }
+    }
+    customElements.define(El.is, El);
   });
   </script>
 </dom-module>
@@ -90,10 +102,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   HTMLImports.whenReady(function() {
-    Polymer({
-      is: 'x-foo',
-      behaviors: [window.readyBehavior]
-    });
+    class El extends window.readyMixin(Polymer.Element) {
+      static get is() { return 'x-foo' }
+    }
+    customElements.define(El.is, El);
   });
   </script>
 </dom-module>
@@ -110,16 +122,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   HTMLImports.whenReady(function() {
-    Polymer({
-      is: 'x-ready',
-      properties: {
-        foo: {
-          observer: '_fooChanged'
+    class El extends window.readyMixin(Polymer.Element) {
+      static get is() { return 'x-ready' }
+      static get properties() {
+        return {
+          foo: {
+            observer: '_fooChanged'
+          }
         }
-      },
-      behaviors: [window.readyBehavior],
-      _fooChanged: function() {}
-    });
+      }
+      _fooChanged() {}
+    }
+    customElements.define(El.is, El);
+
   });
   </script>
 </dom-module>
@@ -132,14 +147,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   HTMLImports.whenReady(function() {
-    Polymer({
-      is: 'x-templatized',
-      properties: {
-        foo: {
-          value: 'foo'
+    class El extends Polymer.Element {
+      static get is() { return 'x-templatized' }
+      static get properties() {
+        return {
+          foo: {
+            value: 'foo'
+          }
         }
       }
-    });
+    }
+    customElements.define(El.is, El);
   });
   </script>
 </dom-module>
@@ -169,14 +187,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.includeMembers(b2.readyList, [b2.$.zot]);
     });
 
-    // test('element dom connected before element', function() {
-    //   assert.includeMembers(el.attachedList, [el.$.a, el.$.b, el.$.c, el.$.d, el.$.foo]);
-    //   var foo = el.$.foo;
-    //   assert.includeMembers(foo.attachedList, [foo.$.bar1, foo.$.bar2]);
-    //   var b1 = foo.$.bar1, b2 = foo.$.bar2;
-    //   assert.includeMembers(b1.attachedList, [b1.$.zot]);
-    //   assert.includeMembers(b2.attachedList, [b2.$.zot]);
-    // });
+    test('can listen to events fired by element dom in connected', function() {
+      assert.includeMembers(el._eventList, [el.$.a, el.$.b, el.$.c, el.$.d, el.$.foo]);
+      var foo = el.$.foo;
+      assert.includeMembers(foo._eventList, [foo.$.bar1, foo.$.bar2]);
+      var b1 = foo.$.bar1, b2 = foo.$.bar2;
+      assert.includeMembers(b1._eventList, [b1.$.zot]);
+      assert.includeMembers(b2._eventList, [b2.$.zot]);
+    });
 
     test('shadowRoot available in ready, connected, observer', function() {
       [el, el.$.a, el.$.b, el.$.c, el.$.d, el.$.foo,
@@ -222,6 +240,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var b1 = foo.$.bar1, b2 = foo.$.bar2;
       assert.includeMembers(b1.readyList, [b1.$.zot]);
       assert.includeMembers(b2.readyList, [b2.$.zot]);
+    });
+
+    test('can listen to events fired by element dom in connected', function() {
+      assert.includeMembers(el._eventList, [el.$.a, el.$.b, el.$.c, el.$.d, el.$.foo]);
+      var foo = el.$.foo;
+      assert.includeMembers(foo._eventList, [foo.$.bar1, foo.$.bar2]);
+      var b1 = foo.$.bar1, b2 = foo.$.bar2;
+      assert.includeMembers(b1._eventList, [b1.$.zot]);
+      assert.includeMembers(b2._eventList, [b2.$.zot]);
     });
 
     test('shadowRoot available in ready, connected, observer', function() {

--- a/test/unit/shady-dynamic.html
+++ b/test/unit/shady-dynamic.html
@@ -131,7 +131,7 @@ HTMLImports.whenReady(function() {
 
 
 <dom-module id="x-select3">
-  <template><slot name="s3"></slot></template>
+  <template><slot id="x-select3-slot" name="s3"></slot></template>
   <script>
   HTMLImports.whenReady(function() {
     Polymer({is: 'x-select3'});
@@ -140,7 +140,7 @@ HTMLImports.whenReady(function() {
 </dom-module>
 
 <dom-module id="x-select2">
-  <template><x-select3 id="select"><slot name="s2"></slot></x-select3></template>
+  <template><x-select3 id="select"><slot id="x-select2-slot" name="s2"></slot></x-select3></template>
   <script>
   HTMLImports.whenReady(function() {
     Polymer({is: 'x-select2'});
@@ -149,7 +149,7 @@ HTMLImports.whenReady(function() {
 </dom-module>
 
 <dom-module id="x-select1">
-  <template><x-select2 id="select"><slot name="s1"></slot></x-select2></template>
+  <template><x-select2 id="select"><slot id="x-select1-slot" name="s1"></slot></x-select2></template>
   <script>
   HTMLImports.whenReady(function() {
     Polymer({is: 'x-select1'});


### PR DESCRIPTION
Re-introduce the `hostStack` in order to maintain “clien…t before host” ordering when `_flushProperties` is called before `connectedCallback` (e.g. as Templatize does).

Should be blocked on https://github.com/webcomponents/shadydom/issues/116