### PR TITLE
Adds back the `beforeRegister` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ configure the module name. The only supported declarative way set the module
 id is to use `id`.
 * <a name="breaking-getPropertyInfo"></a>`element.getPropertyInfo`: This api returned unexpected information some of the time and was rarely used.
 * <a name="breaking-getNativePrototype"></a>`element.getNativePrototype`: Removed because it is no longer needed for internal code and was unused by users.
-* <a name="breaking-beforeRegister"></a>`element.beforeRegister`: This was originally added for metadata compatibility with ES6 classes. We now prefer users create ES6 classes by extending `Polymer.Element`, specifying metadata in the static `config` property. For legacy use via `Polymer({...})`, dynamic effects may now be added using the `registered` lifecycle method.
+* <a name="breaking-beforeRegister"></a>`element.beforeRegister`: This was originally added for metadata compatibility with ES6 classes. We now prefer users create ES6 classes by extending `Polymer.Element`, specifying metadata in the static `config` property. For legacy use via `Polymer({...})`, dynamic effects may still be added by using `beforeRegister` but it is now equivalent to the `registered` lifecycle method. An element's `is` property cannot be set in `beforeRegister` as it could in Polymer 1.x.
 * <a name="breaking-attributeFollows"></a>`element.attributeFollows`: Removed due to disuse.
 * <a name="breaking-classFollows"></a>`element.classFollows`: Removed due to disuse.
 * <a name="breaking-copyOwnProperty"></a>`element.copyOwnProperty`: Removed due to disuse.

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ configure the module name. The only supported declarative way set the module
 id is to use `id`.
 * <a name="breaking-getPropertyInfo"></a>`element.getPropertyInfo`: This api returned unexpected information some of the time and was rarely used.
 * <a name="breaking-getNativePrototype"></a>`element.getNativePrototype`: Removed because it is no longer needed for internal code and was unused by users.
-* <a name="breaking-beforeRegister"></a>`element.beforeRegister`: This was originally added for metadata compatibility with ES6 classes. We now prefer users create ES6 classes by extending `Polymer.Element`, specifying metadata in the static `config` property. For legacy use via `Polymer({...})`, dynamic effects may still be added by using `beforeRegister` but it is now equivalent to the `registered` lifecycle method. An element's `is` property cannot be set in `beforeRegister` as it could in Polymer 1.x.
+* <a name="breaking-beforeRegister"></a>`element.beforeRegister`: This was originally added for metadata compatibility with ES6 classes. We now prefer users create ES6 classes by extending `Polymer.Element`, specifying metadata in the static `properties`, `observers`, and `is` properties. For legacy use via `Polymer({...})`, dynamic effects may still be added by using `beforeRegister` but it is now equivalent to the `registered` lifecycle method. An element's `is` property cannot be set in `beforeRegister` as it could in Polymer 1.x.
 * <a name="breaking-attributeFollows"></a>`element.attributeFollows`: Removed due to disuse.
 * <a name="breaking-classFollows"></a>`element.classFollows`: Removed due to disuse.
 * <a name="breaking-copyOwnProperty"></a>`element.copyOwnProperty`: Removed due to disuse.

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -162,6 +162,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         _registered() {
           super._registered();
+          /* NOTE: `beforeRegister` is called here for bc, but the behavior
+           is different than in 1.x. In 1.0, the method was called *after*
+           mixing prototypes together but *before* processing of meta-objects.
+           However, dynamic effects can still be set here and can be done either
+           in `beforeRegister` or `registered`. It is no longer possible to set
+           `is` in `beforeRegister` as you could in 1.x.
+          */
+          if (info.beforeRegister) {
+            info.beforeRegister.call(Object.getPrototypeOf(this));
+          }
           if (info.registered) {
             info.registered.call(Object.getPrototypeOf(this));
           }
@@ -311,13 +321,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         LegacyElementMixin(HTMLElement));
       // decorate klass with registration info
       klass.is = info.is;
-      // NOTE: while we could call `beforeRegister` here to maintain
-      // some BC, the state of the element at this point is not as it was in 1.0
-      // In 1.0, the method was called *after* mixing prototypes together
-      // but before processing of meta-objects. Since this is now done
-      // in 1 step via `GenerateClassFromInfo`, this is no longer possible.
-      // However, *most* work (not setting `is`) that was previously done in
-      // `beforeRegister` should be possible in `registered`.
       return klass;
     }
 

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -224,6 +224,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     Polymer.registerBehavior1 ={
+      beforeRegister: function() {
+        this._createPropertyObserver('beforeProp', 'beforePropChanged1');
+        this.beforeRegisterCount++;
+        this.beforeRegisterBehaviors = this.behaviors;
+      },
       registered: function() {
         this._createPropertyObserver('prop', 'propChanged1');
         this._createMethodObserver('propChanged2(prop)');
@@ -235,6 +240,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ready: function() {
         this._ensureAttribute('attr', true);
       },
+      beforePropChanged1: function() {
+        this.beforePropChangedCalled = true;
+      },
       propChanged1: function() {
         this.propChanged1Called = true;
       },
@@ -245,6 +253,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     Polymer.registerBehavior2 ={
       prop2: true,
+      beforeRegister: function() {
+        this.beforeRegisterCount++;
+      },
       registered: function() {
         this.registeredCount++;
       }
@@ -252,6 +263,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     Polymer.registerBehavior3 ={
       prop3: true,
+      beforeRegister: function() {
+        this.beforeRegisterCount++;
+      },
       registered: function() {
         this.registeredCount++;
       }
@@ -264,11 +278,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.registerBehavior3
       ],
       prop4: true,
-
+      beforeRegister: function() {
+        this.beforeRegisterCount++;
+      },
       registered: function() {
         this.registeredCount++;
       },
 
+      beforeRegisterCount: 0,
       registeredCount: 0,
 
       is: 'behavior-registered'
@@ -362,6 +379,23 @@ suite('behavior.registered', function() {
     assert.equal(el.registeredBehaviors.length, 3);
     assert.equal(el.registeredBehaviors, el.behaviors);
     assert.deepEqual(el.registeredProps, [true, true, true, true]);
+  });
+
+});
+
+suite('behavior.beforeRegister', function() {
+  test('can install dynamic properties', function() {
+    var el = fixture('registered');
+    assert.ok(el.$.content);
+    el.beforeProp = 43;
+    assert.isTrue(el.beforePropChangedCalled);
+  });
+
+  test('called once for each behavior with access to element prototype', function() {
+    var el = fixture('registered');
+    assert.equal(el.beforeRegisterCount, 4);
+    assert.equal(el.beforeRegisterBehaviors.length, 3);
+    assert.equal(el.beforeRegisterBehaviors, el.behaviors);
   });
 
 });


### PR DESCRIPTION
Fixes #4500. Users can no longer set the `is` property in this method; however, dynamic property effects can still be installed here.
