### PR TITLE
Update closure annotation to support arrays for Polymer.prototype.push

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -580,7 +580,7 @@ Polymer_PropertyEffects.prototype.get = function(path, root){};
 */
 Polymer_PropertyEffects.prototype.set = function(path, value, root){};
 /**
-* @param {string} path Path to array.
+* @param {string | !Array<string|number>} path Path to array.
 * @param {...*} items 
 * @return {number}
 */

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1809,7 +1809,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * This method notifies other paths to the same array that a
        * splice occurred to the array.
        *
-       * @param {string} path Path to array.
+       * @param {string | !Array<string|number>} path Path to array.
        * @param {...*} items Items to push onto array
        * @return {number} New length of the array.
        * @public


### PR DESCRIPTION
Update closure annotation to support arrays for Polymer.prototype.push

Polymer.Prototype.push accepts a path as an argument that is then called by Polymer.Path.get. 

https://github.com/Polymer/polymer/blob/0b23e746bf2232732a322b7614fd0dcf3a8b2a73/lib/utils/path.html#L203

Polymer.Path.Get accepts a string or an Array for Path, so Polymer.Prototype.push should too. It works already, but the closure compilation fails.
