### PR TITLE
fix(bower): standardized version tagging

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/Polymer/polymer.git"
   },
   "dependencies": {
-    "shadycss": "webcomponents/shadycss#^v1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^v1.0.2"
+    "shadycss": "webcomponents/shadycss#^1.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.2"
   },
   "devDependencies": {
-    "web-component-tester": "^v6.0.0",
+    "web-component-tester": "^6.0.0",
     "test-fixture": "PolymerElements/test-fixture#3.0.0-rc.1"
   },
   "private": true,


### PR DESCRIPTION
I think it's better to don't use `v` in components version

Fixes #4920
