### PR TITLE
support limit property (post filter/sort)

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -203,6 +203,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
 
         /**
+         * Define the total number of items to render after filtering and sorting.
+         * Setting limit to zero or negative equates to no limit.
+         */
+        limit: {
+          type: Number,
+          value: 0,
+          observer: '__limitChanged'
+        },
+
+        /**
          * When using a `filter` or `sort` function, the `observe` property
          * should be set to a space-separated list of the names of item
          * sub-fields that should trigger a re-sort or re-filter when changed.
@@ -226,8 +236,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         /**
          * Count of currently rendered items after `filter` (if any) has been applied.
          * If "chunking mode" is enabled, `renderedItemCount` is updated each time a
-         * set of template instances is rendered.
-         *
+         * set of template instances is rendered. This will be no larger than limit.
          */
         renderedItemCount: {
           type: Number,
@@ -276,7 +285,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     constructor() {
       super();
       this.__instances = [];
-      this.__limit = Infinity;
+      this.__chunkLimit = Infinity;
       this.__pool = [];
       this.__renderDebouncer = null;
       this.__itemsIdxToInstIdx = {};
@@ -384,13 +393,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
+    __limitChanged(limit) {
+      if (this.items) {
+        this.__debounceRender(this.__render);
+      }
+    }
+
     __computeFrameTime(rate) {
       return Math.ceil(1000/rate);
     }
 
     __initializeChunking() {
       if (this.initialCount) {
-        this.__limit = this.initialCount;
+        this.__chunkLimit = this.initialCount;
         this.__chunkCount = this.initialCount;
         this.__lastChunkTime = performance.now();
       }
@@ -399,7 +414,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     __tryRenderChunk() {
       // Debounced so that multiple calls through `_render` between animation
       // frames only queue one new rAF (e.g. array mutation & chunked render)
-      if (this.items && this.__limit < this.items.length) {
+      if (this.items && this.__chunkLimit < this.items.length) {
         this.__debounceRender(this.__requestRenderChunk);
       }
     }
@@ -415,7 +430,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let currChunkTime = performance.now();
       let ratio = this._targetFrameTime / (currChunkTime - this.__lastChunkTime);
       this.__chunkCount = Math.round(this.__chunkCount * ratio) || 1;
-      this.__limit += this.__chunkCount;
+      this.__chunkLimit += this.__chunkCount;
       this.__lastChunkTime = currChunkTime;
       this.__debounceRender(this.__render);
     }
@@ -515,17 +530,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.__sortFn) {
         isntIdxToItemsIdx.sort((a, b) => this.__sortFn(items[a], items[b]));
       }
+
       // items->inst map kept for item path forwarding
       const itemsIdxToInstIdx = this.__itemsIdxToInstIdx = {};
       let instIdx = 0;
       // Generate instances and assign items
-      const limit = Math.min(isntIdxToItemsIdx.length, this.__limit);
+      const limit = Math.min(isntIdxToItemsIdx.length, this.__chunkLimit);
       for (; instIdx<limit; instIdx++) {
         let inst = this.__instances[instIdx];
         let itemIdx = isntIdxToItemsIdx[instIdx];
         let item = items[itemIdx];
         itemsIdxToInstIdx[itemIdx] = instIdx;
-        if (inst && instIdx < this.__limit) {
+        if (inst && (instIdx < this.__chunkLimit) && (this.limit <= 0 || instIdx < this.limit)) {
           inst._setPendingProperty(this.as, item);
           inst._setPendingProperty(this.indexAs, instIdx);
           inst._setPendingProperty(this.itemsIndexAs, itemIdx);

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -535,13 +535,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const itemsIdxToInstIdx = this.__itemsIdxToInstIdx = {};
       let instIdx = 0;
       // Generate instances and assign items
-      const limit = Math.min(isntIdxToItemsIdx.length, this.__chunkLimit);
+      let limit = Math.min(isntIdxToItemsIdx.length, this.__chunkLimit);
+      if (this.limit > 0 && this.limit < limit) {
+        limit = this.limit;
+      }
       for (; instIdx<limit; instIdx++) {
         let inst = this.__instances[instIdx];
         let itemIdx = isntIdxToItemsIdx[instIdx];
         let item = items[itemIdx];
         itemsIdxToInstIdx[itemIdx] = instIdx;
-        if (inst && (instIdx < this.__chunkLimit) && (this.limit <= 0 || instIdx < this.limit)) {
+        if (inst && instIdx < this.__chunkLimit) {
           inst._setPendingProperty(this.as, item);
           inst._setPendingProperty(this.indexAs, instIdx);
           inst._setPendingProperty(this.itemsIndexAs, itemIdx);

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -393,7 +393,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
-    __limitChanged(limit) {
+    __limitChanged() {
       if (this.items) {
         this.__debounceRender(this.__render);
       }

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -108,6 +108,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <h4>x-repeat-chunkLimit</h4>
+  <x-repeat-limit id="chunkLimited"></x-repeat-limit>
+
   <h4>x-repeat-limit</h4>
   <x-repeat-limit id="limited"></x-repeat-limit>
 
@@ -3550,6 +3553,294 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
 
+    suite('chunkLimit', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(parseInt(stamped[i].textContent), i);
+        }
+      };
+
+      test('initial chunkLimit', function() {
+        chunkLimited.items = chunkLimited.preppedItems;
+        chunkLimited.$.repeater.__chunkLimit = 2;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('change item paths in & out of chunkLimit', function() {
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        chunkLimited.outerProp = {prop: 'changed'};
+        assert.equal(stamped[0].prop, 'changed');
+        chunkLimited.set('items.0.prop', '0-changed');
+        chunkLimited.set('items.3.prop', '3-changed');
+        assert.equal(stamped[0].textContent, '0-changed');
+        chunkLimited.set('outerProp.prop', 'changed again');
+        assert.equal(stamped[0].prop, 'changed again');
+      });
+
+      test('increase chunkLimit', function() {
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 10;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+        assert.equal(stamped[3].prop, 'changed again');
+        assert.equal(stamped[3].textContent, '3-changed');
+        chunkLimited.set('items.0.prop', 0);
+        chunkLimited.set('items.3.prop', 3);
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 20;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit above items.length', function() {
+        chunkLimited.$.repeater.__chunkLimit = 30;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
+      });
+
+      test('decrease chunkLimit', function() {
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 15;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 15);
+        checkItemOrder(stamped);
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 0;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+      test('negative chunkLimit', function() {
+        chunkLimited.$.repeater.__chunkLimit = -10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('chunkLimit with sort', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, 19 - i);
+        }
+      };
+
+      test('initial chunkLimit', function() {
+        chunkLimited.$.repeater.__chunkLimit = 2;
+        chunkLimited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        chunkLimited.items = null;
+        chunkLimited.$.repeater.render();
+        chunkLimited.items = chunkLimited.preppedItems;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase chunkLimit', function() {
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 10;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 20;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit above items.length', function() {
+        chunkLimited.$.repeater.__chunkLimit = 30;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 20);
+        checkItemOrder(stamped);
+      });
+
+      test('decrease chunkLimit', function() {
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 15;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 15);
+        checkItemOrder(stamped);
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 0;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+      test('negative chunkLimit', function() {
+        chunkLimited.$.repeater.__chunkLimit = -10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('chunkLimit with filter', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, i * 2);
+        }
+      };
+
+      test('initial chunkLimit', function() {
+        var items = chunkLimited.items;
+        chunkLimited.$.repeater.__chunkLimit = 2;
+        chunkLimited.$.repeater.sort = null;
+        chunkLimited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        chunkLimited.items = null;
+        chunkLimited.$.repeater.render();
+        chunkLimited.items = items;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase chunkLimit', function() {
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 5;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit above items.length', function() {
+        chunkLimited.$.repeater.__chunkLimit = 30;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+          checkItemOrder(stamped);
+      });
+
+      test('decrease chunkLimit', function() {
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 5;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 0;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+      test('negative chunkLimit', function() {
+        chunkLimited.$.repeater.__chunkLimit = -10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
+    suite('chunkLimit with sort & filter', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i=0; i<stamped.length; i++) {
+          assert.equal(stamped[i].textContent, (9 - i) * 2);
+        }
+      };
+
+      test('initial chunkLimit', function() {
+        var items = chunkLimited.items;
+        chunkLimited.$.repeater.__chunkLimit = 2;
+        chunkLimited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        chunkLimited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        chunkLimited.items = null;
+        chunkLimited.$.repeater.render();
+        chunkLimited.items = items;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 2);
+        checkItemOrder(stamped);
+      });
+
+      test('increase chunkLimit', function() {
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 5;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Increase limit
+        chunkLimited.$.repeater.__chunkLimit = 10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+      });
+
+      test('increase limit above items.length', function() {
+        chunkLimited.$.repeater.__chunkLimit = 30;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 10);
+        checkItemOrder(stamped);
+      });
+
+      test('decrease chunkLimit', function() {
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 5;
+        chunkLimited.$.repeater.render();
+        var stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 5);
+        checkItemOrder(stamped);
+        // Decrease limit
+        chunkLimited.$.repeater.__chunkLimit = 0;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+      test('negative chunkLimit', function() {
+        chunkLimited.$.repeater.__chunkLimit = -10;
+        chunkLimited.$.repeater.render();
+        stamped = chunkLimited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 0);
+      });
+
+    });
+
     suite('limit', function() {
 
       var checkItemOrder = function(stamped) {
@@ -3560,7 +3851,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('initial limit', function() {
         limited.items = limited.preppedItems;
-        limited.$.repeater.__limit = 2;
+        limited.$.repeater.limit = 2;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 2);
@@ -3580,7 +3871,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('increase limit', function() {
         // Increase limit
-        limited.$.repeater.__limit = 10;
+        limited.$.repeater.limit = 10;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
@@ -3590,7 +3881,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         limited.set('items.0.prop', 0);
         limited.set('items.3.prop', 3);
         // Increase limit
-        limited.$.repeater.__limit = 20;
+        limited.$.repeater.limit = 20;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 20);
@@ -3598,7 +3889,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.__limit = 30;
+        limited.$.repeater.limit = 30;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 20);
@@ -3607,23 +3898,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('decrease limit', function() {
         // Decrease limit
-        limited.$.repeater.__limit = 15;
+        limited.$.repeater.limit = 15;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 15);
         checkItemOrder(stamped);
         // Decrease limit
-        limited.$.repeater.__limit = 0;
+        limited.$.repeater.limit = 1;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 1);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.__limit = -10;
+        limited.$.repeater.limit = -10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 20);
       });
 
     });
@@ -3637,7 +3928,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
 
       test('initial limit', function() {
-        limited.$.repeater.__limit = 2;
+        limited.$.repeater.limit = 2;
         limited.$.repeater.sort = function(a, b) {
           return b.prop - a.prop;
         };
@@ -3652,13 +3943,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('increase limit', function() {
         // Increase limit
-        limited.$.repeater.__limit = 10;
+        limited.$.repeater.limit = 10;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
         checkItemOrder(stamped);
         // Increase limit
-        limited.$.repeater.__limit = 20;
+        limited.$.repeater.limit = 20;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 20);
@@ -3666,7 +3957,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.__limit = 30;
+        limited.$.repeater.limit = 30;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 20);
@@ -3675,23 +3966,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('decrease limit', function() {
         // Decrease limit
-        limited.$.repeater.__limit = 15;
+        limited.$.repeater.limit = 15;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 15);
         checkItemOrder(stamped);
         // Decrease limit
-        limited.$.repeater.__limit = 0;
+        limited.$.repeater.limit = 1;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 1);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.__limit = -10;
+        limited.$.repeater.limit = -10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 20);
       });
 
     });
@@ -3706,7 +3997,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('initial limit', function() {
         var items = limited.items;
-        limited.$.repeater.__limit = 2;
+        limited.$.repeater.limit = 2;
         limited.$.repeater.sort = null;
         limited.$.repeater.filter = function(a) {
           return (a.prop % 2) === 0;
@@ -3722,13 +4013,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('increase limit', function() {
         // Increase limit
-        limited.$.repeater.__limit = 5;
+        limited.$.repeater.limit = 5;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 5);
         checkItemOrder(stamped);
         // Increase limit
-        limited.$.repeater.__limit = 10;
+        limited.$.repeater.limit = 10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
@@ -3736,7 +4027,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.__limit = 30;
+        limited.$.repeater.limit = 30;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
@@ -3745,23 +4036,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('decrease limit', function() {
         // Decrease limit
-        limited.$.repeater.__limit = 5;
+        limited.$.repeater.limit = 5;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 5);
         checkItemOrder(stamped);
         // Decrease limit
-        limited.$.repeater.__limit = 0;
+        limited.$.repeater.limit = 1;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 1);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.__limit = -10;
+        limited.$.repeater.limit = -10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 10);
       });
 
     });
@@ -3776,7 +4067,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('initial limit', function() {
         var items = limited.items;
-        limited.$.repeater.__limit = 2;
+        limited.$.repeater.limit = 2;
         limited.$.repeater.sort = function(a, b) {
           return b.prop - a.prop;
         };
@@ -3794,13 +4085,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('increase limit', function() {
         // Increase limit
-        limited.$.repeater.__limit = 5;
+        limited.$.repeater.limit = 5;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 5);
         checkItemOrder(stamped);
         // Increase limit
-        limited.$.repeater.__limit = 10;
+        limited.$.repeater.limit = 10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
@@ -3808,7 +4099,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('increase limit above items.length', function() {
-        limited.$.repeater.__limit = 30;
+        limited.$.repeater.limit = 30;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 10);
@@ -3817,23 +4108,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('decrease limit', function() {
         // Decrease limit
-        limited.$.repeater.__limit = 5;
+        limited.$.repeater.limit = 5;
         limited.$.repeater.render();
         var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 5);
         checkItemOrder(stamped);
         // Decrease limit
-        limited.$.repeater.__limit = 0;
+        limited.$.repeater.limit = 1;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 1);
       });
 
       test('negative limit', function() {
-        limited.$.repeater.__limit = -10;
+        limited.$.repeater.limit = -10;
         limited.$.repeater.render();
         stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        assert.equal(stamped.length, 0);
+        assert.equal(stamped.length, 10);
       });
 
     });

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -4129,6 +4129,72 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
+    suite('limit and chunkLimit', function() {
+
+      test('limit greater than chunk', function() {
+        limited.$.repeater.limit = 5;
+        limited.$.repeater.__chunkLimit = 3;
+        limited.$.repeater.render();
+        var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 3);
+      });
+
+      test('chunk greater than limit', function() {
+        limited.$.repeater.limit = 3;
+        limited.$.repeater.__chunkLimit = 5;
+        limited.$.repeater.render();
+        var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 3);
+      });
+    });
+
+    suite('limit and chunkLimit with sort & filter', function() {
+
+      var checkItemOrder = function(stamped) {
+        for (var i = 0; i < stamped.length; i++) {
+          assert.equal(stamped[i].textContent, (9 - i) * 2);
+        }
+      };
+
+      test('limit greater than chunk', function() {
+        var items = limited.items;
+        limited.$.repeater.limit = 5;
+        limited.$.repeater.__chunkLimit = 3;
+        limited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        limited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        limited.items = null;
+        limited.$.repeater.render();
+        limited.items = items;
+        limited.$.repeater.render();
+        var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 3);
+        checkItemOrder(stamped);
+      });
+
+      test('chunk greater than limit', function() {
+        var items = limited.items;
+        limited.$.repeater.limit = 3;
+        limited.$.repeater.__chunkLimit = 5;
+        limited.$.repeater.sort = function(a, b) {
+          return b.prop - a.prop;
+        };
+        limited.$.repeater.filter = function(a) {
+          return (a.prop % 2) === 0;
+        };
+        limited.items = null;
+        limited.$.repeater.render();
+        limited.items = items;
+        limited.$.repeater.render();
+        var stamped = limited.root.querySelectorAll('*:not(template):not(dom-repeat)');
+        assert.equal(stamped.length, 3);
+        checkItemOrder(stamped);
+      });
+    });
+
     // TODO(kschaaf): This test suite has proven to be flaky only on IE, only
     // on CI (Sauce) presumably because of rAF handling in the CI environment
     // disabling for IE for now to avoid Polymer tests being flaky

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -130,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
   (function() {
-  /* global limited inDocumentRepeater inDocumentContainer inDocumentContainerOrig stamped:true chunked nonUpgrade*/
+  /* global limited chunkLimited inDocumentRepeater inDocumentContainer inDocumentContainerOrig stamped:true chunked nonUpgrade*/
 
     /*
       Expected:


### PR DESCRIPTION
 - refactor __limit to __chunkLimit
 - add limit property and observer
 - constrain instance generation by __chunkLimit AND limit
 - clone limit tests to ensure chunk and limit both work independently

### Reference Issue
Fixes #4720 