### PR TITLE
Update web-component-tester to stable version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "webcomponentsjs": "^v1.0.0"
   },
   "devDependencies": {
-    "web-component-tester": "^v6.0.0-prerelease.10",
+    "web-component-tester": "^v6.0.0",
     "test-fixture": "PolymerElements/test-fixture#3.0.0-rc.1"
   },
   "private": true,


### PR DESCRIPTION
The latest version of web-component-tester is now stable, so the prerelease tag can be removed.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fixes #4662
