### PR TITLE
Ensure `detached` cannot be called when `disble-upgrade` is set

### DIFF
--- a/src/mini/ready.html
+++ b/src/mini/ready.html
@@ -32,6 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
 
   var baseAttachedCallback = Polymer.Base.attachedCallback;
+  var baseDetachedCallback = Polymer.Base.detachedCallback;
 
   Polymer.Base._addFeature({
 
@@ -152,6 +153,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._attachedPending = false;
         this.attachedCallback();
       }
+      // only call detached if the element is actually detached
+      if (this._detachedPending && !Polymer.dom(document.body).deepContains(this)) {
+        this._attachedPending = false;
+        this.detachedCallback();
+      }
     },
 
     // for system overriding
@@ -175,7 +181,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         this._attachedPending = true;
       }
+    },
+
+    /**
+     * Polymer library implementation of the Custom Elements `detachedCallback`.
+     *
+     * Note, users should not override `detachedCallback`, and instead should
+     * implement the `detached` method on Polymer elements to receive
+     * detached-time callbacks.
+     *
+     * @protected
+     */
+    detachedCallback: function() {
+      if (this._readied) {
+        baseDetachedCallback.call(this);
+      } else {
+        this._detachedPending = true;
+      }
     }
+
+
 
   });
 

--- a/src/mini/ready.html
+++ b/src/mini/ready.html
@@ -153,11 +153,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._attachedPending = false;
         this.attachedCallback();
       }
-      // only call detached if the element is actually detached
-      if (this._detachedPending && !Polymer.dom(document.body).deepContains(this)) {
-        this._attachedPending = false;
-        this.detachedCallback();
-      }
     },
 
     // for system overriding
@@ -196,11 +191,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this._readied) {
         baseDetachedCallback.call(this);
       } else {
-        this._detachedPending = true;
+        this._attachedPending = false;
       }
     }
-
-
 
   });
 

--- a/test/unit/element-disable-upgrade.html
+++ b/test/unit/element-disable-upgrade.html
@@ -32,9 +32,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-attach">
+  <template>
+    <style>
+    :host {
+      display: block;
+    }
+    </style>
+    <div id="child">Live!</div>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({
+      is: 'x-attach',
+      attached: function() {
+        this._wasAttached = true;
+      },
+      detached: function() {
+        this._wasDetached = true;
+      }
+    });
+  });
+  </script>
+</dom-module>
+
 <test-fixture id="simple">
   <template>
     <x-lazy disable-upgrade></x-lazy>
+  </template>
+</test-fixture>
+
+<test-fixture id="attach">
+  <template>
+    <x-attach disable-upgrade></x-attach>
   </template>
 </test-fixture>
 
