### PR TITLE
fix ArraySplice @types to more closely match code

### DIFF
--- a/lib/utils/array-splice.html
+++ b/lib/utils/array-splice.html
@@ -146,19 +146,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *   l: The length of the current array
    *   p: The length of the old array
    *
-   * @param {Array} current The current "changed" array for which to
+   * @param {!Array} current The current "changed" array for which to
    * calculate splices.
    * @param {number} currentStart Starting index in the `current` array for
    * which splices are calculated.
    * @param {number} currentEnd Ending index in the `current` array for
    * which splices are calculated.
-   * @param {Array} old The original "unchanged" array to compare `current`
+   * @param {!Array} old The original "unchanged" array to compare `current`
    * against to determine splices.
    * @param {number} oldStart Starting index in the `old` array for
    * which splices are calculated.
    * @param {number} oldEnd Ending index in the `old` array for
    * which splices are calculated.
-   * @return {Array} Returns an array of splice record objects. Each of these
+   * @return {!Array} Returns an array of splice record objects. Each of these
    * contains: `index` the location where the splice occurred; `removed`
    * the array of removed items from this location; `addedCount` the number
    * of items added at this location.
@@ -300,11 +300,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @function
      * @memberof Polymer.ArraySplice
-     * @param {Array} current The "changed" array for which splices will be
+     * @param {!Array} current The "changed" array for which splices will be
      * calculated.
-     * @param {Array} previous The "unchanged" original array to compare
+     * @param {!Array} previous The "unchanged" original array to compare
      * `current` against to determine the splices.
-     * @return {Array} Returns an array of splice record objects. Each of these
+     * @return {!Array} Returns an array of splice record objects. Each of these
      * contains: `index` the location where the splice occurred; `removed`
      * the array of removed items from this location; `addedCount` the number
      * of items added at this location.

--- a/types/lib/mixins/properties-changed.d.ts
+++ b/types/lib/mixins/properties-changed.d.ts
@@ -20,16 +20,13 @@ declare namespace Polymer {
    * or more property accessors (getter/setter pair) that enqueue an async
    * (batched) `_propertiesChanged` callback.
    *
-   * For basic usage of this mixin, simply declare attributes to observe via
-   * the standard `static get observedAttributes()`, implement `_propertiesChanged`
-   * on the class, and then call `MyClass.createPropertiesForAttributes()` once
-   * on the class to generate property accessors for each observed attribute
-   * prior to instancing. Last, call `this._enableProperties()` in the element's
+   * For basic usage of this mixin, call `MyClass.createProperties(props)`
+   * once at class definition time to create property accessors for properties
+   * named in props, implement `_propertiesChanged` to react as desired to
+   * property changes, and implement `static get observedAttributes()` and
+   * include lowercase versions of any property names that should be set from
+   * attributes. Last, call `this._enableProperties()` in the element's
    * `connectedCallback` to enable the accessors.
-   *
-   * Any `observedAttributes` will automatically be
-   * deserialized via `attributeChangedCallback` and set to the associated
-   * property using `dash-case`-to-`camelCase` convention.
    */
   function PropertiesChanged<T extends new (...args: any[]) => {}>(base: T): T & PropertiesChangedConstructor;
 
@@ -193,9 +190,8 @@ declare namespace Polymer {
      * considered as a change and cause the `_propertiesChanged` callback
      * to be enqueued.
      *
-     * The default implementation returns `true` for primitive types if a
-     * strict equality check fails, and returns `true` for all Object/Arrays.
-     * The method always returns false for `NaN`.
+     * The default implementation returns `true` if a strict equality
+     * check fails. The method always returns false for `NaN`.
      *
      * Override this method to e.g. provide stricter checking for
      * Objects/Arrays when using immutable patterns.
@@ -257,9 +253,9 @@ declare namespace Polymer {
     /**
      * Converts a typed JavaScript value to a string.
      *
-     * This method is called by Polymer when setting JS property values to
-     * HTML attributes.  Users may override this method on Polymer element
-     * prototypes to provide serialization for custom types.
+     * This method is called when setting JS property values to
+     * HTML attributes.  Users may override this method to provide
+     * serialization for custom types.
      *
      * @param value Property value to serialize.
      * @returns String serialized from the provided
@@ -272,9 +268,8 @@ declare namespace Polymer {
      *
      * This method is called when reading HTML attribute values to
      * JS properties.  Users may override this method to provide
-     * deserialization for custom `type`s. The given `type` is executed
-     * as a function with the value as an argument. The `Boolean` `type`
-     * is specially handled such that an empty string returns true.
+     * deserialization for custom `type`s. Types for `Boolean`, `String`,
+     * and `Number` convert attributes to the expected types.
      *
      * @param value Value to deserialize.
      * @param type Type to deserialize the string to.

--- a/types/lib/utils/array-splice.d.ts
+++ b/types/lib/utils/array-splice.d.ts
@@ -44,6 +44,6 @@ declare namespace Polymer {
      * the array of removed items from this location; `addedCount` the number
      * of items added at this location.
      */
-    function calculateSplices(current: any[]|null, previous: any[]|null): any[]|null;
+    function calculateSplices(current: any[], previous: any[]): any[];
   }
 }


### PR DESCRIPTION
There's a bunch of `.length` checks on the `current` and `previous` array args passed to the public calculateSplices() method.

I've updated from `{Array}` to `{!Array}` in every case that an unprotected `.length` check occurs (which would fail if the parameter is `null`).

I also saw no way that `null` would ever be /returned/ from this method, so I made the return type `{!Array}` (non-nullable) as well.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
