### PR TITLE
Declare Polymer.Templatizer directly, for Closure.

### DIFF
--- a/lib/legacy/templatizer-behavior.html
+++ b/lib/legacy/templatizer-behavior.html
@@ -87,9 +87,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * between versions 1.x and 2.x.
      *
      * @polymerBehavior
-     * @memberof Polymer
      */
-    let Templatizer = {
+    Polymer.Templatizer = {
 
       /**
        * Generates an anonymous `TemplateInstance` class (stored as `this.ctor`)
@@ -146,8 +145,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return Polymer.Templatize.modelForElement(this._templatizerTemplate, el);
       }
     };
-
-    Polymer.Templatizer = Templatizer;
 
   })();
 </script>


### PR DESCRIPTION
Closure cannot follow the indirect `@polymerBehavior` annotation, so define Polymer.Templatizer directly.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
