### PR TITLE
Add 2.x hybrid affordances for stamping template content. Fixes #4536

### DIFF
--- a/src/lib/template/dom-bind.html
+++ b/src/lib/template/dom-bind.html
@@ -108,8 +108,16 @@ elements to the template itself as the binding scope.
     },
 
     _insertChildren: function() {
-      var parentDom = Polymer.dom(Polymer.dom(this).parentNode);
-      parentDom.insertBefore(this.root, this);
+      var refNode;
+      var parentNode = Polymer.dom(this).parentNode;
+      // Affordance for 2.x hybrid mode
+      if (parentNode.localName == this.is) {
+        refNode = parentNode;
+        parentNode = Polymer.dom(parentNode).parentNode;
+      } else {
+        refNode = this;
+      }
+      Polymer.dom(parentNode).insertBefore(this.root, refNode);
     },
 
     _removeChildren: function() {

--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!parentNode ||
           (parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE &&
            (!Polymer.Settings.hasShadow ||
-            !(this.parentNode instanceof ShadowRoot)))) {
+            !(parentNode instanceof ShadowRoot)))) {
         this._teardownInstance();
       }
     },

--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -134,11 +134,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var parentNode = Polymer.dom(this).parentNode;
       // Guard against element being detached while render was queued
       if (parentNode) {
-        var parent = Polymer.dom(parentNode);
+        var refNode;
+        // Affordance for 2.x hybrid mode
+        if (parentNode.localName == this.is) {
+          refNode = parentNode;
+          parentNode = Polymer.dom(parentNode).parentNode;
+        } else {
+          refNode = this;
+        }
         if (!this._instance) {
           this._instance = this.stamp();
           var root = this._instance.root;
-          parent.insertBefore(root, this);
+          Polymer.dom(parentNode).insertBefore(root, refNode);
         } else {
           var c$ = this._instance._children;
           if (c$ && c$.length) {
@@ -146,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var lastChild = Polymer.dom(this).previousSibling;
             if (lastChild !== c$[c$.length-1]) {
               for (var i=0, n; (i<c$.length) && (n=c$[i]); i++) {
-                parent.insertBefore(n, this);
+                Polymer.dom(parentNode).insertBefore(n, refNode);
               }
             }
           }

--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -82,8 +82,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     detached: function() {
-      if (!this.parentNode ||
-          (this.parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE &&
+      var parentNode = this.parentNode;
+      if (parentNode && parentNode.localName == this.is) {
+        parentNode = Polymer.dom(parentNode).parentNode;
+      }
+      if (!parentNode ||
+          (parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE &&
            (!Polymer.Settings.hasShadow ||
             !(this.parentNode instanceof ShadowRoot)))) {
         this._teardownInstance();

--- a/src/lib/template/dom-if.html
+++ b/src/lib/template/dom-if.html
@@ -135,17 +135,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _ensureInstance: function() {
+      var refNode;
       var parentNode = Polymer.dom(this).parentNode;
+      // Affordance for 2.x hybrid mode
+      if (parentNode && parentNode.localName == this.is) {
+        refNode = parentNode;
+        parentNode = Polymer.dom(parentNode).parentNode;
+      } else {
+        refNode = this;
+      }
       // Guard against element being detached while render was queued
       if (parentNode) {
-        var refNode;
-        // Affordance for 2.x hybrid mode
-        if (parentNode.localName == this.is) {
-          refNode = parentNode;
-          parentNode = Polymer.dom(parentNode).parentNode;
-        } else {
-          refNode = this;
-        }
         if (!this._instance) {
           this._instance = this.stamp();
           var root = this._instance.root;
@@ -154,7 +154,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var c$ = this._instance._children;
           if (c$ && c$.length) {
             // Detect case where dom-if was re-attached in new position
-            var lastChild = Polymer.dom(this).previousSibling;
+            var lastChild = Polymer.dom(refNode).previousSibling;
             if (lastChild !== c$[c$.length-1]) {
               for (var i=0, n; (i<c$.length) && (n=c$[i]); i++) {
                 Polymer.dom(parentNode).insertBefore(n, refNode);

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -710,6 +710,13 @@ Then the `observe` property should be configured as follows:
       var beforeRow = this._instances[idx + 1];
       var beforeNode = beforeRow && !beforeRow.isPlaceholder ? beforeRow._children[0] : this;
       var parentNode = Polymer.dom(this).parentNode;
+      // Affordance for 2.x hybrid mode
+      if (parentNode.localName == this.is) {
+        if (beforeNode == this) {
+          beforeNode = parentNode;
+        }
+        parentNode = Polymer.dom(parentNode).parentNode;
+      }
       Polymer.dom(parentNode).insertBefore(inst.root, beforeNode);
       this._instances[idx] = inst;
       return inst;

--- a/src/lib/template/dom-repeat.html
+++ b/src/lib/template/dom-repeat.html
@@ -285,9 +285,18 @@ Then the `observe` property should be configured as follows:
       // only perform attachment if the element was previously detached.
       if (this.__isDetached) {
         this.__isDetached = false;
-        var parent = Polymer.dom(Polymer.dom(this).parentNode);
+        var refNode;
+        var parentNode = Polymer.dom(this).parentNode;
+        // Affordance for 2.x hybrid mode
+        if (parentNode.localName == this.is) {
+          refNode = parentNode;
+          parentNode = Polymer.dom(parentNode).parentNode;
+        } else {
+          refNode = this;
+        }
+        var parent = Polymer.dom(parentNode);
         for (var i=0; i<this._instances.length; i++) {
-          this._attachInstance(i, parent);
+          this._attachInstance(i, parent, refNode);
         }
       }
     },
@@ -666,10 +675,10 @@ Then the `observe` property should be configured as follows:
       }
     },
 
-    _attachInstance: function(idx, parent) {
+    _attachInstance: function(idx, parent, refNode) {
       var inst = this._instances[idx];
       if (!inst.isPlaceholder) {
-        parent.insertBefore(inst.root, this);
+        parent.insertBefore(inst.root, refNode);
       }
     },
 

--- a/test/unit/dom-bind.html
+++ b/test/unit/dom-bind.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 
   <script>
-  /* global earlyDomBind earlyBoundChild decEl1 decEl2 decDomBind z container needsHost*/
+  /* global earlyDomBind earlyBoundChild decEl1 decEl2 decDomBind z container needsHost hybridDomBind hybridEl1 hybridEl2*/
     earlyDomBind.value = 'hi!';
   </script>
 
@@ -41,6 +41,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="dom-bind" id="timingDomBind" config="config">
     <x-needs-host id="needsHost"></x-needs-host>
   </template>
+
+  <dom-bind>
+    <template is="dom-bind" id="hybridDomBind">
+      <x-basic value="{{value}}" id="hybridEl1"></x-basic>
+      <x-basic value="{{value}}" id="hybridEl2"></x-basic>
+    </template>
+  </dom-bind>
 
   <script>
 
@@ -235,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
           done();
         });
-      });        
+      });
 
       test('re-enable dom-change', function(done) {
         if (Polymer.Settings.suppressTemplateNotifications) {
@@ -251,6 +258,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else {
           done();
         }
+      });
+
+    });
+
+    suite('hybrid dom-bind', function() {
+
+      var domBind;
+      var el1;
+      var el2;
+
+      setup(function() {
+        domBind = hybridDomBind;
+        el1 = hybridEl1;
+        el2 = hybridEl2;
+      });
+
+      test('value binds top-down', function() {
+        domBind.value = 'foo';
+        assert.equal(el1.value, 'foo');
+        assert.equal(el2.value, 'foo');
+      });
+
+      test('parent is parent of <dom-bind>', function() {
+        domBind.value = 'foo';
+        assert.equal(el1.parentNode, document.body);
+        assert.equal(el2.parentNode, document.body);
       });
 
     });

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -71,8 +71,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template is="dom-if" if id="toBeRemoved"><div id="shouldBeRemoved"></div></template>
   </div>
 
+  <!-- 2.x hybrid test -->
+  <dom-if>
+    <template is="dom-if" id="hybridDomIf" if restamp>
+      <div hybrid-stamped>[[prop]]</div>
+    </template>
+  </dom-if>
+
   <script>
-    /* global configured individual unconfigured1 unconfigured2 inDocumentContainer inDocumentIf structuredContainer structuredDomIf structuredDomBind outerContainer innerContainer shouldBeRemoved toBeRemoved removalContainer*/
+    /* global configured individual unconfigured1 unconfigured2 inDocumentContainer inDocumentIf structuredContainer structuredDomIf structuredDomBind outerContainer innerContainer shouldBeRemoved toBeRemoved removalContainer hybridDomIf*/
+
+    suite('hybrid dom-if', function() {
+
+      test('parent is parent of <dom-if>', function() {
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 1);
+        assert.equal(stamped[0].parentNode, document.body);
+      });
+
+      test('children removed correctly', function() {
+        hybridDomIf.if = false;
+        hybridDomIf.render();
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
     suite('nested pre-configured dom-if', function() {
 
       test('parent scope binding', function() {
@@ -337,7 +362,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var stamped = Polymer.dom(unconfigured1.root).querySelectorAll('*:not(template):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         stamped[0].prop = 'outer';
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
       });
 
@@ -352,7 +377,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         stamped.forEach(function(n) {
           assert.equal(getComputedStyle(n).display, 'none', 'node was not hidden but should have been');
         });
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
       });
 
@@ -368,7 +393,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         stamped.forEach(function(n) {
           assert.equal(getComputedStyle(n).display, 'inline', 'node was hidden but should not have been');
         });
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
       });
 
@@ -380,10 +405,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         CustomElements.takeRecords();
         CustomElements.takeRecords();
         var stamped = Polymer.dom(unconfigured1.root).querySelectorAll('*:not(template)');
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
         assert.equal(stamped.length, 0, 'total stamped count incorrect');
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
       });
 
@@ -398,7 +423,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var stamped = Polymer.dom(unconfigured1.root).querySelectorAll('*:not(template):not(span)');
         assert.equal(stamped.length, 3, 'total stamped count incorrect');
         stamped[0].prop = 'outer';
-        assert.equal(unconfigured1.domUpdateHandlerCount, 
+        assert.equal(unconfigured1.domUpdateHandlerCount,
           Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
       });
 

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('hybrid dom-if', function() {
 
       test('parent is parent of <dom-if>', function() {
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 1);
         assert.equal(stamped[0].parentNode, document.body);
       });
@@ -95,12 +95,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.dom(document.body).removeChild(wrapper);
         CustomElements.takeRecords();
         domIf.render();
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 0);
         Polymer.dom(removalContainer).appendChild(wrapper);
         CustomElements.takeRecords();
         setTimeout(function() {
-          stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+          stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
           assert.equal(stamped.length, 1);
           assert.equal(stamped[0].parentNode, removalContainer);
           done();
@@ -110,7 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('children removed correctly', function() {
         hybridDomIf.if = false;
         hybridDomIf.render();
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 0);
       });
 

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -72,18 +72,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </div>
 
   <!-- 2.x hybrid test -->
-  <dom-if>
+  <dom-if id="hybridDomIfWrapper">
     <template is="dom-if" id="hybridDomIf" if restamp>
       <div hybrid-stamped>[[prop]]</div>
     </template>
   </dom-if>
 
   <script>
-    /* global configured individual unconfigured1 unconfigured2 inDocumentContainer inDocumentIf structuredContainer structuredDomIf structuredDomBind outerContainer innerContainer shouldBeRemoved toBeRemoved removalContainer hybridDomIf*/
+    /* global configured individual unconfigured1 unconfigured2 inDocumentContainer inDocumentIf structuredContainer structuredDomIf structuredDomBind outerContainer innerContainer shouldBeRemoved toBeRemoved removalContainer hybridDomIf hybridDomIfWrapper*/
 
     suite('hybrid dom-if', function() {
 
       test('parent is parent of <dom-if>', function() {
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 1);
+        assert.equal(stamped[0].parentNode, document.body);
+      });
+
+      test('remove & re-add works correctly', function() {
+        var wrapper = hybridDomIfWrapper;
+        Polymer.dom(document.body).removeChild(wrapper);
+        Polymer.dom(document.body).appendChild(wrapper);
+        CustomElements.takeRecords();
+        hybridDomIf.render();
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 1);
         assert.equal(stamped[0].parentNode, document.body);

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -89,15 +89,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(stamped[0].parentNode, document.body);
       });
 
-      test('remove & re-add works correctly', function() {
+      test('remove & re-add works correctly', function(done) {
         var wrapper = hybridDomIfWrapper;
+        var domIf = hybridDomIf;
         Polymer.dom(document.body).removeChild(wrapper);
-        Polymer.dom(document.body).appendChild(wrapper);
         CustomElements.takeRecords();
-        hybridDomIf.render();
+        domIf.render();
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
-        assert.equal(stamped.length, 1);
-        assert.equal(stamped[0].parentNode, document.body);
+        assert.equal(stamped.length, 0);
+        Polymer.dom(removalContainer).appendChild(wrapper);
+        CustomElements.takeRecords();
+        setTimeout(function() {
+          stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+          assert.equal(stamped.length, 1);
+          assert.equal(stamped[0].parentNode, removalContainer);
+          done();
+        });
       });
 
       test('children removed correctly', function() {

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -80,8 +80,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <div id="inDocumentContainer">
   </div>
 
+  <!-- 2.x hybrid test -->
+  <dom-repeat>
+    <template is="dom-repeat" id="hybridDomRepeat" items='[{"prop":"a"},{"prop":"b"},{"prop":"c"}]'>
+      <div hybrid-stamped>[[item.prop]]</div>
+    </template>
+  </dom-repeat>
+
   <script>
-  /* global unconfigured1 unconfigured primitive limited inDocumentRepeater configured inDocumentContainer inDocumentContainerOrig unconfigured2 primitiveLarge simple:true model:true stamped:true chunked */
+  /* global unconfigured1 unconfigured primitive limited inDocumentRepeater configured inDocumentContainer inDocumentContainerOrig unconfigured2 primitiveLarge simple:true model:true stamped:true chunked hybridDomRepeat*/
 
     /*
       Expected:
@@ -99,7 +106,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       stamped[37] .. 3-3-2
       stamped[38] .. 3-3-3
     */
-
 
     suite('errors', function() {
 
@@ -830,7 +836,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(stamped2[39].itemaProp, 'new-1');
           assert.equal(stamped2[40].itemaProp, 'new-2');
           assert.equal(stamped2[41], undefined);
-          assert.equal(unconfigured1.domUpdateHandlerCount, 
+          assert.equal(unconfigured1.domUpdateHandlerCount,
             Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
           done();
         });
@@ -854,7 +860,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(stamped2[38].indexb, 2);
           assert.equal(stamped2[38].indexc, 2);
           assert.equal(stamped2[39], undefined);
-          assert.equal(unconfigured1.domUpdateHandlerCount, 
+          assert.equal(unconfigured1.domUpdateHandlerCount,
             Polymer.Settings.suppressTemplateNotifications ? 0 : 1);
           done();
         });
@@ -3870,22 +3876,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
-      suite('notification suppression', function() {
+    }
 
-        test('re-enable dom-change', function() {
-          if (Polymer.Settings.suppressTemplateNotifications) {
-            unconfigured1.$.repeater.setAttribute('notify-dom-change', '');
-            unconfigured1.domUpdateHandlerCount = 0;
-            unconfigured.items = unconfigured.items.slice();
-            setTimeout(function() {
-              assert.equal(unconfigured1.domUpdateHandlerCount, 1);
-            });
-          }
-        });
+    suite('notification suppression', function() {
 
+      test('re-enable dom-change', function() {
+        if (Polymer.Settings.suppressTemplateNotifications) {
+          unconfigured1.$.repeater.setAttribute('notify-dom-change', '');
+          unconfigured1.domUpdateHandlerCount = 0;
+          unconfigured.items = unconfigured.items.slice();
+          setTimeout(function() {
+            assert.equal(unconfigured1.domUpdateHandlerCount, 1);
+          });
+        }
       });
 
-    }
+    });
+
+    suite('hybrid dom-repeat', function() {
+
+      test('parent is parent of <dom-repeat>', function() {
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 3);
+        stamped.forEach(function(el) {
+          assert.equal(el.parentNode, document.body);
+        });
+      });
+
+      test('children removed correctly', function() {
+        hybridDomRepeat.items = null;
+        hybridDomRepeat.render();
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 0);
+      });
+
+    });
 
   </script>
 

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -81,14 +81,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </div>
 
   <!-- 2.x hybrid test -->
-  <dom-repeat>
+  <dom-repeat id="hybridDomRepeatWrapper">
     <template is="dom-repeat" id="hybridDomRepeat" items='[{"prop":"a"},{"prop":"b"},{"prop":"c"}]'>
       <div hybrid-stamped>[[item.prop]]</div>
     </template>
   </dom-repeat>
 
   <script>
-  /* global unconfigured1 unconfigured primitive limited inDocumentRepeater configured inDocumentContainer inDocumentContainerOrig unconfigured2 primitiveLarge simple:true model:true stamped:true chunked hybridDomRepeat*/
+  /* global unconfigured1 unconfigured primitive limited inDocumentRepeater configured inDocumentContainer inDocumentContainerOrig unconfigured2 primitiveLarge simple:true model:true stamped:true chunked hybridDomRepeat hybridDomRepeatWrapper*/
 
     /*
       Expected:
@@ -3896,6 +3896,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('hybrid dom-repeat', function() {
 
       test('parent is parent of <dom-repeat>', function() {
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 3);
+        stamped.forEach(function(el) {
+          assert.equal(el.parentNode, document.body);
+        });
+      });
+
+      test('remove & re-add works correctly', function() {
+        var wrapper = hybridDomRepeatWrapper;
+        Polymer.dom(document.body).removeChild(wrapper);
+        Polymer.dom(document.body).appendChild(wrapper);
+        CustomElements.takeRecords();
+        hybridDomRepeat.render();
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
         stamped.forEach(function(el) {

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3905,20 +3905,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('remove & re-add works correctly', function() {
+        var domRepeat = hybridDomRepeat;
         var wrapper = hybridDomRepeatWrapper;
         Polymer.dom(document.body).removeChild(wrapper);
         CustomElements.takeRecords();
-        hybridDomRepeat.render();
+        domRepeat.render();
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 0);
         Polymer.dom(document.body).appendChild(wrapper);
         CustomElements.takeRecords();
-        hybridDomRepeat.render();
+        domRepeat.render();
         stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
         stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
-          assert.equal(el.textContent, hybridDomRepeat.items[i].prop);
+          assert.equal(el.textContent, domRepeat.items[i].prop);
         });
       });
 

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3896,7 +3896,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('hybrid dom-repeat', function() {
 
       test('parent is parent of <dom-repeat>', function() {
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
         stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
@@ -3910,12 +3910,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.dom(document.body).removeChild(wrapper);
         CustomElements.takeRecords();
         domRepeat.render();
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 0);
         Polymer.dom(document.body).appendChild(wrapper);
         CustomElements.takeRecords();
         domRepeat.render();
-        stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
         stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
@@ -3926,7 +3926,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('insertion works correctly', function() {
         hybridDomRepeat.splice('items', 1, 0, {prop: 'new'});
         hybridDomRepeat.render();
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 4);
         stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
@@ -3937,7 +3937,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('children removed correctly', function() {
         hybridDomRepeat.items = null;
         hybridDomRepeat.render();
-        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        var stamped = [].slice.call(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 0);
       });
 

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3898,21 +3898,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('parent is parent of <dom-repeat>', function() {
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
-        stamped.forEach(function(el) {
+        stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
+          assert.equal(el.textContent, hybridDomRepeat.items[i].prop);
         });
       });
 
       test('remove & re-add works correctly', function() {
         var wrapper = hybridDomRepeatWrapper;
         Polymer.dom(document.body).removeChild(wrapper);
-        Polymer.dom(document.body).appendChild(wrapper);
         CustomElements.takeRecords();
         hybridDomRepeat.render();
         var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 0);
+        Polymer.dom(document.body).appendChild(wrapper);
+        CustomElements.takeRecords();
+        hybridDomRepeat.render();
+        stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
         assert.equal(stamped.length, 3);
-        stamped.forEach(function(el) {
+        stamped.forEach(function(el, i) {
           assert.equal(el.parentNode, document.body);
+          assert.equal(el.textContent, hybridDomRepeat.items[i].prop);
+        });
+      });
+
+      test('insertion works correctly', function() {
+        hybridDomRepeat.splice('items', 1, 0, {prop: 'new'});
+        hybridDomRepeat.render();
+        var stamped = Array.from(document.querySelectorAll('[hybrid-stamped]'));
+        assert.equal(stamped.length, 4);
+        stamped.forEach(function(el, i) {
+          assert.equal(el.parentNode, document.body);
+          assert.equal(el.textContent, hybridDomRepeat.items[i].prop);
         });
       });
 


### PR DESCRIPTION
Fixes #4536

Checks whether parent `localName` matches `this.is` and stamps above that parent if so.