### PR TITLE
Adds a better warning for attributes that cannot deserialize from JSON

### DIFF
--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -307,7 +307,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               outValue = JSON.parse(value);
             } catch(x) {
               outValue = null;
-              console.warn('Polymer::Attributes: couldn`t decode Array as JSON');
+              console.warn(`Polymer::Attributes: couldn't decode Array as JSON: ${value}`);
             }
             break;
 

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -212,6 +212,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(element.dashCase, 'Changed');
     });
 
+    test('value that cannot deserialize from JSON warns', function() {
+      sinon.spy(console, 'warn');
+      var badAttr = '[foo, bar]';
+      element.setAttribute('array', badAttr);
+      assert.isTrue(console.warn.calledOnce);
+      assert.include(console.warn.firstCall.args[0], badAttr);
+      console.warn.restore();
+    });
+
   });
 
   suite('imperative attribute change (reflect)', function() {


### PR DESCRIPTION
Fixes #4478. This doesn't really fix the issue in general, but it does address the specific feedback given in the issue.