### PR TITLE
Store original template content inside templateInfo

### DIFF
--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -306,7 +306,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   metadata to `nodeInfo`
        */
       static _parseTemplateNestedTemplate(node, outerTemplateInfo, nodeInfo) {
+        let originalContent = node.content.cloneNode(true);
         let templateInfo = this._parseTemplate(node, outerTemplateInfo);
+        templateInfo.originalContent = originalContent;
         let content = templateInfo.content =
           node.content.ownerDocument.createDocumentFragment();
         content.appendChild(node.content);


### PR DESCRIPTION
In some scenarios it is important to have access to original template content even without 'preserve-content' attribute. 

For example in my application I have custom table element where users can insert many templates inside lighting dom for all columns. From this columns I have to create row template dynamically (only this one will be templatized). Unfortunately cell templates (without 'preserve-content') don't work correctly because of consumed property binding (content from _contentForTemplate is also not enough here). 
From other side I don't want use  'preserve-content' attribute because this hits API usability.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
