### PR TITLE
Adds `selectIndexes` and`selectAll` to `array-selector`

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -328,10 +328,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (idxs.length) return this.selectIndex(idxs[0]);
         } else {
           this.__selectedMap.clear();
-          let items = idxs.map((idx) => {
+          let items = [];
+          idxs.forEach((idx) => {
             let item = this.items[idx];
             this.__selectedMap.set(item, idx);
-            return item;
+            items.push(item);
           });
           this.__updateLinks();
           this.set('selected', items);

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -321,7 +321,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {array} idxs Indexes from `items` array to select
        */
       selectIndexes(idxs) {
-        if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(idxs))) {
+        if (arguments.length > 1 || (typeof idxs !== 'undefined' && !Array.isArray(idxs))) {
           idxs = Array.from(arguments);
         }
         if (!this.multi) {

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -315,6 +315,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      /**
+       * Selects the given indexes.
+       *
+       * @param {array} idxs Indexes from `items` array to select
+       */
+      selectIndexes(idxs) {
+        if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(idxs))) {
+          idxs = Array.from(arguments);
+        }
+        if (!this.multi) {
+          if (idxs.length) return this.selectIndex(idxs[0]);
+          return;
+        }
+        this.__selectedMap.clear();
+        let items = idxs.map((idx) => {
+          let item = this.items[idx];
+          this.__selectedMap.set(item, idx);
+          return item;
+        });
+        this.__updateLinks();
+        this.set('selected', items);
+      }
+
+      /**
+       * Selects all of the items.
+       *
+       */
+      selectAll() {
+        if (!this.multi) return;
+        this.__selectedMap.clear();
+        this.items.forEach((item, idx) => {
+          this.__selectedMap.set(item, idx);
+        });
+        this.__updateLinks();
+        this.set('selected', this.items);
+      }
+
+      /**
+       * Deelects all of the items.
+       *
+       */
+      deselectAll() {
+        this.__selectedMap.clear();
+        this.__updateLinks();
+        this.selected = this.selectedItem = null;
+      }
+
     }
 
     return ArraySelectorMixin;

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -325,7 +325,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           idxs = Array.from(arguments);
         }
         if (!this.multi) {
-          if (idxs.length) return this.selectIndex(idxs[0]);
+          if (idxs.length) this.selectIndex(idxs[0]);
         } else {
           this.__selectedMap.clear();
           let items = [];

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -326,16 +326,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         if (!this.multi) {
           if (idxs.length) return this.selectIndex(idxs[0]);
-          return;
+        } else {
+          this.__selectedMap.clear();
+          let items = idxs.map((idx) => {
+            let item = this.items[idx];
+            this.__selectedMap.set(item, idx);
+            return item;
+          });
+          this.__updateLinks();
+          this.set('selected', items);
         }
-        this.__selectedMap.clear();
-        let items = idxs.map((idx) => {
-          let item = this.items[idx];
-          this.__selectedMap.set(item, idx);
-          return item;
-        });
-        this.__updateLinks();
-        this.set('selected', items);
       }
 
       /**
@@ -343,23 +343,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        */
       selectAll() {
-        if (!this.multi) return;
-        this.__selectedMap.clear();
-        this.items.forEach((item, idx) => {
-          this.__selectedMap.set(item, idx);
-        });
-        this.__updateLinks();
-        this.set('selected', this.items);
-      }
-
-      /**
-       * Deelects all of the items.
-       *
-       */
-      deselectAll() {
-        this.__selectedMap.clear();
-        this.__updateLinks();
-        this.selected = this.selectedItem = null;
+        if (this.multi) {
+          this.__selectedMap.clear();
+          this.items.forEach((item, idx) => {
+            this.__selectedMap.set(item, idx);
+          });
+          this.__updateLinks();
+          this.set('selected', this.items);
+        }
       }
 
     }

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -258,19 +258,6 @@ suite('single selection', function() {
     assert.strictEqual(bind.$.singleBound.selected, null);
   });
 
-  test('deselect all: single', function() {
-    let bind = fixture('bind');
-    bind.items = [
-      {name: 'one'},
-      {name: 'two'},
-      {name: 'three'}
-    ];
-    bind.$.singleBound.selectIndex(0);
-    assert.strictEqual(bind.$.singleBound.selected, bind.items[0]);
-    bind.$.singleBound.deselectAll();
-    assert.strictEqual(bind.$.singleBound.selected, null);
-  });
-
 });
 
 suite('multi selection', function() {
@@ -535,19 +522,6 @@ suite('multi selection', function() {
     ];
     bind.$.multiBound.selectAll();
     assert.sameMembers(bind.$.multiBound.selected, bind.items);
-  });
-
-  test('deselect all: multi', function() {
-    let bind = fixture('bind');
-    bind.items = [
-      {name: 'one'},
-      {name: 'two'},
-      {name: 'three'}
-    ];
-    bind.$.multiBound.selectIndexes(0,2);
-    assert.sameMembers(bind.$.multiBound.selected, [bind.items[0], bind.items[2]]);
-    bind.$.multiBound.deselectAll();
-    assert.strictEqual(bind.$.singleBound.selected, null);
   });
 
 });

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -236,6 +236,41 @@ suite('single selection', function() {
     assert.equal(bind.$.singleBound.selected, null);
   });
 
+  test('select indexes only selects first index', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.selectIndexes(0,2);
+    assert.strictEqual(bind.$.singleBound.selected, bind.items[0]);
+  });
+
+  test('select all noops', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.selectAll();
+    assert.strictEqual(bind.$.singleBound.selected, null);
+  });
+
+  test('deselect all: single', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.selectIndex(0);
+    assert.strictEqual(bind.$.singleBound.selected, bind.items[0]);
+    bind.$.singleBound.deselectAll();
+    assert.strictEqual(bind.$.singleBound.selected, null);
+  });
+
 });
 
 suite('multi selection', function() {
@@ -478,6 +513,41 @@ suite('multi selection', function() {
     // set items to new objects; all should be removed (selection based on identity)
     bind.set('items.0', {name: 'new'});
     assert.sameMembers(bind.$.multiBound.selected, [bind.items[2]]);
+  });
+
+  test('select indexes', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.selectIndexes(0,2);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[0], bind.items[2]]);
+  });
+
+  test('select all', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.selectAll();
+    assert.sameMembers(bind.$.multiBound.selected, bind.items);
+  });
+
+  test('deselect all: multi', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.multiBound.selectIndexes(0,2);
+    assert.sameMembers(bind.$.multiBound.selected, [bind.items[0], bind.items[2]]);
+    bind.$.multiBound.deselectAll();
+    assert.strictEqual(bind.$.singleBound.selected, null);
   });
 
 });


### PR DESCRIPTION
### Reference Issue
Fixes #3176
Fixes #3827

These additions are currently for `2.x`, while the above tickets are about `1.x`. I'm working on a similar PR for the `1.x` line of code, so that between the two I can fully address https://github.com/PolymerElements/iron-list/issues/436 and the hybrid nature of the component requires that this support functionality gets into both lines. 
