### PR TITLE
Array-selector batch selection

### DIFF
--- a/lib/elements/array-selector.js
+++ b/lib/elements/array-selector.js
@@ -142,7 +142,7 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
         let part = path.slice('items.'.length);
         let idx = parseInt(part, 10);
         if ((part.indexOf('.') < 0) && part == idx) {
-          this.__deselectChangedIdx(idx);
+          this.deselectIndex(idx);
         }
       }
     }
@@ -242,25 +242,6 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
       return this.isSelected(this.items[idx]);
     }
 
-    __deselectChangedIdx(idx) {
-      let sidx = this.__selectedIndexForItemIndex(idx);
-      if (sidx >= 0) {
-        let i = 0;
-        this.__selectedMap.forEach((idx, item) => {
-          if (sidx == i++) {
-            this.deselect(item);
-          }
-        });
-      }
-    }
-
-    __selectedIndexForItemIndex(idx) {
-      let selected = this.__dataLinkedPaths['items.' + idx];
-      if (selected) {
-        return parseInt(selected.slice('selected.'.length), 10);
-      }
-    }
-
     /**
      * Deselects the given item if it is already selected.
      *
@@ -268,20 +249,7 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
      * @return {void}
      */
     deselect(item) {
-      let idx = this.__selectedMap.get(item);
-      if (idx >= 0) {
-        this.__selectedMap.delete(item);
-        let sidx;
-        if (this.multi) {
-          sidx = this.__selectedIndexForItemIndex(idx);
-        }
-        this.__updateLinks();
-        if (this.multi) {
-          this.splice('selected', sidx, 1);
-        } else {
-          this.selected = this.selectedItem = null;
-        }
-      }
+      this.deselectIndex(this.__selectedMap.get(item));
     }
 
     /**
@@ -291,7 +259,24 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
      * @return {void}
      */
     deselectIndex(idx) {
-      this.deselect(this.items[idx]);
+      if (this.multi) {
+        this.__deselectIndexes([idx]);
+        return;
+      }
+
+      // Don't use this.items in this method. Keep in mind, that it can be
+      // called for deselecting removed from this.items array item.
+      // Use __dataLinkedPaths and this.selectedItem for getting item.
+      const selectedMappedPath = this.__dataLinkedPaths['selectedItem'];
+      if (!selectedMappedPath ||
+          parseInt(selectedMappedPath.slice('items.'.length), 10) !== idx) {
+        return;
+      }
+
+      const item = this.selectedItem;
+      this.__selectedMap.delete(item);
+      this.__updateLinks();
+      this.selected = this.selectedItem = null;
     }
 
     /**
@@ -305,33 +290,7 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
         throw new Error('This method can be used only in multi = true mode');
       }
 
-      if (indexes.length === 0) {
-        return;
-      }
-      if (indexes.length === 1) {
-        this.deselectIndex(indexes[0]);
-        return;
-      }
-
-      const haveToBeDeselectedIndexes =
-          indexes.filter(idx => this.isSelected(this.items[idx]));
-
-      const selectedIndexesToRemove = [];
-      for (const idx of haveToBeDeselectedIndexes) {
-        this.__selectedMap.delete(this.items[idx]);
-        selectedIndexesToRemove.push(this.__selectedIndexForItemIndex(idx));
-      }
-      this.__updateLinks();
-
-      const originalSelected =
-          Array.from(/** @type {!Array<!Object>} */(this.selected));
-      selectedIndexesToRemove.sort((a, b) => a - b);
-      for (let i = selectedIndexesToRemove.length - 1; i >= 0; i--) {
-        this.selected.splice(selectedIndexesToRemove[i], 1);
-      }
-      const selectedSplices = calculateSplices(
-          this.selected, originalSelected);
-      this.notifySplices('selected', selectedSplices);
+      this.__deselectIndexes(indexes);
     }
 
     /**
@@ -353,18 +312,17 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
      * @return {void}
      */
     selectIndex(idx) {
-      let item = this.items[idx];
+      if (this.multi) {
+        this.__selectIndexes([idx]);
+        return;
+      }
+
+      const item = this.items[idx];
       if (!this.isSelected(item)) {
-        if (!this.multi) {
-          this.__selectedMap.clear();
-        }
+        this.__selectedMap.clear();
         this.__selectedMap.set(item, idx);
         this.__updateLinks();
-        if (this.multi) {
-          this.push('selected', item);
-        } else {
-          this.selected = this.selectedItem = item;
-        }
+        this.selected = this.selectedItem = item;
       } else if (this.toggle) {
         this.deselectIndex(idx);
       }
@@ -382,22 +340,87 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
         throw new Error('This method can be used only in multi = true mode');
       }
 
-      if (indexes.length === 0) {
-        return;
+      this.__selectIndexes(indexes);
+    }
 