@@ -139,6 +169,40 @@ suite('Element disableUpgrade', function() {
       el.removeAttribute('disable-upgrade');
       assert.ok(el.root);
       assert.ok(el.$.child);
+    });
+  });
+  suite('disableUpgrade attach/detach', function() {
+    var el;
+    setup(function() {
+      el = fixture('attach');
+    });
+    test('attached does not fire when element is not yet enabled', function() {
+      assert.notOk(el._wasAttached);
+      el.removeAttribute('disable-upgrade');
+      assert.ok(el._wasAttached);
+    });
+    test('detached does not fire when element is not yet enabled', function() {
+      el.parentNode.removeChild(el);
+      Polymer.dom.flush();
+      assert.notOk(el._wasAttached);
+      assert.notOk(el._wasDetached);
+      el.removeAttribute('disable-upgrade');
+      assert.ok(el._wasAttached);
+      assert.ok(el._wasDetached);
+    });
+    test('detached does not fire when element is detached/attached when not yet enabled', function() {
+      var parent = el.parentNode;
+      parent.removeChild(el);
+      Polymer.dom.flush();
+      assert.notOk(el._wasAttached);
+      assert.notOk(el._wasDetached);
+      parent.appendChild(el);
+      Polymer.dom.flush();
+      assert.notOk(el._wasAttached);
+      assert.notOk(el._wasDetached);
+      el.removeAttribute('disable-upgrade');
+      assert.ok(el._wasAttached);
+      assert.notOk(el._wasDetached);
     });
   });
   suite('disableUpgrade and Databinding', function() {

--- a/test/unit/element-disable-upgrade.html
+++ b/test/unit/element-disable-upgrade.html
@@ -181,16 +181,16 @@ suite('Element disableUpgrade', function() {
       el.removeAttribute('disable-upgrade');
       assert.ok(el._wasAttached);
     });
-    test('detached does not fire when element is not yet enabled', function() {
+    test('attached/detached do not fire when element is not yet enabled', function() {
       el.parentNode.removeChild(el);
       Polymer.dom.flush();
       assert.notOk(el._wasAttached);
       assert.notOk(el._wasDetached);
       el.removeAttribute('disable-upgrade');
-      assert.ok(el._wasAttached);
-      assert.ok(el._wasDetached);
+      assert.notOk(el._wasAttached);
+      assert.notOk(el._wasDetached);
     });
-    test('detached does not fire when element is detached/attached when not yet enabled', function() {
+    test('attached/detached do not fire when element is detached/attached when not yet enabled', function() {
       var parent = el.parentNode;
       parent.removeChild(el);
       Polymer.dom.flush();

--- a/test/unit/element-disable-upgrade.html
+++ b/test/unit/element-disable-upgrade.html
@@ -46,10 +46,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
       is: 'x-attach',
       attached: function() {
-        this._wasAttached = true;
+        this._connectLog = this._connectLog || [];
+        this._connectLog.push('attached');
       },
       detached: function() {
-        this._wasDetached = true;
+        this._connectLog = this._connectLog || [];
+        this._connectLog.push('detached');
       }
     });
   });
@@ -177,32 +179,51 @@ suite('Element disableUpgrade', function() {
       el = fixture('attach');
     });
     test('attached does not fire when element is not yet enabled', function() {
-      assert.notOk(el._wasAttached);
+      assert.notOk(el._connectLog);
       el.removeAttribute('disable-upgrade');
-      assert.ok(el._wasAttached);
+      assert.equal(el._connectLog.length, 1);
+      assert.equal(el._connectLog[0], 'attached');
     });
     test('attached/detached do not fire when element is not yet enabled', function() {
       el.parentNode.removeChild(el);
       Polymer.dom.flush();
-      assert.notOk(el._wasAttached);
-      assert.notOk(el._wasDetached);
+      assert.notOk(el._connectLog);
       el.removeAttribute('disable-upgrade');
-      assert.notOk(el._wasAttached);
-      assert.notOk(el._wasDetached);
+      assert.notOk(el._connectLog);
     });
     test('attached/detached do not fire when element is detached/attached when not yet enabled', function() {
       var parent = el.parentNode;
       parent.removeChild(el);
       Polymer.dom.flush();
-      assert.notOk(el._wasAttached);
-      assert.notOk(el._wasDetached);
+      assert.notOk(el._connectLog);
       parent.appendChild(el);
       Polymer.dom.flush();
-      assert.notOk(el._wasAttached);
-      assert.notOk(el._wasDetached);
+      assert.notOk(el._connectLog);
+      assert.notOk(el._connectLog);
       el.removeAttribute('disable-upgrade');
-      assert.ok(el._wasAttached);
-      assert.notOk(el._wasDetached);
+      assert.equal(el._connectLog.length, 1);
+      assert.equal(el._connectLog[0], 'attached');
+    });
+
+    test('attached/detached fire as expected after element is enabled', function() {
+      var parent = el.parentNode;
+      parent.removeChild(el);
+      Polymer.dom.flush();
+      assert.notOk(el._connectLog);
+      parent.appendChild(el);
+      Polymer.dom.flush();
+      assert.notOk(el._connectLog);
+      el.removeAttribute('disable-upgrade');
+      assert.equal(el._connectLog.length, 1);
+      assert.equal(el._connectLog[0], 'attached');
+      parent.removeChild(el);
+      Polymer.dom.flush();
+      assert.equal(el._connectLog.length, 2);
+      assert.equal(el._connectLog[1], 'detached');
+      parent.appendChild(el);
+      Polymer.dom.flush();
+      assert.equal(el._connectLog.length, 3);
+      assert.equal(el._connectLog[2], 'attached');
     });
   });
   suite('disableUpgrade and Databinding', function() {


### PR DESCRIPTION
This fixes an issue that allowed an element with `disable-upgrade` to process the `detached` callback.