### PR TITLE
Move shadycss and webcomponentsjs from dev-deps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "doc": "docs",
     "test": "test"
   },
-  "devDependencies": {
+  "dependencies": {
     "@webcomponents/shadycss": "^1.0.0",
-    "@webcomponents/webcomponentsjs": "^1.0.0",
+    "@webcomponents/webcomponentsjs": "^1.0.0"
+  },
+  "devDependencies": {
     "babel-preset-babili": "0.0.12",
     "del": "^2.2.1",
     "dom5": "^1.3.1",


### PR DESCRIPTION
First of all, thanks for taking some actions towards npm support, npm is a must in modern webdev.

In https://github.com/Polymer/polymer/commit/6b6092e0aee8158e08648e71a39f05775940cd3b `shadycss` and `webcomponentsjs` were added to the wrong section, those should be in `dependencies`, not in `devDependencies`.

npm deps should be aligned with Bower deps and `dependencies` basically should be the same for both Bower and npm. 

Related Bower configuration: https://github.com/Polymer/polymer/blob/master/bower.json#L22-L25