### PR TITLE
4939 array selector batch selection

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -297,6 +297,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
+       * Deselects the given indexes if it is already selected.
+       *
+       * @param {Array<number>} indexes Indexes from `items` array to deselect
+       */
+      deselectIndexes(indexes) {
+        if (!this.multi) {
+          throw new Error('This method can be used only in multi = true mode');
+        }
+
+        if (indexes.length === 0) {
+          return;
+        }
+        if (indexes.length === 1) {
+          this.deselectIndex(indexes[0]);
+          return;
+        }
+
+        const haveToBeDeselectedIndexes =
+            indexes.filter(idx => this.isSelected(this.items[idx]));
+
+        const selectedIndexesToRemove = [];
+        for (const idx of haveToBeDeselectedIndexes) {
+          this.__selectedMap.delete(this.items[idx]);
+          selectedIndexesToRemove.push(this.__selectedIndexForItemIndex(idx));
+        }
+        this.__updateLinks();
+
+        const originalSelected =
+            Array.from(/** @type {!Array<!Object>} */(this.selected));
+        selectedIndexesToRemove.sort();
+        for (let i = selectedIndexesToRemove.length - 1; i >= 0; i--) {
+          this.selected.splice(selectedIndexesToRemove[i], 1);
+        }
+        const selectedSplices = Polymer.ArraySplice.calculateSplices(
+            this.selected, originalSelected);
+        this.notifySplices('selected', selectedSplices);
+      }
+
+      /**
        * Selects the given item.  When `toggle` is true, this will automatically
        * deselect the item if already selected.
        *
@@ -328,6 +367,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         } else if (this.toggle) {
           this.deselectIndex(idx);
         }
+      }
+
+      /**
+       * Selects the given indexes.  When `toggle` is true, this will automatically
+       * deselect the items if already selected.
+       *
+       * @param {Array<number>} indexes Indexes from `items` array to select
+       */
+      selectIndexes(indexes) {
+        if (!this.multi) {
+          throw new Error('This method can be used only in multi = true mode');
+        }
+
+        if (indexes.length === 0) {
+          return;
+        }
+        if (indexes.length === 1) {
+          this.selectIndex(indexes[0]);
+          return;
+        }
+
+        const haveToBeSelectedIndexes =
+            indexes.filter(idx => !this.isSelected(this.items[idx]));
+
+        if (this.toggle) {
+          const alreadySelectedIndexes =
+              indexes.filter(idx => this.isSelected(this.items[idx]));
+          this.deselectIndexes(alreadySelectedIndexes);
+        }
+
+        for (const idx of haveToBeSelectedIndexes) {
+          this.__selectedMap.set(this.items[idx], idx);
+        }
+        this.__updateLinks();
+        this.push(
+            'selected', ...haveToBeSelectedIndexes.map(idx => this.items[idx]));
       }
 
     }

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -146,7 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           let part = path.slice('items.'.length);
           let idx = parseInt(part, 10);
           if ((part.indexOf('.') < 0) && part == idx) {
-            this.__deselectChangedIdx(idx);
+            this.deselectIndex(idx);
           }
         }
       }
@@ -246,45 +246,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this.isSelected(this.items[idx]);
       }
 
