### PR TITLE
Exclude script and style tags for parsing bindings

### DIFF
--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -256,6 +256,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {!NodeInfo} nodeInfo Node metadata for current template.
        */
       static _parseTemplateChildNodes(root, templateInfo, nodeInfo) {
+        if (root.localName === 'script' || root.localName === 'style') {
+          return;
+        }
         for (let node=root.firstChild, parentIndex=0, next; node; node=next) {
           // Wrap templates
           if (node.localName == 'template') {

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -68,6 +68,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         literal1 {{cpnd1}} literal2 {{cpnd2}}{{cpnd3.prop}} literal3 {{computeCompound(cpnd4, cpnd5, 'literalComputed')}} literal4
       </div>
       <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
+      <script id="scriptWithBinding">
+        function foo() {
+          return "We have a {{binding}} here";
+        }
+      </script>
+      <style id="styleWithBinding">
+        :host {
+          content: '[[binding]]'
+        }
+      </style>
   </template>
   <script>
     let ComputingBehavior = {

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -69,9 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
       <span id="boundWithDash">{{objectWithDash.binding-with-dash}}</span>
       <script id="scriptWithBinding">
+        /* eslint-disable no-unused-vars */
         function foo() {
           return "We have a {{binding}} here";
         }
+        /* eslint-enable no-unused-vars */
       </script>
       <style id="styleWithBinding">
         :host {

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -386,6 +386,14 @@ suite('single-element binding effects', function() {
     assert.equal(el.lateBoundObserver.firstCall.args[0], 'late');
   });
 
+  test('does not parse bindings inside <script>', function() {
+    assert.include(el.$.scriptWithBinding.textContent, "{{binding}}");
+  });
+
+  test('does not parse bindings inside <style>', function() {
+    assert.include(el.shadowRoot.querySelector('style').textContent, "[[binding]]");
+  });
+
 });
 
 suite('computed bindings with dynamic functions', function() {

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -391,7 +391,14 @@ suite('single-element binding effects', function() {
   });
 
   test('does not parse bindings inside <style>', function() {
-    assert.include(el.shadowRoot.querySelector('style').textContent, "[[binding]]");
+    var style = el.shadowRoot.querySelector('style');
+    // native shadow dom
+    if (style) {
+      assert.include(style.textContent, "[[binding]]");
+    // shady dom
+    } else {
+      assert.include(document.querySelector('[scope="x-basic"]').textContent, "[[binding]]");
+    }
   });
 
 });


### PR DESCRIPTION
Previously both `<script>` and `<style>` were scanned for bindings. This has unintended side-effects for functions and styles.
### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #3726
Supersedes #3872