### PR TITLE
Allow non-JSON literals when property type is "Object".

### DIFF
--- a/lib/mixins/property-accessors.html
+++ b/lib/mixins/property-accessors.html
@@ -362,6 +362,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               outValue = JSON.parse(/** @type {string} */(value));
             } catch(x) {
               // allow non-JSON literals like Strings and Numbers
+              outValue = value;
             }
             break;
 

--- a/test/unit/attributes-elements.html
+++ b/test/unit/attributes-elements.html
@@ -90,7 +90,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         observer: 'attr1Changed'
       },
       shorthandNumber: Number,
-      shorthandBool: Boolean
+      shorthandBool: Boolean,
+      foreignTypeObjectProp: {
+        type: Object,
+        value: 'none'
+      }
     },
 
     propChangedCount: 0,
@@ -166,7 +170,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         readOnly: true
       },
       shorthandNumber: Number,
-      shorthandBool: Boolean
+      shorthandBool: Boolean,
+      foreignTypeObjectProp: {
+        type: Object,
+        reflectToAttribute: true,
+        value: 'none'
+      }
     },
     _warn: function() {
       var search = Array.prototype.join.call(arguments, '');

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -180,7 +180,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('change object attribute to foreign type', function() {
       element.setAttribute('object', 'The quick brown fox');
-      assert.deepEqual(element.object, 'The quick brown fox');
+      assert.strictEqual(element.object, 'The quick brown fox');
     });
 
     test('change array attribute', function() {
@@ -247,7 +247,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('change object attribute to foreign type', function() {
       element.setAttribute('object', 'The quick brown fox');
-      assert.deepEqual(element.object, 'The quick brown fox');
+      assert.strictEqual(element.object, 'The quick brown fox');
     });
 
     test('change array attribute', function() {

--- a/test/unit/attributes.html
+++ b/test/unit/attributes.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         shorthand-number="88"
         behavior-shorthand-bool
         behavior-shorthand-number="99"
-        >
+        foreign-type-object-prop="The quick brown fox">
       </x-basic>
     </template>
   </test-fixture>
@@ -81,7 +81,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         shorthand-bool
         shorthand-number="88"
         behavior-shorthand-bool
-        behavior-shorthand-number="99">
+        behavior-shorthand-number="99"
+        foreign-type-object-prop="The quick brown fox">
       </x-reflect>
     </template>
   </test-fixture>
@@ -106,6 +107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(element.shorthandBool, undefined);
       assert.strictEqual(element.behaviorShorthandNumber, undefined);
       assert.strictEqual(element.behaviorShorthandBool, undefined);
+      assert.strictEqual(element.foreignTypeObjectProp, 'none');
     }
 
     function testAttributesMatchCustomConfiguration(element) {
@@ -133,6 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(element.shorthandBool, true);
       assert.strictEqual(element.behaviorShorthandNumber, 99);
       assert.strictEqual(element.behaviorShorthandBool, true);
+      assert.strictEqual(element.foreignTypeObjectProp, configuredString);
     }
 
     test('basic default values', function() {
@@ -173,6 +176,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('change object attribute', function() {
       element.setAttribute('object', '{"foo": "bar", "nested": {"meaning": 42}, "arr": [0, "foo", true]}');
       assert.deepEqual(element.object, configuredObject);
+    });
+
+    test('change object attribute to foreign type', function() {
+      element.setAttribute('object', 'The quick brown fox');
+      assert.deepEqual(element.object, 'The quick brown fox');
     });
 
     test('change array attribute', function() {
@@ -235,6 +243,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('change object attribute', function() {
       element.setAttribute('object', '{"foo": "bar", "nested": {"meaning": 42}, "arr": [0, "foo", true]}');
       assert.deepEqual(element.object, configuredObject);
+    });
+
+    test('change object attribute to foreign type', function() {
+      element.setAttribute('object', 'The quick brown fox');
+      assert.deepEqual(element.object, 'The quick brown fox');
     });
 
     test('change array attribute', function() {


### PR DESCRIPTION
It seems there are in general no tests if properties are correctly deserialized or I didn't see or get it???
If someone can give me a hint I would try to implement them.

### Reference Issue
Fixes #4464
