### PR TITLE
Upgrade babel-preset-babili

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@webcomponents/shadycss": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^1.0.0",
-    "babel-preset-babili": "0.0.12",
+    "babel-preset-babili": "0.1.2",
     "del": "^2.2.1",
     "dom5": "^1.3.1",
     "eslint-plugin-html": "^2.0.1",


### PR DESCRIPTION
Latest release of babel-preset-babili fixes breaking complex regular expression with corresponding upstream bug report being https://github.com/babel/babili/issues/526 and PR that fixes it being https://github.com/babel/babili/pull/490 that also affects Polymer.