-      __deselectChangedIdx(idx) {
-        let sidx = this.__selectedIndexForItemIndex(idx);
-        if (sidx >= 0) {
-          let i = 0;
-          this.__selectedMap.forEach((idx, item) => {
-            if (sidx == i++) {
-              this.deselect(item);
-            }
-          });
-        }
-      }
-
-      __selectedIndexForItemIndex(idx) {
-        let selected = this.__dataLinkedPaths['items.' + idx];
-        if (selected) {
-          return parseInt(selected.slice('selected.'.length), 10);
-        }
-      }
-
       /**
        * Deselects the given item if it is already selected.
        *
        * @param {*} item Item from `items` array to deselect
        */
       deselect(item) {
-        let idx = this.__selectedMap.get(item);
-        if (idx >= 0) {
-          this.__selectedMap.delete(item);
-          let sidx;
-          if (this.multi) {
-            sidx = this.__selectedIndexForItemIndex(idx);
-          }
-          this.__updateLinks();
-          if (this.multi) {
-            this.splice('selected', sidx, 1);
-          } else {
-            this.selected = this.selectedItem = null;
-          }
-        }
+        this.deselectIndex(this.__selectedMap.get(item));
       }
 
       /**
@@ -293,7 +261,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {number} idx Index from `items` array to deselect
        */
       deselectIndex(idx) {
-        this.deselect(this.items[idx]);
+        if (this.multi) {
+          this.__deselectIndexes([idx]);
+          return;
+        }
+
+        // Don't use this.items in this method. Keep in mind, that it can be
+        // called for deselecting removed from this.items array item.
+        // Use __dataLinkedPaths and this.selectedItem for getting item.
+        const selectedMappedPath = this.__dataLinkedPaths['selectedItem'];
+        if (!selectedMappedPath ||
+            parseInt(selectedMappedPath.slice('items.'.length), 10) !== idx) {
+          return;
+        }
+
+        const item = this.selectedItem;
+        this.__selectedMap.delete(item);
+        this.__updateLinks();
+        this.selected = this.selectedItem = null;
       }
 
       /**
@@ -306,33 +291,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           throw new Error('This method can be used only in multi = true mode');
         }
 
-        if (indexes.length === 0) {
-          return;
-        }
-        if (indexes.length === 1) {
-          this.deselectIndex(indexes[0]);
-          return;
-        }
-
-        const haveToBeDeselectedIndexes =
-            indexes.filter(idx => this.isSelected(this.items[idx]));
-
-        const selectedIndexesToRemove = [];
-        for (const idx of haveToBeDeselectedIndexes) {
-          this.__selectedMap.delete(this.items[idx]);
-          selectedIndexesToRemove.push(this.__selectedIndexForItemIndex(idx));
-        }
-        this.__updateLinks();
-
-        const originalSelected =
-            Array.from(/** @type {!Array<!Object>} */(this.selected));
-        selectedIndexesToRemove.sort();
-        for (let i = selectedIndexesToRemove.length - 1; i >= 0; i--) {
-          this.selected.splice(selectedIndexesToRemove[i], 1);
-        }
-        const selectedSplices = Polymer.ArraySplice.calculateSplices(
-            this.selected, originalSelected);
-        this.notifySplices('selected', selectedSplices);
+        this.__deselectIndexes(indexes);
       }
 
       /**
@@ -352,18 +311,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {number} idx Index from `items` array to select
        */
       selectIndex(idx) {
-        let item = this.items[idx];
+        if (this.multi) {
+          this.__selectIndexes([idx]);
+          return;
+        }
+
+        const item = this.items[idx];
         if (!this.isSelected(item)) {
-          if (!this.multi) {
-            this.__selectedMap.clear();
-          }
+          this.__selectedMap.clear();
           this.__selectedMap.set(item, idx);
           this.__updateLinks();
-          if (this.multi) {
-            this.push('selected', item);
-          } else {
-            this.selected = this.selectedItem = item;
-          }
+          this.selected = this.selectedItem = item;
         } else if (this.toggle) {
           this.deselectIndex(idx);
         }
@@ -380,21 +338,85 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           throw new Error('This method can be used only in multi = true mode');
         }
 