-      }
-      if (indexes.length === 1) {
-        this.selectIndex(indexes[0]);
+    /**
+     * @param {Array<number>} indexes Indexes from `items` array to deselect
+     * @return {void}
+     * @private
+     */
+    __deselectIndexes(indexes) {
+      // Don't use this.items in this method. Keep in mind, that it can be
+      // called for deselecting removed from this.items array item.
+      // Use __dataLinkedPaths and then this.selected for getting
+      // item.
+      const selectedIndexes = indexes.map(idx => {
+        const selectedMappedPath = this.__dataLinkedPaths['items.' + idx];
+        return selectedMappedPath ?
+            parseInt(selectedMappedPath.slice('selected.'.length), 10) : -1;
+      });
+      const haveToBeDeselectedSelectedIndexes =
+          selectedIndexes.filter(sidx => sidx >= 0);
+
+      if (haveToBeDeselectedSelectedIndexes.length === 0) {
         return;
       }
 
-      const haveToBeSelectedIndexes =
-          indexes.filter(idx => !this.isSelected(this.items[idx]));
+      const selectedIndexesToRemove = [];
+      for (const sidx of haveToBeDeselectedSelectedIndexes) {
+        this.__selectedMap.delete(this.selected[sidx]);
+        selectedIndexesToRemove.push(sidx);
+      }
+
+      this.__updateLinks();
+
+      // In case of deselecting one item just splice selected array with
+      // polymer splice method to avoid calculateSplices method with
+      // O(n * m) complexity for trivial case.
+      // When we have to deselect more than one item do it in batch with
+      // native splice method and then dispatch one event for whole array
+      // mutation.
+      if (selectedIndexesToRemove.length === 1) {
+        this.splice('selected', selectedIndexesToRemove[0], 1);
+      } else {
+        const originalSelected =
+            Array.from(/** @type {!Array<!Object>} */(this.selected));
+        selectedIndexesToRemove.sort((a, b) => a - b);
+        for (let i = selectedIndexesToRemove.length - 1; i >= 0; i--) {
+          this.selected.splice(selectedIndexesToRemove[i], 1);
+        }
+        const selectedSplices = calculateSplices(
+            this.selected, originalSelected);
+        this.notifySplices('selected', selectedSplices);
+      }
+    }
+
+    /**
+     * @param {Array<number>} indexes Indexes from `items` array to select
+     * @return {void}
+     * @private
+     */
+    __selectIndexes(indexes) {
+      const itemsCount = this.items.length;
+
+      const alreadySelectedIndexes = [];
+      const haveToBeSelectedIndexes = [];
+      for (const idx of indexes) {
+        if (idx < 0 && idx >= itemsCount) {
+          continue;
+        }
+        if (this.isSelected(this.items[idx])) {
+          alreadySelectedIndexes.push(idx);
+        } else {
+          haveToBeSelectedIndexes.push(idx);
+        }
+      }
 
       if (this.toggle) {
-        const alreadySelectedIndexes =
-            indexes.filter(idx => this.isSelected(this.items[idx]));
         this.deselectIndexes(alreadySelectedIndexes);
+      }
+
+      if (haveToBeSelectedIndexes.length === 0) {
+        return;
       }
 
       for (const idx of haveToBeSelectedIndexes) {
@@ -405,7 +428,8 @@ let ArraySelectorMixin = dedupingMixin(superClass => {
       }
       this.__updateLinks();
       this.push(
-          'selected', ...haveToBeSelectedIndexes.map(idx => this.items[idx]));
+        'selected',
+        ...haveToBeSelectedIndexes.map(idx => this.items[idx]));
     }
 
   }

--- a/test/unit/array-selector.html
+++ b/test/unit/array-selector.html
@@ -238,6 +238,19 @@ suite('single selection', function() {
     assert.equal(bind.$.singleBound.selected, null);
   });
 
+  test('reset item in array, selection should go away', function() {
+    let bind = fixture('bind');
+    bind.items = [
+      {name: 'one'},
+      {name: 'two'},
+      {name: 'three'}
+    ];
+    bind.$.singleBound.select(bind.items[0]);
+    assert.equal(bind.$.singleBound.selected, bind.items[0]);
+    bind.set('items.0', {name: 'new'});
+    assert.equal(bind.$.singleBound.selected, null);
+  });
+
 });
 
 suite('multi selection', function() {


### PR DESCRIPTION
### Reference Issue
Fixes #4939 
Fixes #4947

### Changes in this PR:
1. Added `selectIndexes` and `deselectIndexes` methods for batch items (de)selection and tests for them (separate commit).
2. Refactor all (de)selection logic to simplify and remove code duplication as much as I can.

### What I wanted to achieve
1. Tried to combine all of the logic for control selection in `multi = false` state in `__selectIndexes` and `__deselectIndexes` methods
2. Same for `multi = true` state in `selectIndex` and `deselectIndex` methods.

### What else I suggest to improve
1. Get rid of direct `__dataLinkedPaths` usage and path parsing
2. Improve `__applySplices` method to use batch removing items from selected array.

I can do this improvements in this PR or create one more. I think this is big enough.

I will welcome any comments and suggestions. Thank you!
