### PR TITLE
Move Debouncer memberof annotation to right place, and add a summary.

### DIFF
--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -18,6 +18,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /** @typedef {{run: function(function(), number=):number, cancel: function(number)}} */
   let AsyncModule; // eslint-disable-line no-unused-vars
 
+  /**
+   * Collapse multiple callbacks into one invocation after a timer.
+   *
+   * @memberof Polymer
+   */
   class Debouncer {
     constructor() {
       this._asyncModule = null;
@@ -107,9 +112,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
-  /**
-   * @memberof Polymer
-   */
   Polymer.Debouncer = Debouncer;
 })();
 </script>


### PR DESCRIPTION
Fixes one of the issues at https://github.com/Polymer/polymer-analyzer/issues/691
