### PR TITLE
Process paths regardless of accessor, & loop on computeLinkedPaths.

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -371,12 +371,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    */
   function runComputedEffects(inst, changedProps, oldProps, hasPaths) {
     let computeEffects = inst.__computeEffects;
-    if (computeEffects) {
-      let inputProps = changedProps;
-      while (runEffects(inst, computeEffects, inputProps, oldProps, hasPaths)) {
+    let inputProps = changedProps;
+    while (inputProps) {
+      computeEffects && runEffects(inst, computeEffects, inputProps, oldProps, hasPaths);
+      computeLinkedPaths(inst, inputProps, hasPaths);
+      if ((inputProps = inst.__dataPending)) {
         Object.assign(oldProps, inst.__dataOld);
         Object.assign(changedProps, inst.__dataPending);
-        inputProps = inst.__dataPending;
         inst.__dataPending = null;
       }
     }
@@ -416,21 +417,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function computeLinkedPaths(inst, changedProps, hasPaths) {
     let links;
     if (hasPaths && (links = inst.__dataLinkedPaths)) {
-      const cache = inst.__dataTemp;
       let link;
       for (let a in links) {
         let b = links[a];
         for (let path in changedProps) {
           if (Polymer.Path.isDescendant(a, path)) {
             link = Polymer.Path.translate(a, b, path);
-            cache[link] = changedProps[link] = changedProps[path];
-            let notifyProps = inst.__dataToNotify || (inst.__dataToNotify = {});
-            notifyProps[link] = true;
+            inst._setPendingPropertyOrPath(link, changedProps[path], true, true);
           } else if (Polymer.Path.isDescendant(b, path)) {
             link = Polymer.Path.translate(b, a, path);
-            cache[link] = changedProps[link] = changedProps[path];
-            let notifyProps = inst.__dataToNotify || (inst.__dataToNotify = {});
-            notifyProps[link] = true;
+            inst._setPendingPropertyOrPath(link, changedProps[path], true, true);
           }
         }
       }
@@ -1292,32 +1288,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _setPendingPropertyOrPath(path, value, shouldNotify, isPathNotification) {
         let rootProperty = Polymer.Path.root(Array.isArray(path) ? path[0] : path);
-        let hasAccessor = this.__dataHasAccessor && this.__dataHasAccessor[rootProperty];
-        let isPath = (rootProperty !== path);
-        if (hasAccessor) {
-          if (isPath) {
-            if (!isPathNotification) {
-              // Dirty check changes being set to a path against the actual object,
-              // since this is the entry point for paths into the system; from here
-              // the only dirty checks are against the `__dataTemp` cache to prevent
-              // duplicate work in the same turn only. Note, if this was a notification
-              // of a change already set to a path (isPathNotification: true),
-              // we always let the change through and skip the `set` since it was
-              // already dirty checked at the point of entry and the underlying
-              // object has already been updated
-              let old = Polymer.Path.get(this, path);
-              path = /** @type {string} */ (Polymer.Path.set(this, path, value));
-              // Use property-accessor's simpler dirty check
-              if (!path || !super._shouldPropertyChange(path, value, old)) {
-                return false;
-              }
+        if (rootProperty !== path) {
+          if (!isPathNotification) {
+            // Dirty check changes being set to a path against the actual object,
+            // since this is the entry point for paths into the system; from here
+            // the only dirty checks are against the `__dataTemp` cache to prevent
+            // duplicate work in the same turn only. Note, if this was a notification
+            // of a change already set to a path (isPathNotification: true),
+            // we always let the change through and skip the `set` since it was
+            // already dirty checked at the point of entry and the underlying
+            // object has already been updated
+            let old = Polymer.Path.get(this, path);
+            path = /** @type {string} */ (Polymer.Path.set(this, path, value));
+            // Use property-accessor's simpler dirty check
+            if (!path || !super._shouldPropertyChange(path, value, old)) {
+              return false;
             }
-            this.__dataHasPaths = true;
           }
+          this.__dataHasPaths = true;
           return this._setPendingProperty(path, value, shouldNotify);
         } else {
-          if (isPath) {
-            Polymer.Path.set(this, path, value);
+          if (this.__dataHasAccessor && this.__dataHasAccessor[rootProperty]) {
+            return this._setPendingProperty(path, value, shouldNotify);
           } else {
             this[path] = value;
           }
@@ -1548,8 +1540,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__dataHasPaths = false;
         // Compute properties
         runComputedEffects(this, changedProps, oldProps, hasPaths);
-        // Compute linked paths
-        computeLinkedPaths(this, changedProps, hasPaths);
         // Clear notify properties prior to possible reentry (propagate, observe),
         // but after computing effects have a chance to add to them
         let notifyProps = this.__dataToNotify;

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -371,13 +371,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    */
   function runComputedEffects(inst, changedProps, oldProps, hasPaths) {
     let computeEffects = inst.__computeEffects;
-    let inputProps = changedProps;
-    while (inputProps) {
-      computeEffects && runEffects(inst, computeEffects, inputProps, oldProps, hasPaths);
-      computeLinkedPaths(inst, inputProps, hasPaths);
-      if ((inputProps = inst.__dataPending)) {
+    if (computeEffects) {
+      let inputProps = changedProps;
+      while (runEffects(inst, computeEffects, inputProps, oldProps, hasPaths)) {
         Object.assign(oldProps, inst.__dataOld);
         Object.assign(changedProps, inst.__dataPending);
+        inputProps = inst.__dataPending;
         inst.__dataPending = null;
       }
     }
@@ -410,24 +409,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * API.
    *
    * @param {Element} inst The instance whose props are changing
-   * @param {Object} changedProps Bag of changed properties
-   * @param {boolean} hasPaths True with `props` contains one or more paths
+   * @param {string} path Path that has changed
+   * @param {*} value Value of changed path
    * @private
    */
-  function computeLinkedPaths(inst, changedProps, hasPaths) {
-    let links;
-    if (hasPaths && (links = inst.__dataLinkedPaths)) {
+  function computeLinkedPaths(inst, path, value) {
+    let links = inst.__dataLinkedPaths;
+    if (links) {
       let link;
       for (let a in links) {
         let b = links[a];
-        for (let path in changedProps) {
-          if (Polymer.Path.isDescendant(a, path)) {
-            link = Polymer.Path.translate(a, b, path);
-            inst._setPendingPropertyOrPath(link, changedProps[path], true, true);
-          } else if (Polymer.Path.isDescendant(b, path)) {
-            link = Polymer.Path.translate(b, a, path);
-            inst._setPendingPropertyOrPath(link, changedProps[path], true, true);
-          }
+        if (Polymer.Path.isDescendant(a, path)) {
+          link = Polymer.Path.translate(a, b, path);
+          inst._setPendingPropertyOrPath(link, value, true, true);
+        } else if (Polymer.Path.isDescendant(b, path)) {
+          link = Polymer.Path.translate(b, a, path);
+          inst._setPendingPropertyOrPath(link, value, true, true);
         }
       }
     }
@@ -1306,7 +1303,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
           this.__dataHasPaths = true;
-          return this._setPendingProperty(path, value, shouldNotify);
+          if (this._setPendingProperty(path, value, shouldNotify)) {
+            computeLinkedPaths(this, path, value);
+            return true;
+          }
         } else {
           if (this.__dataHasAccessor && this.__dataHasAccessor[rootProperty]) {
             return this._setPendingProperty(path, value, shouldNotify);

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1284,17 +1284,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _setPendingPropertyOrPath(path, value, shouldNotify, isPathNotification) {
-        let rootProperty = Polymer.Path.root(Array.isArray(path) ? path[0] : path);
-        if (rootProperty !== path) {
+        if (isPathNotification ||
+            Polymer.Path.root(Array.isArray(path) ? path[0] : path) !== path) {
+          // Dirty check changes being set to a path against the actual object,
+          // since this is the entry point for paths into the system; from here
+          // the only dirty checks are against the `__dataTemp` cache to prevent
+          // duplicate work in the same turn only. Note, if this was a notification
+          // of a change already set to a path (isPathNotification: true),
+          // we always let the change through and skip the `set` since it was
+          // already dirty checked at the point of entry and the underlying
+          // object has already been updated
           if (!isPathNotification) {
-            // Dirty check changes being set to a path against the actual object,
-            // since this is the entry point for paths into the system; from here
-            // the only dirty checks are against the `__dataTemp` cache to prevent
-            // duplicate work in the same turn only. Note, if this was a notification
-            // of a change already set to a path (isPathNotification: true),
-            // we always let the change through and skip the `set` since it was
-            // already dirty checked at the point of entry and the underlying
-            // object has already been updated
             let old = Polymer.Path.get(this, path);
             path = /** @type {string} */ (Polymer.Path.set(this, path, value));
             // Use property-accessor's simpler dirty check
@@ -1308,7 +1308,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             return true;
           }
         } else {
-          if (this.__dataHasAccessor && this.__dataHasAccessor[rootProperty]) {
+          if (this.__dataHasAccessor && this.__dataHasAccessor[path]) {
             return this._setPendingProperty(path, value, shouldNotify);
           } else {
             this[path] = value;

--- a/test/unit/path-effects-elements.html
+++ b/test/unit/path-effects-elements.html
@@ -114,6 +114,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         computedFromPaths: {
           computed: 'computeFromPaths(a, nested.b, nested.obj.c)'
         },
+        computedFromLinkedPaths: {
+          computed: 'computeFromLinkedPaths(a, linked1.prop, linked2.prop)'
+        },
         computed: {
           computed: 'compute(nested.obj.value)'
         }
@@ -163,6 +166,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       computeFromPaths: function(a, b, c) {
         return a + b + c;
       },
+      computeFromLinkedPaths: sinon.spy(function(a, b, c) {
+        return a + b + c;
+      }),
       compute: function(val) {
         return '[' + val + ']';
       }

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -909,6 +909,69 @@ suite('path API', function() {
     assert.equal(el.aChanged.callCount, 3);
   });
 
+  test('multiple linked dependencies to computed property', function() {
+    let linkedObj = {prop: 'Linked'};
+    el.computeFromLinkedPaths.reset();
+    el.setProperties({
+      linked1: linkedObj,
+      linked2: linkedObj,
+      a: 'A'
+    });
+    assert.equal(el.computeFromLinkedPaths.callCount, 1);
+    assert.equal(el.computedFromLinkedPaths, 'ALinkedLinked');
+
+    el.linkPaths('linked1', 'linked2');
+    el.set('linked1.prop', 'Linked+');
+    assert.equal(el.computeFromLinkedPaths.callCount, 2);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+Linked+');
+    el.linked3 = el.linked2;
+    el.linkPaths('linked2', 'linked3');
+    el.set('linked3.prop', 'Linked++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 3);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++Linked++');
+    el.set('linked2.prop', 'Linked+++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 4);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+++Linked+++');
+    el.set('linked1.prop', 'Linked++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 5);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++Linked++++');
+
+    el.linked4 = el.linked1;
+    el.linkPaths('linked4', 'linked1');
+    el.set('linked4.prop', 'Linked+++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 6);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+++++Linked+++++');
+    el.set('linked3.prop', 'Linked++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 7);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++++Linked++++++');
+    el.set('linked2.prop', 'Linked+++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 8);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+++++++Linked+++++++');
+    el.set('linked1.prop', 'Linked++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 9);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++++++Linked++++++++');
+
+    el.linked5 = el.linked3;
+    el.linkPaths('linked5', 'linked3');
+    el.set('linked4.prop', 'Linked+++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 10);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+++++++++Linked+++++++++');
+    el.set('linked3.prop', 'Linked++++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 11);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++++++++Linked++++++++++');
+    el.set('linked2.prop', 'Linked+++++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 12);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked+++++++++++Linked+++++++++++');
+    el.set('linked1.prop', 'Linked++++++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 13);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++++++++++Linked++++++++++++');
+
+    el.unlinkPaths('linked4');
+    el.set('linked4.prop', 'Linked+++++++++++++');
+    assert.equal(el.computeFromLinkedPaths.callCount, 13);
+    assert.equal(el.computedFromLinkedPaths, 'ALinked++++++++++++Linked++++++++++++');
+  });
+
   test('link two arrays', function() {
     el.x = el.y = [];
     el.linkPaths('y', 'x');

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -898,11 +898,15 @@ suite('path API', function() {
     assert.equal(el.xChanged.callCount, 1);
     assert.equal(el.yChanged.callCount, 1);
     assert.equal(el.aChanged.callCount, 1);
-    el.unlinkPaths('y');
     el.set('a.foo', 2);
     assert.equal(el.xChanged.callCount, 2);
-    assert.equal(el.yChanged.callCount, 1);
+    assert.equal(el.yChanged.callCount, 2);
     assert.equal(el.aChanged.callCount, 2);
+    el.unlinkPaths('y');
+    el.set('a.foo', 3);
+    assert.equal(el.xChanged.callCount, 3);
+    assert.equal(el.yChanged.callCount, 2);
+    assert.equal(el.aChanged.callCount, 3);
   });
 
   test('link two arrays', function() {


### PR DESCRIPTION
Fixes #4542

The `_setPendingPropertyOrPath` implementation that the public `set` leverages does not trigger `_propertiesChanged` if the root property being set has no accessor.  Generally this is correct, except that `linkPaths` can result in triggering linked paths with accessors, but where the root property being set has none.  As such, `set` should always result in `_propertiesChanged` running, to match the 1.x behavior and give `computeLinkedPaths` an opportunity to run.

Additionally, since `computeLinkedPaths` only did one loop over the links, if a newly generated link was subsequently linked to a path earlier in the list, it would never compute to that link.  As such, `computeLinkedPaths` was moved to `runComputedEffects` and takes advantage of the same while loop that runs until no more pending properties are generated.