### PR TITLE
Adds `_enableProperties` and prevents readying from re-entering

### DIFF
--- a/lib/elements/dom-bind.html
+++ b/lib/elements/dom-bind.html
@@ -103,7 +103,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (let n=this.root.firstChild; n; n=n.nextSibling) {
             this.__children[this.__children.length] = n;
           }
-          this._flushProperties();
+          this._enableProperties();
         }
         this.__insertChildren();
         this.dispatchEvent(new CustomEvent('dom-change', {

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -576,7 +576,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _initializeProperties() {
         Polymer.telemetry.instanceCount++;
-        hostStack.registerHost(this);
         this.constructor.finalize();
         const importPath = this.constructor.importPath;
         // note: finalize template when we have access to `localName` to
@@ -649,9 +648,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       ready() {
         if (this._template) {
-          hostStack.beginHosting(this);
           this.root = this._stampTemplate(this._template);
-          hostStack.endHosting(this);
           this.$ = this.root.$;
         }
         super.ready();
@@ -784,53 +781,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return PolymerElement;
   });
-
-  /**
-   * Helper api for enqueing client dom created by a host element.
-   *
-   * By default elements are flushed via `_flushProperties` when
-   * `connectedCallback` is called. Elements attach their client dom to
-   * themselves at `ready` time which results from this first flush.
-   * This provides an ordering guarantee that the client dom an element
-   * creates is flushed before the element itself (i.e. client `ready`
-   * fires before host `ready`).
-   *
-   * However, if `_flushProperties` is called *before* an element is connected,
-   * as for example `Templatize` does, this ordering guarantee cannot be
-   * satisfied because no elements are connected. (Note: Bound elements that
-   * receive data do become enqueued clients and are properly ordered but
-   * unbound elements are not.)
-   *
-   * To maintain the desired "client before host" ordering guarantee for this
-   * case we rely on the "host stack. Client nodes registers themselves with
-   * the creating host element when created. This ensures that all client dom
-   * is readied in the proper order, maintaining the desired guarantee.
-   *
-   * @private
-   */
-  let hostStack = {
-
-    stack: [],
-
-    registerHost(inst) {
-      if (this.stack.length) {
-        let host = this.stack[this.stack.length-1];
-        host._enqueueClient(inst);
-      }
-    },
-
-    beginHosting(inst) {
-      this.stack.push(inst);
-    },
-
-    endHosting(inst) {
-      let stackLen = this.stack.length;
-      if (stackLen && this.stack[stackLen-1] == inst) {
-        this.stack.pop();
-      }
-    }
-
-  }
 
   /**
    * Provides basic tracking of element definitions (registrations) and

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -631,9 +631,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (window.ShadyCSS && this._template) {
           window.ShadyCSS.styleElement(this);
         }
-        if (!this.__dataInitialized) {
-          this._flushProperties();
-        }
+        this._enableProperties();
       }
 
       /**

--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -477,11 +477,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-       * Call to enable property accessors. This method must be called
-       * for any side effects of setting properties to occur. For elements,
-       * generally `connectedCallback` is a normal spot to do so.
-       * It is safe to call this method multiple times as it only turns
-       * on property accessors once.
+       * Call to enable property accessor processing. Before this method is
+       * called accessor values will be set but side effects are
+       * queued. When called, any pending side effects occur immediately.
+       * For elements, generally `connectedCallback` is a normal spot to do so.
+       * It is safe to call this method multiple times as it only turns on
+       * property accessors once.
        */
       _enableProperties() {
         if (!this.__dataEnabled) {

--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -475,6 +475,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      // TODO(kschaaf): document.
+      _enableProperties() {
+        if (!this.__dataPropertiesEnabled) {
+          this.__dataPropertiesEnabled = true;
+          if (this.__dataInstanceProps) {
+            this._initializeInstanceProperties(this.__dataInstanceProps);
+            this.__dataInstanceProps = null;
+          }
+          this.ready()
+        }
+      }
+
       /**
        * Calls the `_propertiesChanged` callback with the current set of
        * pending changes (and old values recorded when pending changes were
@@ -487,9 +499,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _flushProperties() {
-        if (!this.__dataInitialized) {
-          this.ready()
-        } else if (this.__dataPending) {
+        if (this.__dataPending) {
           let changedProps = this.__dataPending;
           this.__dataPending = null;
           this.__dataCounter++;
@@ -513,12 +523,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @public
        */
       ready() {
-        // Update instance properties that shadowed proto accessors; these take
-        // priority over any defaults set in constructor or attributeChangedCallback
-        if (this.__dataInstanceProps) {
-          this._initializeInstanceProperties(this.__dataInstanceProps);
-          this.__dataInstanceProps = null;
-        }
         this.__dataInitialized = true;
         // Run normal flush
         this._flushProperties();

--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -137,6 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _initializeProperties() {
         this.__serializing = false;
         this.__dataCounter = 0;
+        this.__dataEnabled = false;
         this.__dataInitialized = false;
         this.__dataInvalid = false;
         // initialize data with prototype values saved when creating accessors
@@ -475,10 +476,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
-      // TODO(kschaaf): document.
+      /**
+       * Call to enable property accessors. This method must be called
+       * for any side effects of setting properties to occur. For elements,
+       * generally `connectedCallback` is a normal spot to do so.
+       * It is safe to call this method multiple times as it only turns
+       * on property accessors once.
+       */
       _enableProperties() {
-        if (!this.__dataPropertiesEnabled) {
-          this.__dataPropertiesEnabled = true;
+        if (!this.__dataEnabled) {
+          this.__dataEnabled = true;
           if (this.__dataInstanceProps) {
             this._initializeInstanceProperties(this.__dataInstanceProps);
             this.__dataInstanceProps = null;
@@ -490,11 +497,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Calls the `_propertiesChanged` callback with the current set of
        * pending changes (and old values recorded when pending changes were
-       * set), and resets the pending set of changes.
+       * set), and resets the pending set of changes. Generally, this method
+       * should not be called in user code.
        *
-       * Note that this method must be called once to enable the property
-       * accessors system.  For elements, generally `connectedCallback`
-       * is a normal spot to do so.
        *
        * @protected
        */

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1432,6 +1432,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!this.__dataClientsInitialized) {
           this.__dataClientsInitialized = true;
           this._readyClients();
+          // Override point where accessors are turned on; importantly,
+          // this is after clients have fully readied, providing a guarantee
+          // that any property effects occur only after all clients are ready.
           this.__dataInitialized = true;
         } else {
           // Flush all clients

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1446,6 +1446,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
         }
+        this.__dataInitialized = true;
       }
 
       /**
@@ -1500,9 +1501,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @protected
        */
-      _readyClients() {
-        this.__dataInitialized = true;
-      }
+      _readyClients() {}
 
       /**
        * Implements `PropertyAccessors`'s properties changed callback.

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1461,7 +1461,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.__dataPendingClients = null;
           for (let i=0; i < clients.length; i++) {
             let client = clients[i];
-            if (!client.__dataPropertiesEnabled) {
+            if (!client.__dataEnabled) {
               client._enableProperties();
             }
           }
@@ -1496,13 +1496,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-       * Overrides `PropertyAccessors` to call `_readyClients` callback
-       * if it was not called as a result of flushing properties.
+       * Overrides `PropertyAccessors` so that property accessor
+       * side effects are not enabled until after client dom is fully ready.
+       * Also calls `_flushClients` callback to ensure client dom is enabled
+       * that was not enabled as a result of flushing properties.
        *
        * @override
        */
       ready() {
+        // It is important that `super.ready()` is not called here as it
+        // immediately turns on accessors. Instead, we wait until `readyClients`
+        // to enable accessors to provide a guarantee that clients are ready
+        // before processing any accessors side effects.
         this._flushProperties();
+        // If no data was pending, `_flushProperties` will not `flushClients`
+        // so ensure this is done.
         if (!this.__dataClientsInitialized) {
           this._flushClients();
         }
@@ -2215,6 +2223,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _stampTemplate(template) {
+        // Ensures that created dom is `_enqueueClient`'d to this element so
+        // that it can be flushed on next call to `_flushProperties`
         hostStack.beginHosting(this);
         let dom = super._stampTemplate(template);
         hostStack.endHosting(this);

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1086,6 +1086,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _initializeProperties() {
         super._initializeProperties();
+        hostStack.registerHost(this);
         this.__dataClientsInitialized = false;
         this.__dataPendingClients = null;
         this.__dataToNotify = null;
@@ -1431,22 +1432,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!this.__dataClientsInitialized) {
           this.__dataClientsInitialized = true;
           this._readyClients();
+          this.__dataInitialized = true;
+        } else {
+          // Flush all clients
+          let clients = this.__dataPendingClients;
+          if (clients) {
+            this.__dataPendingClients = null;
+            for (let i=0; i < clients.length; i++) {
+              let client = clients[i];
+              if (client.__dataPending) {
+                client._flushProperties();
+              }
+            }
+          }
         }
-        // Flush all clients
+      }
+
+      /**
+       * Perform any initial setup on client dom. Called before the first
+       * `_flushProperties` call on client dom and before any element
+       * observers are called.
+       *
+       * @protected
+       */
+      _readyClients() {
         let clients = this.__dataPendingClients;
         if (clients) {
           this.__dataPendingClients = null;
           for (let i=0; i < clients.length; i++) {
             let client = clients[i];
-            // boot up client if necessary, otherwise flush properties
             if (!client.__dataPropertiesEnabled) {
               client._enableProperties();
-            } else if (client.__dataPending) {
-              client._flushProperties();
             }
           }
         }
-        this.__dataInitialized = true;
       }
 
       /**
@@ -1493,15 +1512,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._flushProperties();
         }
       }
-
-      /**
-       * Perform any initial setup on client dom. Called before the first
-       * `_flushProperties` call on client dom and before any element
-       * observers are called.
-       *
-       * @protected
-       */
-      _readyClients() {}
 
       /**
        * Implements `PropertyAccessors`'s properties changed callback.
@@ -2205,7 +2215,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _stampTemplate(template) {
+        hostStack.beginHosting(this);
         let dom = super._stampTemplate(template);
+        hostStack.endHosting(this);
         let templateInfo = this._bindTemplate(template, true);
         // Add template-instance-specific data to instanced templateInfo
         templateInfo.nodeList = dom.nodeList;
@@ -2504,6 +2516,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return PropertyEffects;
   });
+
+  /**
+   * Helper api for enqueing client dom created by a host element.
+   *
+   * By default elements are flushed via `_flushProperties` when
+   * `connectedCallback` is called. Elements attach their client dom to
+   * themselves at `ready` time which results from this first flush.
+   * This provides an ordering guarantee that the client dom an element
+   * creates is flushed before the element itself (i.e. client `ready`
+   * fires before host `ready`).
+   *
+   * However, if `_flushProperties` is called *before* an element is connected,
+   * as for example `Templatize` does, this ordering guarantee cannot be
+   * satisfied because no elements are connected. (Note: Bound elements that
+   * receive data do become enqueued clients and are properly ordered but
+   * unbound elements are not.)
+   *
+   * To maintain the desired "client before host" ordering guarantee for this
+   * case we rely on the "host stack. Client nodes registers themselves with
+   * the creating host element when created. This ensures that all client dom
+   * is readied in the proper order, maintaining the desired guarantee.
+   *
+   * @private
+   */
+  let hostStack = {
+
+    stack: [],
+
+    registerHost(inst) {
+      if (this.stack.length) {
+        let host = this.stack[this.stack.length-1];
+        host._enqueueClient(inst);
+      }
+    },
+
+    beginHosting(inst) {
+      this.stack.push(inst);
+    },
+
+    endHosting(inst) {
+      let stackLen = this.stack.length;
+      if (stackLen && this.stack[stackLen-1] == inst) {
+        this.stack.pop();
+      }
+    }
+
+  }
 
 })();
 </script>

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -230,9 +230,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // And the host has already initialized clients; this prevents
     // an issue with a host observing data changes before clients are ready.
     let host;
-    if (notified && (host = inst.__dataHost) && host._flushProperties
-      && host.__dataClientsInitialized) {
-      host._flushProperties();
+    if (notified && (host = inst.__dataHost) && host._invalidateProperties) {
+      host._invalidateProperties();
     }
   }
 
@@ -1430,6 +1429,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _flushClients() {
         if (!this.__dataClientsInitialized) {
+          this.__dataClientsInitialized = true;
           this._readyClients();
         }
         // Flush all clients
@@ -1438,7 +1438,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.__dataPendingClients = null;
           for (let i=0; i < clients.length; i++) {
             let client = clients[i];
-            if (!client.__dataInitialized || client.__dataPending) {
+            // boot up client if necessary, otherwise flush properties
+            if (!client.__dataPropertiesEnabled) {
+              client._enableProperties();
+            } else if (client.__dataPending) {
               client._flushProperties();
             }
           }
@@ -1479,9 +1482,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @override
        */
       ready() {
-        super.ready();
+        this._flushProperties();
         if (!this.__dataClientsInitialized) {
-          this._readyClients();
+          this._flushClients();
         }
         // Before ready, client notifications do not trigger _flushProperties.
         // Therefore a flush is necessary here if data has been set.
@@ -1498,7 +1501,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @protected
        */
       _readyClients() {
-        this.__dataClientsInitialized = true;
+        this.__dataInitialized = true;
       }
 
       /**

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -63,7 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // or when there isn't instance props.
         let options = this.__templatizeOptions;
         if ((props && options.instanceProps) || !options.instanceProps) {
-          this._flushProperties();
+          this._enableProperties();
         }
       }
       /**
@@ -251,7 +251,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         template.__dataTemp = {};
         template.__dataPending = null;
         template.__dataOld = null;
-        template._flushProperties();
+        template._enableProperties();
       }
     }
 

--- a/test/unit/property-accessors.html
+++ b/test/unit/property-accessors.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._propertiesChanged = sinon.spy();
       }
       connectedCallback() {
-        this._flushProperties();
+        this._enableProperties();
       }
     }
     XFoo.createPropertiesForAttributes();

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -421,6 +421,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-handle-notify-event">
+  <template>
+    <slot name="drawer"></slot>
+    <div id="before"></div>
+    <x-basic id="basic1"
+      on-notifyingvalue-with-default-changed="handleNotify">
+    </x-basic>
+    <div id="later"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'x-handle-notify-event',
+      properties: {
+        prop: {
+          observer: 'propChanged'
+        }
+      },
+      created: function() {
+        this.readySpy = sinon.spy();
+        this.afterSettingProp = sinon.spy();
+        this.propChanged = sinon.spy();
+        this.handleNotify = sinon.spy(function() {
+          this.prop = 'prop';
+          this.afterSettingProp();
+        });
+      },
+      ready: function() {
+        this.readySpy();
+      }
+    });
+  </script>
+</dom-module>
+
 <script>
   Polymer({
     is: 'x-reflect',

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -633,6 +633,37 @@ suite('2-way binding effects between elements', function() {
 
 });
 
+suite('handling notifying evevnts', function() {
+
+  test('handle notifcation event and set property with observer when connected', function() {
+    var el = document.createElement('x-handle-notify-event');
+    document.body.appendChild(el);
+    assert.ok(el.shadowRoot.querySelector('#before'), 'element not found before default notifying elmeent');
+    assert.ok(el.shadowRoot.querySelector('#later'), 'element not found after default notifying elmeent');
+    assert.isTrue(el.readySpy.calledOnce, 'ready called more than once');
+    assert.isTrue(el.handleNotify.calledOnce, 'listener called more than once');
+    assert.isTrue(el.propChanged.calledOnce, 'observer called more than once');
+    assert.isTrue(el.handleNotify.calledBefore(el.propChanged), 'observer called before event');
+    assert.isTrue(el.afterSettingProp.calledBefore(el.propChanged), 'accessor side effect processed during notifying event (before clients ready)');
+    assert.isTrue(el.propChanged.calledBefore(el.readySpy), 'observer called before ready');
+    document.body.removeChild(el);
+  });
+
+  test('handle notifcation event and set property with observer when *not* connected and _enableProperties called', function() {
+    var el = document.createElement('x-handle-notify-event');
+    el._enableProperties();
+    assert.ok(el.shadowRoot.querySelector('#before'), 'element not found before default notifying elmeent');
+    assert.ok(el.shadowRoot.querySelector('#later'), 'element not found after default notifying elmeent');
+    assert.isTrue(el.readySpy.calledOnce, 'ready called more than once');
+    assert.isTrue(el.handleNotify.calledOnce, 'listener called more than once');
+    assert.isTrue(el.propChanged.calledOnce, 'observer called more than once');
+    assert.isTrue(el.handleNotify.calledBefore(el.propChanged), 'observer called before event');
+    assert.isTrue(el.afterSettingProp.calledBefore(el.propChanged), 'accessor side effect processed during notifying event (before clients ready)');
+    assert.isTrue(el.propChanged.calledBefore(el.readySpy), 'observer called before ready');
+  });
+
+});
+
 suite('1-way binding effects between elements', function() {
 
   var el;

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -1514,7 +1514,7 @@ suite('a la carte usage of API', function() {
     BaseClass = class extends Polymer.PropertyEffects(HTMLElement) {
       connectedCallback() {
         this.pcSpy = sinon.spy();
-        this._flushProperties();
+        this._enableProperties();
       }
       _propertiesChanged(props, changedProps, oldProps) {
         this.pcSpy(props, changedProps, oldProps);


### PR DESCRIPTION
Fixes #4598. Prevents `ready` and `_readyClients` from being able to re-enter. Also changes the boot up method for property accessors from `_flushProperties` to `_enableProperties`.

Changes `PropertyEffects` so that it does not enable property side effects until explicitly after clients have readied. Moves the `hostStack` from `ElementMixin` to `PropertyEffects`. This also more consistently ensures that an element subtree can fully boot up while out of the dom via calling `_enableProperties`.