### PR TITLE
dom-repat: set path when an observed path changes.

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -610,18 +610,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // If path was index into array...
       if (itemsIdx == parseInt(itemsIdx, 10)) {
         let itemSubPath = dot < 0 ? '' : itemsPath.substring(dot+1);
-        // See if the item subpath should trigger a full refresh...
-        if (!this.__handleObservedPaths(itemSubPath)) {
-          // If not, forward to the instance for that index
-          let instIdx = this.__itemsIdxToInstIdx[itemsIdx];
-          let inst = this.__instances[instIdx];
-          if (inst) {
-            let itemPath = this.as + (itemSubPath ? '.' + itemSubPath : '');
-            // This is effectively `notifyPath`, but avoids some of the overhead
-            // of the public API
-            inst._setPendingPropertyOrPath(itemPath, value, false, true);
-            inst._flushProperties();
-          }
+        // If the path is observed, it will trigger a full refresh
+        this.__handleObservedPaths(itemSubPath)
+        // Note, even if a rull refresh is triggered, always do the path
+        // notification because unless mutableData is used for dom-repeat
+        // and all elements in the instance subtree, a full refresh may
+        // not trigger the proper update.
+        let instIdx = this.__itemsIdxToInstIdx[itemsIdx];
+        let inst = this.__instances[instIdx];
+        if (inst) {
+          let itemPath = this.as + (itemSubPath ? '.' + itemSubPath : '');
+          // This is effectively `notifyPath`, but avoids some of the overhead
+          // of the public API
+          inst._setPendingPropertyOrPath(itemPath, value, false, true);
+          inst._flushProperties();
         }
         return true;
       }

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -281,7 +281,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.__itemsIdxToInstIdx = {};
       this.__chunkCount = null;
       this.__lastChunkTime = null;
-      this.__needFullRefresh = false;
       this.__sortFn = null;
       this.__filterFn = null;
       this.__observePaths = null;
@@ -370,7 +369,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let methodHost = this.__getMethodHost();
       this.__sortFn = sort && (typeof sort == 'function' ? sort :
         function() { return methodHost[sort].apply(methodHost, arguments); });
-      this.__needFullRefresh = true;
       if (this.items) {
         this.__debounceRender(this.__render);
       }
@@ -380,7 +378,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let methodHost = this.__getMethodHost();
       this.__filterFn = filter && (typeof filter == 'function' ? filter :
         function() { return methodHost[filter].apply(methodHost, arguments); });
-      this.__needFullRefresh = true;
       if (this.items) {
         this.__debounceRender(this.__render);
       }
@@ -436,7 +433,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!this.__handleItemPath(change.path, change.value)) {
         // Otherwise, the array was reset ('items') or spliced ('items.splices'),
         // so queue a full refresh
-        this.__needFullRefresh = true;
         this.__initializeChunking();
         this.__debounceRender(this.__render);
       }
@@ -448,7 +444,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let paths = this.__observePaths;
         for (let i=0; i<paths.length; i++) {
           if (path.indexOf(paths[i]) === 0) {
-            this.__needFullRefresh = true;
             this.__debounceRender(this.__render, this.delay);
             return true;
           }
@@ -477,7 +472,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     render() {
       // Queue this repeater, then flush all in order
-      this.__needFullRefresh = true;
       this.__debounceRender(this.__render);
       Polymer.flush();
     }
@@ -611,7 +605,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (itemsIdx == parseInt(itemsIdx, 10)) {
         let itemSubPath = dot < 0 ? '' : itemsPath.substring(dot+1);
         // If the path is observed, it will trigger a full refresh
-        this.__handleObservedPaths(itemSubPath)
+        this.__handleObservedPaths(itemSubPath);
         // Note, even if a rull refresh is triggered, always do the path
         // notification because unless mutableData is used for dom-repeat
         // and all elements in the instance subtree, a full refresh may

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -4088,6 +4088,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert(stamped[0].classList.contains('x-simple-repeat'), 'expected scoping');
       });
 
+      test('paths update on observed properties', function() {
+        let simple = fixture('simple');
+        Polymer.flush();
+        //debugger;
+        var stamped = simple.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped[0].itemaProp, 'prop-1');
+        simple.$.repeat.observe = 'prop';
+        Polymer.flush();
+        simple.set('items.0.prop', {foo: 0});
+        Polymer.flush();
+        assert.equal(stamped[0].get('itemaProp.foo'), 0);
+        simple.set('items.0.prop.foo', 1);
+        Polymer.flush();
+        assert.equal(stamped[0].get('itemaProp.foo'), 1);
+        simple.set('items.0.prop.foo', 2);
+        Polymer.flush();
+        assert.equal(stamped[0].get('itemaProp.foo'), 2);
+      });
     });
 
     suite('timing', function() {


### PR DESCRIPTION
Fixes #4650: if an observed path changes, the repeat should render but in addition, the path should be notified. This is necessary since “mutableData” is optional.
