### PR TITLE
Support property observers which are direct function references

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -208,12 +208,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @private
    */
   function runObserverEffect(inst, property, props, oldProps, info) {
-    let fn = inst[info.methodName];
+    let fn = typeof info.method === "string" ? inst[info.method] : info.method;
     let changedProp = info.property;
     if (fn) {
       fn.call(inst, inst.__data[changedProp], oldProps[changedProp]);
     } else if (!info.dynamicFn) {
-      console.warn('observer method `' + info.methodName + '` not defined');
+      console.warn('observer method `' + info.method + '` not defined');
     }
   }
 
@@ -1989,19 +1989,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * full API docs.
        *
        * @param {string} property Property name
-       * @param {string} methodName Name of observer method to call
+       * @param {string|function(*,*)} method Function or name of observer method to call
        * @param {boolean=} dynamicFn Whether the method name should be included as
        *   a dependency to the effect.
        * @protected
        */
-      _createPropertyObserver(property, methodName, dynamicFn) {
-        let info = { property, methodName, dynamicFn: Boolean(dynamicFn) };
+      _createPropertyObserver(property, method, dynamicFn) {
+        let info = { property, method, dynamicFn: Boolean(dynamicFn) };
         this._addPropertyEffect(property, TYPES.OBSERVE, {
           fn: runObserverEffect, info, trigger: {name: property}
         });
         if (dynamicFn) {
-          this._addPropertyEffect(methodName, TYPES.OBSERVE, {
-            fn: runObserverEffect, info, trigger: {name: methodName}
+          this._addPropertyEffect(method, TYPES.OBSERVE, {
+            fn: runObserverEffect, info, trigger: {name: method}
           });
         }
       }
@@ -2129,13 +2129,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Creates a single-property observer for the given property.
        *
        * @param {string} property Property name
-       * @param {string} methodName Name of observer method to call
+       * @param {string|function(*,*)} method Function or name of observer method to call
        * @param {boolean=} dynamicFn Whether the method name should be included as
        *   a dependency to the effect.
        * @protected
        */
-      static createPropertyObserver(property, methodName, dynamicFn) {
-        this.prototype._createPropertyObserver(property, methodName, dynamicFn);
+      static createPropertyObserver(property, method, dynamicFn) {
+        this.prototype._createPropertyObserver(property, method, dynamicFn);
       }
 
       /**

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -496,7 +496,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
       prop2: {
         value: 'default',
-        observer: 'prop2Changed'
+        observer: function(newProp, oldProp) { return this.prop2Changed(newProp, oldProp); }
       }
     },
     created: function() {


### PR DESCRIPTION
Partially addresses #4543

Provides better static analysis and refactoring support in multiple tools. Alleviates the need for property reflection with Closure-compiler renaming.

The test case included isn't actually that useful (but does test the change). Real benefits come with the class style syntax:

```js
class FooElement extends Polymer.Element {
  static get is() { return 'foo-element'; }
  static get properties() {
    return {
      bar: {
        type: String,
        observer: FooElement.prototype.barChanged_
      }
    }
  }
  barChanged_(newValue, oldValue) {
    console.log(newValue, oldValue)
  }
}
```