### PR TITLE
App-level support for passive gesture touch listeners

### DIFF
--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -40,22 +40,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   })();
 
+  /**
+   * @param {string} name Possible mouse event name
+   * @return {boolean} true if mouse event, false if not
+   */
+  function isMouseEvent(name) {
+    return MOUSE_EVENTS.indexOf(name) > -1;
+  }
+
   /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
   // check for passive event listeners
   let SUPPORTS_PASSIVE = false;
   (function() {
     try {
-      let opts = Object.defineProperty({}, 'passive', {get: function() {SUPPORTS_PASSIVE = true;}});
+      let opts = Object.defineProperty({}, 'passive', {get() {SUPPORTS_PASSIVE = true;}});
       window.addEventListener('test', null, opts);
       window.removeEventListener('test', null, opts);
     } catch(e) {}
   })();
 
+  // decide whether to use {passive: true} for gestures listening for touch events
+  let PASSIVE_TOUCH = Boolean(HAS_NATIVE_TA && SUPPORTS_PASSIVE && Polymer.passiveTouchGestures);
+
   // Check for touch-only devices
   let IS_TOUCH_ONLY = navigator.userAgent.match(/iP(?:[oa]d|hone)|Android/);
 
   let GestureRecognizer = function(){}; // eslint-disable-line no-unused-vars
-  GestureRecognizer.prototype.reset = function(){};
+  /** @type {function()} */
+  GestureRecognizer.prototype.reset;
   /** @type {function(MouseEvent) | undefined} */
   GestureRecognizer.prototype.mousedown;
   /** @type {(function(MouseEvent) | undefined)} */
@@ -140,7 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function hasLeftMouseButton(ev) {
     let type = ev.type;
     // exit early if the event is not a mouse event
-    if (MOUSE_EVENTS.indexOf(type) === -1) {
+    if (!isMouseEvent(type)) {
       return false;
     }
     // ev.button is not reliable for mousemove (0 is overloaded as both left button and no buttons)
@@ -450,7 +462,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       for (let i = 0, dep, gd; i < deps.length; i++) {
         dep = deps[i];
         // don't add mouse handlers on iOS because they cause gray selection overlays
-        if (IS_TOUCH_ONLY && MOUSE_EVENTS.indexOf(dep) > -1 && dep !== 'click') {
+        if (IS_TOUCH_ONLY && isMouseEvent(dep) && dep !== 'click') {
           continue;
         }
         gd = gobj[dep];
@@ -458,7 +470,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          node.addEventListener(dep, this._handleNative);
+          let options = !isMouseEvent(dep) && PASSIVE_TOUCH ? {passive: true} : undefined;
+          node.addEventListener(dep, this._handleNative, options);
         }
         gd[name] = (gd[name] || 0) + 1;
         gd._count = (gd._count || 0) + 1;
@@ -491,7 +504,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              node.removeEventListener(dep, this._handleNative);
+              let options = !isMouseEvent(dep) && PASSIVE_TOUCH ? {passive: true} : undefined;
+              node.removeEventListener(dep, this._handleNative, options);
             }
           }
         }

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -59,8 +59,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     } catch(e) {}
   })();
 
-  // decide whether to use {passive: true} for gestures listening for touch events
-  let PASSIVE_TOUCH = Boolean(HAS_NATIVE_TA && SUPPORTS_PASSIVE && Polymer.passiveTouchGestures);
+  /**
+   * Generate settings for event listeners, dependant on `Polymer.passiveTouchGestures`
+   *
+   * @return {{passive: boolean} | undefined} Options to use for addEventListener and removeEventListener
+   */
+  function PASSIVE_TOUCH() {
+    if (HAS_NATIVE_TA && SUPPORTS_PASSIVE && Polymer.passiveTouchGestures) {
+      return {passive: true};
+    } else {
+      return;
+    }
+  }
 
   // Check for touch-only devices
   let IS_TOUCH_ONLY = navigator.userAgent.match(/iP(?:[oa]d|hone)|Android/);
