### PR TITLE
test if path exist with ghost clicks events

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -71,9 +71,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // disable "ghost clicks"
     if (mouseEvent.type === 'click') {
       var path = Polymer.dom(mouseEvent).path;
-      for (var i = 0; i < path.length; i++) {
-        if (path[i] === POINTERSTATE.mouse.target) {
-          return;
+      if (path) {
+        for (var i = 0; i < path.length; i++) {
+          if (path[i] === POINTERSTATE.mouse.target) {
+            return;
+          }
         }
       }
       mouseEvent.preventDefault();


### PR DESCRIPTION
This PR add a test to the path var which can be undefined on some ghost click ( cordova/IOS ) and cause double click.
this catch have been done already in 2.x
It seems many issues can be related to this, difficult to say as behavior depends on target.