-        if (indexes.length === 0) {
-          return;
-        }
-        if (indexes.length === 1) {
-          this.selectIndex(indexes[0]);
+        this.__selectIndexes(indexes);
+      }
+
+      /**
+       * @param {Array<number>} indexes Indexes from `items` array to deselect
+       * @private
+       */
+       __deselectIndexes(indexes) {
+        // Don't use this.items in this method. Keep in mind, that it can be
+        // called for deselecting removed from this.items array item.
+        // Use __dataLinkedPaths and then this.selected for getting
+        // item.
+        const selectedIndexes = indexes.map(idx => {
+          const selectedMappedPath = this.__dataLinkedPaths['items.' + idx];
+          return selectedMappedPath ?
+              parseInt(selectedMappedPath.slice('selected.'.length), 10) : -1;
+        });
+        const haveToBeDeselectedSelectedIndexes =
+            selectedIndexes.filter(sidx => sidx >= 0);
+
+        if (haveToBeDeselectedSelectedIndexes.length === 0) {
           return;
         }
 
-        const haveToBeSelectedIndexes =
-            indexes.filter(idx => !this.isSelected(this.items[idx]));
+        const selectedIndexesToRemove = [];
+        for (const sidx of haveToBeDeselectedSelectedIndexes) {
+          this.__selectedMap.delete(this.selected[sidx]);
+          selectedIndexesToRemove.push(sidx);
+        }
+
+        this.__updateLinks();
+
+        // In case of deselecting one item just splice selected array with
+        // polymer splice method to avoid calculateSplices method with
+        // O(n * m) complexity for trivial case.
+        // When we have to deselect more than one item do it in batch with
+        // native splice method and then dispatch one event for whole array
+        // mutation.
+        if (selectedIndexesToRemove.length === 1) {
+          this.splice('selected', selectedIndexesToRemove[0], 1);
+        } else {
+          const originalSelected =
+              Array.from(/** @type {!Array<!Object>} */(this.selected));
+          selectedIndexesToRemove.sort();
+          for (let i = selectedIndexesToRemove.length - 1; i >= 0; i--) {
+            this.selected.splice(selectedIndexesToRemove[i], 1);
+          }
+          const selectedSplices = Polymer.ArraySplice.calculateSplices(
+              this.selected, originalSelected);
+          this.notifySplices('selected', selectedSplices);
+        }
+      }
+
+      /**
+       * @param {Array<number>} indexes Indexes from `items` array to select
+       * @private
+       */
+      __selectIndexes(indexes) {
+        const itemsCount = this.items.length;
+
+        const alreadySelectedIndexes = [];
+        const haveToBeSelectedIndexes = [];
+        for (const idx of indexes) {
+          if (idx < 0 && idx >= itemsCount) {
+            continue;
+          }
+          if (this.isSelected(this.items[idx])) {
+            alreadySelectedIndexes.push(idx);
+          } else {
+            haveToBeSelectedIndexes.push(idx);
+          }
+        }
 
         if (this.toggle) {
-          const alreadySelectedIndexes =
-              indexes.filter(idx => this.isSelected(this.items[idx]));
           this.deselectIndexes(alreadySelectedIndexes);
+        }
+
+        if (haveToBeSelectedIndexes.length === 0) {
+          return;
         }
 
         for (const idx of haveToBeSelectedIndexes) {
@@ -402,7 +424,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         this.__updateLinks();
         this.push(
-            'selected', ...haveToBeSelectedIndexes.map(idx => this.items[idx]));
+          'selected',
+          ...haveToBeSelectedIndexes.map(idx => this.items[idx]));
       }
 
     }

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -236,6 +236,19 @@ suite('single selection', function() {
     assert.equal(bind.$.singleBound.selected, null);
   });
 