@@ -470,7 +480,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          let options = !isMouseEvent(dep) && PASSIVE_TOUCH ? {passive: true} : undefined;
+          let options = !isMouseEvent(dep) && PASSIVE_TOUCH();
           node.addEventListener(dep, this._handleNative, options);
         }
         gd[name] = (gd[name] || 0) + 1;
@@ -504,7 +514,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              let options = !isMouseEvent(dep) && PASSIVE_TOUCH ? {passive: true} : undefined;
+              let options = !isMouseEvent(dep) && PASSIVE_TOUCH();
               node.removeEventListener(dep, this._handleNative, options);
             }
           }

--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -93,5 +93,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.setSanitizeDOMValue = function(newSanitizeDOMValue) {
     Polymer.sanitizeDOMValue = newSanitizeDOMValue;
   };
+
+  /**
+   * Globally settable property to make Polymer Gestures use passive TouchEvent listeners when recognizing gestures.
+   * When set to `true`, gestures made from touch will not be able to prevent scrolling, allowing for smoother
+   * scrolling performance.
+   * Defaults to `false` for backwards compatibility.
+   *
+   * @memberof Polymer
+   */
+  Polymer.passiveTouchGestures = false;
 })();
 </script>

--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -102,6 +102,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @memberof Polymer
    */
-  Polymer.passiveTouchGestures = false;
+  Polymer.passiveTouchGestures = Polymer.passiveTouchGestures || false;
 })();
 </script>

--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -102,6 +102,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @memberof Polymer
    */
-  Polymer.passiveTouchGestures = Polymer.passiveTouchGestures || false;
+  let passiveTouchGestures = false;
+
+  Polymer.passiveTouchGestures = passiveTouchGestures;
+
+  /**
+   * Sets `passiveTouchGestures` globally for all elements using Polymer Gestures.
+   *
+   * @memberof Polymer
+   * @param {boolean} usePassive enable or disable passive touch gestures globally
+   */
+  Polymer.setPassiveTouchGestures = function(usePassive) {
+    Polymer.passiveTouchGestures = usePassive;
+  };
 })();
 </script>

--- a/test/smoke/passive-gestures.html
+++ b/test/smoke/passive-gestures.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <script src="../../../webcomponentsjs/webcomponents-loader.js"></script>
+  <script>Polymer = {passiveTouchGestures: true}</script>
+  <link rel="import" href="../../polymer.html">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+  <dom-module id="x-passive">
+    <template>
+      <style>
+        :host {
+          display: block;
+          height: 2000px;
+          background-color: -webkit-gradient(linear, left top, left bottom, from(blue), to(red));
+          background-image: -webkit-linear-gradient(top, blue, red);
+          background-image: -moz-linear-gradient(top, blue, red);
+          background-image: linear-gradient(to bottom, blue, red);
+        }
+      </style>
+    </template>
+  </dom-module>
+  <script>
+    Polymer({
+      is: 'x-passive',
+      listeners: {
+        'down': 'prevent',
+        'move': 'prevent'
+      },
+      prevent(e) {
+        e.preventDefault();
+        console.log('prevented!');
+      }
+    });
+  </script>
+  <x-passive></x-passive>
+</body>
+</html>

--- a/test/smoke/passive-gestures.html
+++ b/test/smoke/passive-gestures.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <script src="../../../webcomponentsjs/webcomponents-loader.js"></script>
-  <script>Polymer = {passiveTouchGestures: true}</script>
   <link rel="import" href="../../polymer.html">
+  <script>Polymer.setPassiveTouchGestures(true);</script>
   <style>
     html, body {
       margin: 0;


### PR DESCRIPTION
Apps can set `Polymer.passiveTouchGestures` to `true` to force all touch listeners for gestures to use passive event handlers.
This may improve scrolling performance, at the cost of being unable to control scrolling with `gestureEvent.preventDefault()`.
Instead, elements must use `Polymer.Gestures.setTouchAction(node, 'direction')`

This PR overrules #4724

Fixes #4667
Fixes #3787
Fixes #3604