### PR TITLE
Guard against overwriting bound values with hasOwnProperty. Fixes #4540

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -597,14 +597,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         for (let p in p$) {
           let info = p$[p];
-          if (!this._isPropertyPending(p)) {
+          // Don't set default value if there is already an own property, which
+          // happens when a `properties` property with default but no effects had
+          // a property set (e.g. bound) by its host before upgrade
+          if (!this.hasOwnProperty(p)) {
             let value = typeof info.value == 'function' ?
               info.value.call(this) :
               info.value;
             // Set via `_setProperty` if there is an accessor, to enable
             // initializing readOnly property defaults
             if (this._hasAccessor(p)) {
-              this._setProperty(p, value)
+              this._setPendingProperty(p, value, true);
             } else {
               this[p] = value;
             }

--- a/test/unit/configure.html
+++ b/test/unit/configure.html
@@ -270,6 +270,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         defaultUsesNoEffectProp: {
           type: Number
         },
+        boundNoEffectProp: {
+          type: Number,
+          value: 5
+        },
         prop: {
           value: 'lazy',
           observer: 'propChanged'
@@ -294,7 +298,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <dom-module id="x-config-lazy-host">
     <template>
-      <x-config-lazy id="lazy" prop="{{foo}}" read-only-prop="{{foo}}" had-attr-prop="attrValue"></x-config-lazy>
+      <x-config-lazy id="lazy" prop="{{foo}}" read-only-prop="{{foo}}" had-attr-prop="attrValue" bound-no-effect-prop="{{foo}}"></x-config-lazy>
     </template>
     <script>
     HTMLImports.whenReady(function() {
@@ -489,6 +493,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer(window.XConfigLazy);
       assert.equal(el.$.lazy.noEffectProp, 1);
       assert.equal(el.$.lazy.defaultUsesNoEffectProp, 2);
+      assert.equal(el.$.lazy.boundNoEffectProp, 'foo');
       assert.equal(el.$.lazy.prop, 'foo');
       assert.isTrue(el.$.lazy.propChanged.calledOnce);
       assert.equal(el.$.lazy.readOnlyProp, 'readOnly');


### PR DESCRIPTION
Fixes #4540
