### PR TITLE
Do not assign to a readonly property on window

### DIFF
--- a/test/unit/shady-content.html
+++ b/test/unit/shady-content.html
@@ -12,7 +12,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script>
-    window.customElements = window.customElements || {};
+    if (!window.customElements) {
+      window.customElements = {};
+    }
     customElements.forcePolyfill = true;
     window.ShadyDOM = {
       force: true

--- a/test/unit/shady-dynamic.html
+++ b/test/unit/shady-dynamic.html
@@ -12,7 +12,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script>
-    window.customElements = window.customElements || {};
+    if (!window.customElements) {
+      window.customElements = {};
+    }
     customElements.forcePolyfill = true;
     window.ShadyDOM = {
       force: true

--- a/test/unit/shady-events.html
+++ b/test/unit/shady-events.html
@@ -11,7 +11,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 <script>
-  window.customElements = window.customElements || {};
+  if (!window.customElements) {
+    window.customElements = {};
+  }
   customElements.forcePolyfill = true;
   window.ShadyDOM = {
     force: true


### PR DESCRIPTION
If `window.customElements` exists there's a good chance that it's a readonly property as per spec, and assigning to readonly properties throws an exception in strict mode.
