### PR TITLE
Support Polymer 2.x shared styles

### DIFF
--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -292,6 +292,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       normalizeRootSelector: function(rule) {
         rule.selector = rule.selector.replace(ROOT, 'html');
+        // handle 2.x rules like `:host, html {}`
+        var parts = rule.selector.split(COMPLEX_SELECTOR_SEP);
+        parts = parts.filter(function(part) {
+          return part.trim() !== HOST;
+        });
+        rule.selector = parts.join(COMPLEX_SELECTOR_SEP);
       },
 
       _transformDocumentSelector: function(selector) {

--- a/src/lib/style-transformer.html
+++ b/src/lib/style-transformer.html
@@ -295,7 +295,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // handle 2.x rules like `:host, html {}`
         var parts = rule.selector.split(COMPLEX_SELECTOR_SEP);
         parts = parts.filter(function(part) {
-          return part.trim() !== HOST;
+          return !part.match(HOST_OR_HOST_GT_STAR);
         });
         rule.selector = parts.join(COMPLEX_SELECTOR_SEP);
       },
@@ -339,6 +339,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var CONTENT_START = new RegExp('^(' + CONTENT + ')');
     var SELECTOR_NO_MATCH = 'should_not_match';
     var SLOTTED_PAREN = /(?:::slotted)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
+    var HOST_OR_HOST_GT_STAR = /:host(?:\s*>\s*\*)?/;
 
     // exports
     return api;

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -143,7 +143,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
   <style is="custom-style">
     :host, html {
-      --polymer-2-root: 10px solid rgb(123, 123, 123);
+      --polymer-2-shared-host: 10px solid rgb(123, 123, 123);
+    }
+    :host > *, html {
+      --polymer-2-shared-host-gt-star: 5px dotted orange;
     }
   </style>
 </head>
@@ -325,9 +328,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <style>
         :host {
-          border: var(--polymer-2-root);
+          border: var(--polymer-2-shared-host);
+        }
+        #foo {
+          border: var(--polymer-2-shared-host-gt-star);
         }
       </style>
+      <div id="foo"></div>
     </template>
   </dom-module>
 
@@ -409,6 +416,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('polymer 2 shared styles applied', function() {
         var polymer2 = document.querySelector('polymer-2-root');
         assertComputed(polymer2, '10px');
+        assertComputed(polymer2.$.foo, '5px');
       })
 
       test('custom properties registered as defaults', function() {

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -141,6 +141,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     --html-foo: 10px dotted green;
   }
   </style>
+  <style is="custom-style">
+    :host, html {
+      --polymer-2-root: 10px solid rgb(123, 123, 123);
+    }
+  </style>
 </head>
 <body>
   <div class="italic">italic</div>
@@ -161,6 +166,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <x-blue-bold-text></x-blue-bold-text>
 
   <parent-variable-with-var></parent-variable-with-var>
+
+  <polymer-2-root></polymer-2-root>
 
   <br><br>
   <div id="after"></div>
@@ -314,6 +321,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </dom-module>
 
+  <dom-module id="polymer-2-root">
+    <template>
+      <style>
+        :host {
+          border: var(--polymer-2-root);
+        }
+      </style>
+    </template>
+  </dom-module>
+
   <script>
   HTMLImports.whenReady(function() {
     Polymer({
@@ -338,6 +355,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
       is: 'x-top-selectors'
     });
+    Polymer({
+      is: 'polymer-2-root'
+    })
   })
   </script>
 
@@ -385,6 +405,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertComputed(xFoo.$.bar3, '4px');
         assertComputed(xFoo.$.bar3.$.baz, '5px');
       });
+
+      test('polymer 2 shared styles applied', function() {
+        var polymer2 = document.querySelector('polymer-2-root');
+        assertComputed(polymer2, '10px');
+      })
 
       test('custom properties registered as defaults', function() {
         var propsToCheck = ['--italic'];


### PR DESCRIPTION
Add support for `:host, html` selectors in custom styles

Fixes #4742