### PR TITLE
Vend mixins for listeners block and hostAttributes block

### DIFF
--- a/lib/mixins/host-attributes-mixin.html
+++ b/lib/mixins/host-attributes-mixin.html
@@ -1,0 +1,34 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="property-accessors.html">
+<link rel="import" href="../utils/mixin.html">
+<script>
+  (function() {
+    'use strict';
+
+    Polymer.HostAttributes = Polymer.dedupingMixin((base) => {
+      let attributeBase = Polymer.PropertyAccessorsMixin(base);
+
+      class HostAttributes extends attributeBase {
+        ready() {
+          let hostAttributes = this.constructor.hostAttributes;
+          if (hostAttributes) {
+            for (let name in hostAttributes) {
+              this._ensureAttribute(name, hostAttributes[name]);
+            }
+          }
+          super.ready();
+        }
+      }
+
+      return HostAttributes;
+    });
+  })();
+</script>

--- a/lib/mixins/host-attributes-mixin.html
+++ b/lib/mixins/host-attributes-mixin.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'use strict';
 
     Polymer.HostAttributes = Polymer.dedupingMixin((base) => {
-      let attributeBase = Polymer.PropertyAccessorsMixin(base);
+      let attributeBase = Polymer.PropertyAccessors(base);
 
       class HostAttributes extends attributeBase {
         ready() {

--- a/lib/mixins/listeners-mixin.html
+++ b/lib/mixins/listeners-mixin.html
@@ -1,0 +1,34 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="template-stamp.html">
+<link rel="import" href="../utils/mixin.html">
+<script>
+  (function() {
+    'use strict';
+
+    Polymer.Listeners = Polymer.dedupingMixin((base) => {
+      let listenerBase = Polymer.TemplateStamp(base);
+
+      class Listeners extends listenerBase {
+        ready() {
+          let listeners = this.constructor.listeners;
+          if (listeners) {
+            for (let l in listeners) {
+              this._addMethodEventListenerToNode(this, l, listeners[l]);
+            }
+          }
+          super.ready();
+        }
+      }
+
+      return Listeners;
+    });
+  })();
+</script>

--- a/test/unit/attributes-elements.html
+++ b/test/unit/attributes-elements.html
@@ -8,6 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../../lib/mixins/host-attributes-mixin.html">
 <script>
   let PropertyTypeBehavior = {
     properties: {
@@ -200,4 +201,95 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.setAttribute('prop2', 'hi');
     }
   });
+</script>
+
+<script>
+  class XBasicLite extends Polymer.mixinBehaviors([PropertyTypeBehavior], Polymer.HostAttributes(Polymer.Element)) {
+    static get hostAttributes() {
+      return {
+        attr1: 'this is attr 1',
+        attr2: 42,
+        attr3: 'host',
+        'aria-role': 'button',
+        title: 'awesome',
+        'attr-object': { foo: 'bar', nested: { 'meaning': 42 }, arr: [0, 'foo', true] },
+        'attr-stupid': false,
+        class: 'foo bar baz'
+      }
+    }
+
+    static get properties() {
+      return {
+        object: {
+          type: Object,
+          value: function() { return {}; }
+        },
+        array: {
+          type: Array,
+            value: function() { return []; }
+        },
+        number: {
+          type: Number,
+            value: 0
+        },
+        string: {
+          type: String,
+            value: 'none'
+        },
+        bool: {
+          type: Boolean,
+            value: true
+        },
+        negBool: {
+          type: Boolean,
+            value: false
+        },
+        date: {
+          type: Date,
+            value: function() { return new Date(0); }
+        },
+        dashCase: {
+          type: String,
+            value: 'none'
+        },
+        UPCASE: {
+          type: String,
+            value: 'none'
+        },
+        noType: {
+          value: 'none'
+        },
+        readOnly: {
+          type: String,
+            value: 'default',
+              readOnly: true
+        },
+        prop: {
+          value: 'prop',
+            observer: 'propChanged'
+        },
+        attr1: {
+          observer: 'attr1Changed'
+        },
+        shorthandNumber: Number,
+        shorthandBool: Boolean
+      }
+    }
+
+    constructor() {
+      super();
+      this.propChangedCount = 0;
+      this.attr1ChangedCount = 0;
+    }
+
+    propChanged() {
+      this.propChangedCount++;
+    }
+
+    attr1Changed() {
+      this.attr1ChangedCount++;
+    }
+  }
+
+  customElements.define('x-basic-lite', XBasicLite);
 </script>

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -86,6 +86,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="basic-lite">
+    <template>
+      <x-basic-lite attr3="instance"></x-basic-lite>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="basic-lite-with-attributes">
+    <template>
+      <x-basic-lite
+        object='{"foo": "bar", "nested": {"meaning": 42}, "arr": [0, "foo", true]}'
+        array='[0, "foo", true, {"foo": "bar"}]'
+        number="42"
+        string="The quick brown fox"
+        bool
+        date="Wed Mar 04 2015 10:46:05 GMT-0800 (PST)"
+        -u-p-c-a-s-e="The quick brown fox"
+        dash-case="The quick brown fox"
+        no-type="Should be String"
+        read-only="Should not change"
+        class="Should not deserialize"
+        nard="Should not deserialize"
+        behavior-bool
+        behavior-number="77"
+        shorthand-bool
+        shorthand-number="88"
+        behavior-shorthand-bool
+        behavior-shorthand-number="99"
+        >
+      </x-basic-lite>
+    </template>
+  </test-fixture>
+
   <script>
   suite('create-time deserialization', function() {
     function testAttributesMatchDefaults(element) {
@@ -159,6 +191,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var element = fixture('reflect-to-attribute');
       assert.isTrue(element.__warnedAboutUPCASE = true);
     });
+
+    test('basic-lite default values', function() {
+      var element = fixture('basic-lite');
+      testAttributesMatchDefaults(element);
+    });
+
+    test('basic-lite deserialize attributes', function () {
+      var element = fixture('basic-lite-with-attributes');
+      testAttributesMatchCustomConfiguration(element);
+    });
   });
 
   suite('imperative attribute change (no-reflect)', function() {
@@ -166,6 +208,68 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     setup(function() {
       element = fixture('basic');
+      configuredObject = {foo: 'bar', nested: {'meaning': 42}, arr: [0, 'foo', true]};
+      configuredArray = [0, 'foo', true, {foo: 'bar'}];
+    });
+
+    test('change object attribute', function() {
+      element.setAttribute('object', '{"foo": "bar", "nested": {"meaning": 42}, "arr": [0, "foo", true]}');
+      assert.deepEqual(element.object, configuredObject);
+    });
+
+    test('change array attribute', function() {
+      element.setAttribute('array', '[0, "foo", true, {"foo": "bar"}]');
+      assert.deepEqual(element.array, configuredArray);
+    });
+
+    test('change number attribute', function() {
+      element.setAttribute('number', 42);
+      assert.strictEqual(element.number, 42);
+    });
+
+    test('change string attribute', function() {
+      element.setAttribute('string', 'howdy');
+      assert.strictEqual(element.string, 'howdy');
+    });
+
+    test('change boolean attribute true', function() {
+      element.setAttribute('bool', '');
+      assert.strictEqual(element.bool, true);
+    });
+
+    test('change boolean attribute truthy', function() {
+      element.setAttribute('bool', 'sure!');
+      assert.strictEqual(element.bool, true);
+    });
+
+    test('change boolean attribute false', function() {
+      element.setAttribute('bool', '');
+      assert.strictEqual(element.bool, true);
+      element.removeAttribute('bool');
+      assert.strictEqual(element.bool, false);
+    });
+
+    test('change dashCase attribute', function() {
+      element.setAttribute('dash-case', 'Changed');
+      assert.strictEqual(element.dashCase, 'Changed');
+    });
+
+    test('value that cannot deserialize from JSON warns', function() {
+      sinon.spy(console, 'warn');
+      var badAttr = '[foo, bar]';
+      element.setAttribute('array', badAttr);
+      assert.isTrue(console.warn.calledOnce);
+      assert.include(console.warn.firstCall.args[0], badAttr);
+      console.warn.restore();
+    });
+
+  });
+
+  suite('imperative attribute change (no-reflect, basic-lite)', function() {
+    var element, configuredObject, configuredArray;
+
+    setup(function() {
+      element = fixture('basic-lite');
       configuredObject = {foo: 'bar', nested: {'meaning': 42}, arr: [0, 'foo', true]};
       configuredArray = [0, 'foo', true, {foo: 'bar'}];
     });
@@ -335,6 +439,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(element.$.basic.propChangedCount, 1);
       assert.equal(element.$.basic.attr1ChangedCount, 1);
       assert.equal(element.prop2, 'hi');
+    });
+
+    test('hostAttributes set correctly, basic-lite', function() {
+      var element = fixture('basic-lite');
+      assert.strictEqual(element.getAttribute('attr1'), 'this is attr 1');
+      assert.strictEqual(element.getAttribute('attr2'), '42');
+      assert.strictEqual(element.getAttribute('attr3'), 'instance', 'host attribute overrode instance attribute and should not');
+      assert.strictEqual(element.getAttribute('aria-role'), 'button');
+      assert.strictEqual(element.getAttribute('title'), 'awesome');
+      assert.strictEqual(element.title, 'awesome');
+      assert.equal(element.getAttribute('attr-object'), JSON.stringify(configuredObject));
+      assert.equal(element.hasAttribute('attr-stupid'), false);
+      // class *is* serialized
+      // BREAKME(sorvell): document breaking change.
+      assert.ok(element.classList.contains('foo'));
+      assert.ok(element.classList.contains('bar'));
+      assert.ok(element.classList.contains('baz'));
+
     });
 
   });