+  test('reset item in array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[0]);
+    assert.equal(bind.$.singleBound.selected, bind.items[0]);
+    bind.set('items.0', {name: 'new'});
+    assert.equal(bind.$.singleBound.selected, null);
+  });
+
 });
 
 suite('multi selection', function() {

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -480,6 +480,125 @@ suite('multi selection', function() {
     assert.sameMembers(bind.$.multiBound.selected, [bind.items[2]]);
   });
 
+  test('batch selection and deselection of items', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'},
+      {name: 'four'},
+      {name: 'five'},
+      {name: 'six'}
+    ];
+    bind.$.multiBound.selectIndexes([1, 3]);
+    assert.sameMembers(
+        bind.$.multiBound.selected,
+        [bind.items[1], bind.items[3]]);
+
+    bind.$.multiBound.selectIndexes([3, 4, 5]);
+    assert.sameMembers(
+        bind.$.multiBound.selected,
+        [bind.items[1], bind.items[3], bind.items[4], bind.items[5]]);
+
+    bind.$.multiBound.deselectIndexes([1, 5]);
+    assert.sameMembers(
+        bind.$.multiBound.selected,
+        [bind.items[3], bind.items[4]]);
+
+    bind.$.multiBound.deselectIndexes([2, 4]);
+    assert.sameMembers(
+        bind.$.multiBound.selected,
+        [bind.items[3]]);
+  });
+
+  test('batch selection notification', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'},
+      {name: 'four'},
+      {name: 'five'},
+      {name: 'six'}
+    ];
+    // select second, third, fifth and sixth
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.selectIndexes([1, 2, 4, 5]);
+    assert.isTrue(bind.$.observer.multiChanged.calledTwice);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 4);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 0);
+    assert.sameMembers(
+        bind.$.observer.multiSelected,
+        [bind.items[1], bind.items[2], bind.items[4], bind.items[5]]);
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].path, 'multiSelected.length');
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].value, 4);
+
+    // select first
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.select(bind.items[0]);
+    assert.isTrue(bind.$.observer.multiChanged.calledTwice);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 0);
+    assert.sameMembers(
+        bind.$.observer.multiSelected,
+        [bind.items[1], bind.items[2], bind.items[4], bind.items[5], bind.items[0]]);
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].path, 'multiSelected.length');
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].value, 5);
+
+    // deselect items
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.deselectIndexes([5, 0, 2]);
+    assert.isTrue(bind.$.observer.multiChanged.calledTwice);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].path, 'multiSelected.splices');
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices.length, 2);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].addedCount, 0);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[0].removed.length, 1);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[1].addedCount, 0);
+    assert.equal(bind.$.observer.multiChanged.firstCall.args[0].value.indexSplices[1].removed.length, 2);
+    assert.sameMembers(
+        bind.$.observer.multiSelected,
+        [bind.items[1], bind.items[4]]);
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].path, 'multiSelected.length');
+    assert.equal(bind.$.observer.multiChanged.secondCall.args[0].value, 2);
+  });
+
+  test('batch selection toggle', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'},
+      {name: 'four'},
+      {name: 'five'},
+      {name: 'six'}
+    ];
+
+    bind.$.multiBound.toggle = true;
+
+    // select second, third, fifth and sixth
+    bind.$.multiBound.selectIndexes([1, 2, 4, 5]);
+    assert.sameMembers(
+        bind.$.observer.multiSelected,
+        [bind.items[1], bind.items[2], bind.items[4], bind.items[5]]);
+
+    // select first and deselect third
+    bind.$.multiBound.selectIndexes([0, 2]);
+    assert.sameMembers(
+        bind.$.observer.multiSelected,
+        [bind.items[1], bind.items[4], bind.items[5], bind.items[0]]);
+
+    // deselect items
+    bind.$.observer.multiChanged = sinon.spy();
+    bind.$.multiBound.deselectIndexes([4, 2]);
+    assert.sameMembers(
+      bind.$.observer.multiSelected,
+      [bind.items[1], bind.items[5], bind.items[0]]);
+  });
+
 });
 
 suite('corner cases', function() {


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #4939 
Fixes #4947

### Changes in this PR:
1. Added `selectIndexes` and `deselectIndexes` methods for batch items (de)selection and tests for them (separate commit).
2. Refactor all (de)selection logic to simplify and remove code duplication as much as I can.

### What I wanted to achieve
1. Tried to combine all of the logic for control selection in `multi = false` state in `__selectIndexes` and `__deselectIndexes` methods
2. Same for `multi = true` state in `selectIndex` and `deselectIndex` methods.

### What else I suggest to improve
1. Get rid of direct `__dataLinkedPaths` usage and path parsing

I will welcome any comments and suggestions. Thank you!
