### PR TITLE
Fix compiling with Polymer({}) calls

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -798,6 +798,24 @@ Polymer_PropertyEffects._evaluateBinding = function(inst, part, path, props, old
 * @extends {Polymer_PropertyEffects}
 */
 function Polymer_ElementMixin(){}
+/** @type {HTMLTemplateElement} */
+Polymer_ElementMixin.prototype._template;
+
+/** @type {string} */
+Polymer_ElementMixin.prototype._importPath;
+
+/** @type {string} */
+Polymer_ElementMixin.prototype.rootPath;
+
+/** @type {string} */
+Polymer_ElementMixin.prototype.importPath;
+
+/** @type {(StampedTemplate|HTMLElement|ShadowRoot)} */
+Polymer_ElementMixin.prototype.root;
+
+/** @type {!Object.<string, !Node>} */
+Polymer_ElementMixin.prototype.$;
+
 /**
 * @override
 * @param {!HTMLTemplateElement} template Template to stamp
@@ -1163,8 +1181,8 @@ Polymer_ElementMixin.prototype.connectedCallback = function(){};
 */
 Polymer_ElementMixin.prototype.disconnectedCallback = function(){};
 /**
-* @param {NodeList} dom to attach to the element.
-* @return {Node}
+* @param {StampedTemplate} dom to attach to the element.
+* @return {ShadowRoot}
 */
 Polymer_ElementMixin.prototype._attachDom = function(dom){};
 /**
@@ -1331,6 +1349,15 @@ Polymer_GestureEventListeners.prototype._removeEventListenerFromNode = function(
 * @extends {Polymer_GestureEventListeners}
 */
 function Polymer_LegacyElementMixin(){}
+/** @type {boolean} */
+Polymer_LegacyElementMixin.prototype.isAttached;
+
+/** @type {WeakMap.<!Element, !Object.<string, !Function>>} */
+Polymer_LegacyElementMixin.prototype.__boundListeners;
+
+/** @type {Object.<string, Function>} */
+Polymer_LegacyElementMixin.prototype._debouncers;
+
 /**
 * @override
 * @param {!HTMLTemplateElement} template Template to stamp
@@ -1696,8 +1723,8 @@ Polymer_LegacyElementMixin.prototype.connectedCallback = function(){};
 */
 Polymer_LegacyElementMixin.prototype.disconnectedCallback = function(){};
 /**
-* @param {NodeList} dom to attach to the element.
-* @return {Node}
+* @param {StampedTemplate} dom to attach to the element.
+* @return {ShadowRoot}
 */
 Polymer_LegacyElementMixin.prototype._attachDom = function(dom){};
 /**
@@ -2545,8 +2572,8 @@ Polymer_ArraySelectorMixin.prototype.connectedCallback = function(){};
 */
 Polymer_ArraySelectorMixin.prototype.disconnectedCallback = function(){};
 /**
-* @param {NodeList} dom to attach to the element.
-* @return {Node}
+* @param {StampedTemplate} dom to attach to the element.
+* @return {ShadowRoot}
 */
 Polymer_ArraySelectorMixin.prototype._attachDom = function(dom){};
 /**

--- a/externs/polymer-externs.js
+++ b/externs/polymer-externs.js
@@ -50,7 +50,7 @@ PolymerElementConstructor.template;
 
 /**
  * @param {!PolymerInit} init
- * @return {!HTMLElement}
+ * @return {!function(new:HTMLElement)}
  */
 function Polymer(init){}
 
@@ -84,3 +84,10 @@ PolymerTelemetry.dumpRegistrations;;
 
 /** @type {PolymerTelemetry} */
 Polymer.telemetry;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @implements {Polymer_LegacyElementMixin}
+ */
+var PolymerElement = Polymer.LegacyElementMixin();

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -72,6 +72,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       constructor() {
         super();
         this.root = this;
+        /** @type {boolean} */
+        this.isAttached;
+        /** @type {WeakMap<!Element, !Object<string, !Function>>} */
+        this.__boundListeners;
+        /** @type {Object<string, Function>} */
+        this._debouncers;
         this.created();
       }
 
@@ -376,7 +382,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} methodName Name of handler method on `this` to call.
        */
       listen(node, eventName, methodName) {
-        node = /** @type {Element} */ (node || this);
+        node = /** @type {!Element} */ (node || this);
         let hbl = this.__boundListeners ||
           (this.__boundListeners = new WeakMap());
         let bl = hbl.get(node);
@@ -401,7 +407,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        anymore.
        */
       unlisten(node, eventName, methodName) {
-        node = /** @type {Element} */ (node || this);
+        node = /** @type {!Element} */ (node || this);
         let bl = this.__boundListeners && this.__boundListeners.get(node);
         let key = eventName + methodName;
         let handler = bl && bl[key];

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -544,6 +544,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this._importPath;
       }
 
+      constructor() {
+        super();
+        /** @type {HTMLTemplateElement} */
+        this._template;
+        /** @type {string} */
+        this._importPath;
+        /** @type {string} */
+        this.rootPath;
+        /** @type {string} */
+        this.importPath;
+        /** @type {StampedTemplate | HTMLElement | ShadowRoot} */
+        this.root;
+        /** @type {!Object<string, !Node>} */
+        this.$;
+      }
+
       /**
        * Overrides the default `Polymer.PropertyAccessors` to ensure class
        * metaprogramming related to property accessors and effects has
@@ -644,7 +660,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _readyClients() {
         if (this._template) {
-          this.root = this._attachDom(this.root);
+          this.root = this._attachDom(/** @type {StampedTemplate} */(this.root));
         }
         // The super._readyClients here sets the clients initialized flag.
         // We must wait to do this until after client dom is created/attached
@@ -662,8 +678,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @throws {Error}
        * @suppress {missingReturn}
-       * @param {NodeList} dom to attach to the element.
-       * @return {Node} node to which the dom has been attached.
+       * @param {StampedTemplate} dom to attach to the element.
+       * @return {ShadowRoot} node to which the dom has been attached.
        */
       _attachDom(dom) {
         if (this.attachShadow) {

--- a/lib/utils/style-gather.html
+++ b/lib/utils/style-gather.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   const INCLUDE_ATTR = 'include';
 
   function importModule(moduleId) {
-    const PolymerDomModule = customElements.get('dom-module');
+    const /** Polymer.DomModule */ PolymerDomModule = customElements.get('dom-module');
     if (!PolymerDomModule) {
       return null;
     }


### PR DESCRIPTION
Add types for instance properties of ElementMixin and LegacyElementMixin