--- a/test/unit/events-elements.html
+++ b/test/unit/events-elements.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer.html">
+<link rel="import" href="../../lib/mixins/listeners-mixin.html">
 
 <script>
   var EventLoggerImpl = {
@@ -93,3 +94,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </dom-module>
+
+<script>
+  class XListenersLite extends Polymer.mixinBehaviors([EventLoggerImpl], Polymer.Listeners(Polymer.Element)) {
+    static get listeners() {
+      return {
+        foo: 'handle',
+        bar: 'missing'
+      }
+    }
+  }
+  customElements.define('x-listeners-lite', XListenersLite);
+</script>

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -49,6 +49,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
+      suite('listeners block with listeners mixin', function() {
+        suiteSetup(function() {
+          el = document.createElement('x-listeners-lite');
+          document.body.appendChild(el);
+        });
+
+        suiteTeardown(function() {
+          document.body.removeChild(el);
+        });
+
+        test('fire - method exists', function() {
+          el.fire('foo');
+          assert.equal(el._handled[el.localName], 'foo');
+        });
+
+        test('fire - method missing', function() {
+          sinon.spy(console, 'warn');
+          el.fire('bar');
+          assert.isTrue(console.warn.calledOnce);
+          assert.equal(console.warn.getCall(0).args[0], 'listener method `missing` not defined');
+          console.warn.restore();
+        });
+
+      });
+
       suite('on-*', function() {
 
         var options;

--- a/test/unit/gestures-elements.html
+++ b/test/unit/gestures-elements.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer.html">
+<link rel="import" href="../../lib/mixins/listeners-mixin.html">
 
 <dom-module id="x-foo">
   <template>
@@ -36,6 +37,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-foo-lite">
+  <template>
+    <style>
+      #div {
+        height: 40px;
+        background: red;
+      }
+    </style>
+
+    <div id="div"></div>
+  </template>
+
+  <script>
+    class XFooLite extends Polymer.Listeners(Polymer.GestureEventListeners(Polymer.Element)) {
+      static get is() {return 'x-foo-lite'}
+      static get listeners() {
+        return {
+          tap: 'tapHandler'
+        }
+      }
+      tapHandler(e) {
+        this._testLocalTarget = e.target;
+        this._testRootTarget = e.composedPath()[0];
+      }
+    }
+    customElements.define(XFooLite.is, XFooLite);
+  </script>
+</dom-module>
+
 <dom-module id="x-app">
 
   <template>
@@ -53,6 +83,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._testRootTarget = e.composedPath()[0];
       }
     });
