### PR TITLE
fix(dom-api-shady): getOwnerRoot issue with window

### DIFF
--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -193,7 +193,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     getOwnerRoot: function() {
-      return this._ownerShadyRootForNode(this.node);
+      return this.node === window ? this.node : this._ownerShadyRootForNode(this.node);
     },
 
     _ownerShadyRootForNode: function(node) {
@@ -218,7 +218,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // can be cached while an element is inside a fragment.
         // If this happens and we cache the result, the value can become stale
         // because for perf we avoid processing the subtree of added fragments.
-        if (root || document.documentElement.contains(node)) {
+        if (root || (document.documentElement.contains(node)) {
           node._ownerShadyRoot = root;
         }
       }

--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -218,7 +218,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // can be cached while an element is inside a fragment.
         // If this happens and we cache the result, the value can become stale
         // because for perf we avoid processing the subtree of added fragments.
-        if (root || (document.documentElement.contains(node)) {
+        if (root || document.documentElement.contains(node)) {
           node._ownerShadyRoot = root;
         }
       }


### PR DESCRIPTION
fix _ownerShadyRootForNode process _ownerShadyRootForNode for window element!

When we use some jquery plugin we have error on `document.documentElement.contains(node)` becouse node is window!
I don't know when and why node is window but i have always this error when tap on some jquery modules! 
I will try to find the exactly what happened but bytheway `getOwnerRoot` must skip process on window

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
