### PR TITLE
[ci skip] Fix documentation in PropertyAccessors

### DIFF
--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -79,8 +79,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * the standard `static get observedAttributes()`, implement `_propertiesChanged`
    * on the class, and then call `MyClass.createPropertiesForAttributes()` once
    * on the class to generate property accessors for each observed attribute
-   * prior to instancing.  Last, call `this._flushProperties()` once to enable
-   * the accessors.
+   * prior to instancing. Last, call `this._enableProperties()` in the element's
+   * `connectedCallback` to enable the accessors.
    *
    * Any `observedAttributes` will automatically be
    * deserialized via `attributeChangedCallback` and set to the associated


### PR DESCRIPTION
Function to enable accessors is `_enableProperties`, and should be
called in the `connectedCallback`