### PR TITLE
Data notifications do not flush host if host has not initialized clients

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -656,6 +656,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           hostStack.endHosting(this);
           this.$ = this.root.$;
         }
+        // The super.ready here makes this element able to observe data changes.
+        // We must wait to do this until after client dom is created/attached
+        // so that any notifications fired during this process are not handled
+        // before all clients are ready.
         super.ready();
       }
 
@@ -669,10 +673,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @override
        */
       _readyClients() {
-        super._readyClients();
         if (this._template) {
           this.root = this._attachDom(this.root);
         }
+        super._readyClients();
       }
 
 

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -656,10 +656,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           hostStack.endHosting(this);
           this.$ = this.root.$;
         }
-        // The super.ready here makes this element able to observe data changes.
-        // We must wait to do this until after client dom is created/attached
-        // so that any notifications fired during this process are not handled
-        // before all clients are ready.
         super.ready();
       }
 
@@ -676,6 +672,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this._template) {
           this.root = this._attachDom(this.root);
         }
+        // The super._readyClients here sets the clients initialized flag.
+        // We must wait to do this until after client dom is created/attached
+        // so that this flag can be checked to prevent notifications fired
+        // during this process from being handled before clients are ready.
         super._readyClients();
       }
 

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -227,8 +227,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
     // Flush host if we actually notified and host was batching
+    // And the host has already initialized clients; this prevents
+    // an issue with a host observing data changes before clients are ready.
     let host;
-    if (notified && (host = inst.__dataHost) && host._flushProperties) {
+    if (notified && (host = inst.__dataHost) && host._flushProperties
+      && host.__dataClientsInitialized) {
       host._flushProperties();
     }
   }
@@ -1508,6 +1511,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         super.ready();
         if (!this.__dataClientsInitialized) {
           this._readyClients();
+        }
+        // Before ready, client notifications do not trigger _flushProperties.
+        // Therefore a flush is necessary here if data has been set.
+        if (this.__dataPending) {
+          this._flushProperties();
         }
       }
 

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -184,6 +184,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
         this.titleChanged = sinon.spy();
       },
+      ready: function() {
+        this.isReady = true;
+      },
       clearObserverCounts: function() {
         for (var i in this.observerCounts) {
           this.observerCounts[i] = 0;
@@ -344,7 +347,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'boundcomputedvalueChanged(boundcomputedvalue)',
         'boundcomputednotifyingvalueChanged(boundcomputednotifyingvalue)',
         'boundreadonlyvalueChanged(boundreadonlyvalue)',
-        'boundCustomNotifyingValueChanged(boundCustomNotifyingValue)'
+        'boundCustomNotifyingValueChanged(boundCustomNotifyingValue)',
+        'boundnotifyingvalueWithDefaultChanged(boundnotifyingvalueWithDefault)'
       ],
       properties: {
         a: {
@@ -367,7 +371,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           boundcomputedvalueChanged: 0,
           boundcomputednotifyingvalueChanged: 0,
           boundreadonlyvalueChanged: 0,
-          boundCustomNotifyingValueChanged: 0
+          boundCustomNotifyingValueChanged: 0,
+          boundnotifyingvalueWithDefault: 0
         };
       },
       computeComputedValue: function(a, b) {
@@ -378,23 +383,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.observerCounts[i] = 0;
         }
       },
+      assertClientsReady: function() {
+        assert.isTrue(this.$.basic1.isReady, 'basic1 not `ready` by observer time');
+        assert.isTrue(this.$.basic2.isReady, 'basic2 element not `ready` by observer time');
+        assert.isTrue(this.$.basic3.isReady, 'basic3 element not `ready` by observer time');
+        assert.isTrue(this.$.basic4.isReady, 'basic4 element not `ready` by observer time');
+      },
       boundvalueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundvalueChanged++;
       },
       boundnotifyingvalueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundnotifyingvalueChanged++;
       },
       boundcomputedvalueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundcomputedvalueChanged++;
       },
       boundcomputednotifyingvalueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundcomputednotifyingvalueChanged++;
       },
       boundreadonlyvalueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundreadonlyvalueChanged++;
       },
       boundCustomNotifyingValueChanged: function() {
+        this.assertClientsReady();
         this.observerCounts.boundCustomNotifyingValueChanged++;
+      },
+      boundnotifyingvalueWithDefaultChanged: function() {
+        this.assertClientsReady();
+        this.observerCounts.boundnotifyingvalueWithDefault++;
       }
     });
   </script>


### PR DESCRIPTION
Fixes #4585.

This preserves the Polymer 1.x guarantee that client dom is fully “readied” when data observers run.
