### PR TITLE
Remove reference to Polymer._toOverride, it seems like an incomplete feature/part of the test.

### DIFF
--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -82,9 +82,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__change = e.detail.value;
       },
 
-      _toOverride: function() {
-      },
-
       _computeProp: function(a) {
         return a;
       }
@@ -137,8 +134,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ready: function() {
         this.__readyB = true;
       },
-
-      _toOverride: function() {}
     };
 
     Polymer.BehaviorC = {
@@ -210,8 +205,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _fooChanged: function(foo) {
         this.__foo = foo;
       },
-
-     _toOverride: Polymer._toOverride
     });
 
     Polymer({
@@ -449,7 +442,6 @@ suite('multi-behaviors element', function() {
   });
 
   test('multi-behavior overrides ordering', function() {
-    assert.equal(el._toOverride, Polymer._toOverride, 'Behavior method was not overridden by prototype');
     assert(el.overridableProperty, 'Behavior property was not overridden by prototype');
     assert(el.overridablePropertyB, 'Behavior config-property was not overridden by sub-behavior');
   });

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -111,9 +111,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__change = e.detail.value;
       },
 
-      _toOverride: function() {
-      },
-
       _computeProp: function(a) {
         return a;
       }
@@ -167,7 +164,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__readyB = true;
       },
 
-      _toOverride: function() {}
     };
 
     Polymer.BehaviorC = {
@@ -241,7 +237,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           constructor() {
             super();
-            this._toOverride = Polymer._toOverride;
           }
 
           _fooChanged(foo) {
@@ -511,7 +506,6 @@ suite('multi-behaviors element', function() {
   });
 
   test('multi-behavior overrides ordering', function() {
-    assert.equal(el._toOverride, Polymer._toOverride, 'Behavior method was not overridden by prototype');
     assert(el.overridableProperty, 'Behavior property was not overridden by prototype');
     assert(el.overridablePropertyB, 'Behavior config-property was not overridden by sub-behavior');
   });


### PR DESCRIPTION
It is not referenced anywhere else, and does not seem to serve a purpose within the test. It's never assigned to, so it is always just `undefined`.