### PR TITLE
Various Safari 10.1 fixes

### DIFF
--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -244,7 +244,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // if there is not a shadowroot, exit the loop
       while (next && next.shadowRoot && !window.ShadyDOM) {
         // if there is a node at x/y in the shadowroot, look deeper
+        let oldNext = next;
         next = next.shadowRoot.elementFromPoint(x, y);
+        // on Safari, elementFromPoint may return the shadowRoot host
+        if (oldNext === next) {
+          break;
+        }
         if (next) {
           node = next;
         }

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -752,7 +752,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('scoped-styling-var', function() {
 
   function assertComputed(element, value, pseudo, name) {
-    // force a style-recalc for Safari
+    // force a style-recalc for Safari missing updated CSS Custom Properties
+    // https://bugs.webkit.org/show_bug.cgi?id=170708
     element.offsetWidth;
     name = name || 'border-top-width';
     var computed = element.getComputedStyleValue && !pseudo ?
@@ -791,6 +792,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('instances of scoped @keyframes', function(done) {
     if (navigator.userAgent.match(/Safari\/603/) && ShadyCSS.nativeCss && ShadyCSS.nativeShadow) {
       // `:nth-of-type` is broken in shadow roots on Safari 10.1
+      // https://bugs.webkit.org/show_bug.cgi?id=166748
       this.skip();
     }
     var xKeyframes = styled.$.keyframes2;

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -752,6 +752,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('scoped-styling-var', function() {
 
   function assertComputed(element, value, pseudo, name) {
+    // force a style-recalc for Safari
+    element.offsetWidth;
     name = name || 'border-top-width';
     var computed = element.getComputedStyleValue && !pseudo ?
       element.getComputedStyleValue(name) :
@@ -787,6 +789,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   test('instances of scoped @keyframes', function(done) {
+    if (navigator.userAgent.match(/Safari\/603/) && ShadyCSS.nativeCss && ShadyCSS.nativeShadow) {
+      // `:nth-of-type` is broken in shadow roots on Safari 10.1
+      this.skip();
+    }
     var xKeyframes = styled.$.keyframes2;
     var onAnimationEnd = function() {
       assertStylePropertyValue(xKeyframes, 'left', '5px');

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -759,13 +759,7 @@ HTMLImports.whenReady(function() {
       Polymer.flush();
       assert.notInclude(d.getAttribute('style-scoped') || '', styled.is, 'scoping attribute not removed when added to other root');
       assert.notInclude(d.className, styled.is, 'scoping class not removed when added to other root');
-      Polymer.dom(styled.root).appendChild(d);
-      Polymer.flush();
-      assertComputed(d, '4px');
-      Polymer.dom(styled.root).removeChild(d);
-      Polymer.flush();
-      assert.notInclude(d.getAttribute('style-scoped') || '', styled.is, 'scoping attribute not removed when removed from root');
-      assert.notInclude(d.className, styled.is, 'scoping class not removed when removed from root');
+      assertComputed(d, '0px');
       Polymer.dom(styled.root).appendChild(d);
       Polymer.flush();
       assertComputed(d, '4px');


### PR DESCRIPTION
Fix infinite loop on `Polymer.Gestures.deepTargetFind`
Fix styling test for changes caused by [webcomponents/shadycss#79](https://github.com/webcomponents/shadycss/pull/79)
Skip styling test broken by safari bug