### PR TITLE
Annotate DomApi with @memberof Polymer

### DIFF
--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -39,6 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Node API wrapper class returned from `Polymer.dom.(target)` when
    * `target` is a `Node`.
+   *
+   * @memberof Polymer
    */
   class DomApi {
 


### PR DESCRIPTION
This class is assigned to `Polymer.DomApi` on line 286.