### PR TITLE
Fix missing comma in `Path.translate` JSDoc

### DIFF
--- a/lib/utils/path.html
+++ b/lib/utils/path.html
@@ -115,7 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Example:
      *
      * ```
-     * Polymer.Path.translate('foo.bar', 'zot' 'foo.bar.baz') // 'zot.baz'
+     * Polymer.Path.translate('foo.bar', 'zot', 'foo.bar.baz') // 'zot.baz'
      * ```
      *
      * @memberof Polymer.Path


### PR DESCRIPTION
Check the very bottom of the page: https://www.polymer-project.org/2.0/docs/api/namespaces/Polymer.Path