+  </script>
+
+</dom-module>
+
+<dom-module id="x-app-lite">
+
+  <template>
+    <x-foo-lite id="foo"></x-foo-lite>
+  </template>
+
+  <script>
+    class XAppLite extends Polymer.GestureEventListeners(Polymer.Listeners(Polymer.Element)) {
+      static get is() {return 'x-app-lite'}
+      static get listeners() {
+        return {
+          tap: 'tapHandler'
+        }
+      }
+      tapHandler(e) {
+        this._testLocalTarget = e.target;
+        this._testRootTarget = e.composedPath()[0];
+      }
+    }
+    customElements.define(XAppLite.is, XAppLite);
   </script>
 
 </dom-module>

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -68,6 +68,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    suite('simulate events, with Polymer.Element and mixins', function() {
+
+      var app;
+
+      setup(function(done) {
+        app = document.createElement('x-app-lite');
+        document.body.appendChild(app);
+        Polymer.RenderStatus.afterNextRender(null, done);
+      });
+
+      teardown(function() {
+        document.body.removeChild(app);
+      });
+
+      test('tap on x-foo and check localTarget and rootTarget', function() {
+        var foo = app.$.foo;
+        foo.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+        assert.equal(app._testLocalTarget, app, 'local target');
+        assert.equal(app._testRootTarget, foo, 'root target');
+      });
+
+      test('tap on x-foo.div and check target info', function() {
+        var foo = app.$.foo;
+        var div = foo.$.div;
+        div.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+        assert.equal(app._testLocalTarget, app, 'app local target');
+        assert.equal(app._testRootTarget, div, 'app root target');
+        assert.equal(foo._testLocalTarget, foo, 'foo local target');
+        assert.equal(foo._testRootTarget, div, 'foo root target');
+      });
+
+      test('HTMLElement.click triggers tap', function() {
+        // put the element off screen to prevent x/y weirdness from .click()
+        app.style.cssText = 'position: absolute; left: -1000px; top: -1000px;';
+        // make a mousedown *very* far away to tickle the distance check
+        var ev = new CustomEvent('mousedown', {composed: true});
+        ev.clientX = 1e8;
+        ev.clientY = 1e8;
+        app.dispatchEvent(ev);
+        app.click();
+        assert.equal(app._testLocalTarget, app, 'app local target');
+        assert.equal(app._testRootTarget, app, 'app root target');
+      });
+    });
+
     suite('Event Setup and Teardown', function() {
       var outer, inner;
       suiteSetup(function(done) {


### PR DESCRIPTION
Allow for easier migration to `Polymer.Element` for elements that use legacy `hostAttributes` and `listeners` blocks in `Polymer({})`

Fixes #4625