### PR TITLE
Fix event path for tap event on touch

### DIFF
--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -919,7 +919,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     forward: function(e, preventer) {
       let dx = Math.abs(e.clientX - this.info.x);
       let dy = Math.abs(e.clientY - this.info.y);
-      let t = Gestures._findOriginalTarget(e);
+      // find original target from `preventer` for TouchEvents, or `e` for MouseEvents
+      let t = Gestures._findOriginalTarget(preventer || e);
       // dx,dy can be NaN if `click` has been simulated and there was no `down` for `start`
       if (isNaN(dx) || isNaN(dy) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE) || isSyntheticClick(e)) {
         // prevent taps from being generated if an event has canceled them

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -913,14 +913,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
     /**
      * @this {GestureRecognizer}
-     * @param {Event} e
-     * @param {Function} preventer
+     * @param {Event | Touch} e
+     * @param {Event=} preventer
      */
     forward: function(e, preventer) {
       let dx = Math.abs(e.clientX - this.info.x);
       let dy = Math.abs(e.clientY - this.info.y);
       // find original target from `preventer` for TouchEvents, or `e` for MouseEvents
-      let t = Gestures._findOriginalTarget(preventer || e);
+      let t = Gestures._findOriginalTarget(/** @type {Event} */(preventer || e));
       // dx,dy can be NaN if `click` has been simulated and there was no `down` for `start`
       if (isNaN(dx) || isNaN(dy) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE) || isSyntheticClick(e)) {
         // prevent taps from being generated if an event has canceled them

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -35,6 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       teardown(function() {
         document.body.removeChild(app);
+        Polymer.Gestures.resetMouseCanceller();
       });
 
       test('tap on x-foo and check localTarget and rootTarget', function() {
@@ -42,6 +43,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         foo.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
         assert.equal(app._testLocalTarget, app, 'local target');
         assert.equal(app._testRootTarget, foo, 'root target');
+        let touches = [{
+          clientX: 0,
+          clientY: 0,
+          identifier: 1,
+          // target is set to the element with `addEventListener`, which is app
+          target: app
+        }];
+        let touchstart = new CustomEvent('touchstart', {bubbles: true, composed: true});
+        touchstart.changedTouches = touchstart.touches = touches;
+        foo.dispatchEvent(touchstart);
+        let touchend = new CustomEvent('touchend', {bubbles: true, composed: true});
+        touchend.touches = touchend.changedTouches = touches;
+        foo.dispatchEvent(touchend);
+        assert.equal(app._testLocalTarget, app, 'local target touch');
+        assert.equal(app._testRootTarget, foo, 'root target touch');
       });
 
       test('tap on x-foo.div and check target info', function() {
@@ -52,6 +68,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(app._testRootTarget, div, 'app root target');
         assert.equal(foo._testLocalTarget, foo, 'foo local target');
         assert.equal(foo._testRootTarget, div, 'foo root target');
+        let touches = [{
+          clientX: 0,
+          clientY: 0,
+          identifier: 1,
+          // target is set to the element with `addEventListener`, which is app
+          target: app
+        }]
+        let touchstart = new CustomEvent('touchstart', {bubbles: true, composed: true});
+        touchstart.touches = touchstart.changedTouches = touches;
+        let touchend = new CustomEvent('touchend', {composed: true, bubbles: true});
+        touchend.touches = touchend.changedTouches = touches;
+        div.dispatchEvent(touchstart);
+        div.dispatchEvent(touchend);
+        assert.equal(app._testLocalTarget, app, 'app local target touch');
+        assert.equal(app._testRootTarget, div, 'app root target touch');
+        assert.equal(foo._testLocalTarget, foo, 'foo local target touch');
+        assert.equal(foo._testRootTarget, div, 'foo root target touch');
       });
 
       test('HTMLElement.click triggers tap', function() {
@@ -268,7 +301,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               clientX: clientX,
               clientY: clientY,
               identifier: 1,
-              target: child
+              // target is set to the element with `addEventListener`, which is el
+              target: el
             }
           ];
           ev.clientX = clientX;
@@ -283,7 +317,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 clientX: clientX,
                 clientY: clientY,
                 identifier: 1,
-                target: child
+                // target is set to the element with `addEventListener`, which is el
+                target: el
               }
             ];
             ev.clientX = clientX;


### PR DESCRIPTION
Always use findOriginalTarget with a real event!

Fixes #4670