### PR TITLE
Fix formatting.

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -2093,15 +2093,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * roughly corresponds to a phase in effect processing.  The effect
        * metadata should be in the following form:
        *
-       *   {
-       *     fn: effectFunction, // Reference to function to call to perform effect
-       *     info: { ... }       // Effect metadata passed to function
-       *     trigger: {          // Optional triggering metadata; if not provided
-       *       name: string      // the property is treated as a wildcard
-       *       structured: boolean
-       *       wildcard: boolean
+       *     {
+       *       fn: effectFunction, // Reference to function to call to perform effect
+       *       info: { ... }       // Effect metadata passed to function
+       *       trigger: {          // Optional triggering metadata; if not provided
+       *         name: string      // the property is treated as a wildcard
+       *         structured: boolean
+       *         wildcard: boolean
+       *       }
        *     }
-       *   }
        *
        * Effects are called from `_propertiesChanged` in the following order by
        * type:
@@ -2114,7 +2114,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * Effect functions are called with the following signature:
        *
-       *   effectFunction(inst, path, props, oldProps, info, hasPaths)
+       *     effectFunction(inst, path, props, oldProps, info, hasPaths)
        *
        * @param {string} property Property that should trigger the effect
        * @param {string} type Effect type, from this.PROPERTY_EFFECT_TYPES


### PR DESCRIPTION
Fixes doc formatting for addPropertyEffect. Fixes https://github.com/Polymer/docs/issues/2284.

Testing: set up your polymer repo for checking the docs locally:

```
bower install
bower install polymerelements/iron-component-page # don't ask me why this isn't installed by default
polymer analyze polymer-element.html > analysis.json
polymer serve
```

Browse  to localhost:<whatever>/components/polymer/ to see the docs.
