### PR TITLE
Adds `restamp` mode to dom-repeat

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -269,6 +269,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         _targetFrameTime: {
           type: Number,
           computed: '__computeFrameTime(targetFramerate)'
+        },
+
+        /**
+         * When `restamp` is true, template instances are never reused with
+         * different items.  Instances mapping to current items are moved
+         * to their new location, new instances are created for any new
+         * items, and instances for removed items are discarded.  This mode is
+         * generally more expensive than `restamp: false` as it results in
+         * more instances to be created and discarded during updates and
+         * disconnection/reconnection churn.  By default, object identity is
+         * used for mapping instances to items.  Set `restampKey` to provide
+         * key based identity.
+         */
+        restamp: {
+          type: Boolean
+        },
+
+        /**
+         * When `restamp: true` is used, `restampKey` can be used to provide
+         * a path into the item object that serves as a unique key for the
+         * item, for purposes of mapping instances to items.  Instances for
+         * items with the same key will be reused, while all others will be
+         * either restamped or discarded.
+         */
+        restampKey: {
+          type: String
         }
 
       };
@@ -283,7 +309,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       super();
       this.__instances = [];
       this.__limit = Infinity;
-      this.__pool = [];
       this.__renderDebouncer = null;
       this.__itemsIdxToInstIdx = {};
       this.__chunkCount = null;
@@ -299,8 +324,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     disconnectedCallback() {
       super.disconnectedCallback();
       this.__isDetached = true;
-      for (let i=0; i<this.__instances.length; i++) {
-        this.__detachInstance(i);
+      let instances = this.__instances;
+      for (let i=0; i<instances.length; i++) {
+        this.__detachInstance(instances[i]);
       }
     }
 
@@ -310,9 +336,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // only perform attachment if the element was previously detached.
       if (this.__isDetached) {
         this.__isDetached = false;
-        let parent = this.parentNode;
-        for (let i=0; i<this.__instances.length; i++) {
-          this.__attachInstance(i, parent);
+        let instances = this.__instances;
+        for (let i=0; i<instances.length; i++) {
+          this.__attachInstance(instances[i]);
         }
       }
     }
@@ -508,13 +534,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // No template found yet
         return;
       }
-      this.__applyFullRefresh();
-      // Reset the pool
-      // TODO(kschaaf): Reuse pool across turns and nested templates
-      // Now that objects/arrays are re-evaluated when set, we can safely
-      // reuse pooled instances across turns, however we still need to decide
-      // semantics regarding how long to hold, how many to hold, etc.
-      this.__pool.length = 0;
+      let items = this.items || [];
+      let inst2items = new Array(items.length);
+      for (let i=0; i<items.length; i++) {
+        inst2items[i] = i;
+      }
+      // Apply user filter
+      if (this.__filterFn) {
+        inst2items = inst2items.filter((i, idx, array) =>
+          this.__filterFn(items[i], idx, array));
+      }
+      // Apply user sort
+      if (this.__sortFn) {
+        inst2items.sort((a, b) => this.__sortFn(items[a], items[b]));
+      }
+
+      // items->inst map kept for item path forwarding
+      const items2inst = this.__itemsIdxToInstIdx = {};
+      const instances = this.__instances;
+      const limit = Math.max(Math.min(inst2items.length, this.__limit), 0);
+      // Generate instances and assign items
+      if (this.restamp) {
+        this.__renderRestamp(items, instances, limit, inst2items, items2inst);
+      } else {
+        this.__renderRefresh(items, instances, limit, inst2items, items2inst);
+      }
+      // Remove any extra instances from previous state
+      while (this.__instances.length > limit) {
+        this.__detachAndRemoveInstanceAt(limit);
+      }
       // Set rendered item count
       this._setRenderedItemCount(this.__instances.length);
       // Notify users
@@ -526,65 +574,90 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.__tryRenderChunk();
     }
 
-    __applyFullRefresh() {
-      let items = this.items || [];
-      let isntIdxToItemsIdx = new Array(items.length);
-      for (let i=0; i<items.length; i++) {
-        isntIdxToItemsIdx[i] = i;
-      }
-      // Apply user filter
-      if (this.__filterFn) {
-        isntIdxToItemsIdx = isntIdxToItemsIdx.filter((i, idx, array) =>
-          this.__filterFn(items[i], idx, array));
-      }
-      // Apply user sort
-      if (this.__sortFn) {
-        isntIdxToItemsIdx.sort((a, b) => this.__sortFn(items[a], items[b]));
-      }
-      // items->inst map kept for item path forwarding
-      const itemsIdxToInstIdx = this.__itemsIdxToInstIdx = {};
-      let instIdx = 0;
-      // Generate instances and assign items
-      const limit = Math.min(isntIdxToItemsIdx.length, this.__limit);
-      for (; instIdx<limit; instIdx++) {
-        let inst = this.__instances[instIdx];
-        let itemIdx = isntIdxToItemsIdx[instIdx];
+    __renderRestamp(items, instances, limit, inst2items, items2inst) {
+      let keyPath = this.restampKey;
+      const instCache = new Map();
+      nextItem: for (let i=0; i<limit; i++) {
+        let itemIdx = inst2items[i];
         let item = items[itemIdx];
-        itemsIdxToInstIdx[itemIdx] = instIdx;
-        if (inst && instIdx < this.__limit) {
+        let key = keyPath && Polymer.Path.get(item, keyPath) || item;
+        let inst, instItem;
+        while ((inst = instances[i])) {
+          instItem = inst[this.as];
+          let instKey = keyPath && Polymer.Path.get(instItem, keyPath) || instItem;
+          if (key === instKey) {
+            inst._setPendingProperty(this.as, item);
+            inst._setPendingProperty(this.indexAs, i);
+            inst._setPendingProperty(this.itemsIndexAs, itemIdx);
+            inst._flushProperties();
+            items2inst[itemIdx] = i;
+            continue nextItem;
+          }
+          let cache = instCache.get(instKey);
+          if (cache) {
+            cache.push(inst);
+          } else {
+            instCache.set(instKey, [inst]);
+          }
+          instances.splice(i, 1);
+        }
+        let cache = instCache.get(key);
+        if (cache && (inst = cache.shift())) {
+          this.__reuseInstance(inst, item, i, itemIdx);
+          if (!cache.length) {
+            instCache.delete(key);
+          }
+        } else {
+          this.__insertInstance(item, i, itemIdx);
+        }
+        items2inst[itemIdx] = i;
+      }
+      instCache.forEach(cache => cache.forEach(inst => this.__detachInstance(inst)));
+    }
+
+    __renderRefresh(items, instances, limit, inst2items, items2inst) {
+      for (let i=0; i<limit; i++) {
+        let inst = instances[i];
+        let itemIdx = inst2items[i];
+        let item = items[itemIdx];
+        if (inst) {
           inst._setPendingProperty(this.as, item);
-          inst._setPendingProperty(this.indexAs, instIdx);
+          inst._setPendingProperty(this.indexAs, i);
           inst._setPendingProperty(this.itemsIndexAs, itemIdx);
           inst._flushProperties();
         } else {
-          this.__insertInstance(item, instIdx, itemIdx);
+          this.__insertInstance(item, i, itemIdx);
         }
-      }
-      // Remove any extra instances from previous state
-      for (let i=this.__instances.length-1; i>=instIdx; i--) {
-        this.__detachAndRemoveInstance(i);
+        items2inst[itemIdx] = i;
       }
     }
 
-    __detachInstance(idx) {
-      let inst = this.__instances[idx];
+    __detachInstance(inst) {
       for (let i=0; i<inst.children.length; i++) {
         let el = inst.children[i];
         inst.root.appendChild(el);
       }
-      return inst;
     }
 
-    __attachInstance(idx, parent) {
-      let inst = this.__instances[idx];
-      parent.insertBefore(inst.root, this);
-    }
-
-    __detachAndRemoveInstance(idx) {
-      let inst = this.__detachInstance(idx);
-      if (inst) {
-        this.__pool.push(inst);
+    __reuseInstance(inst, item, idx, itemIdx) {
+      let beforeInst = this.__instances[idx];
+      let beforeNode = beforeInst ? beforeInst.children[0] : this;
+      for (let i=0; i<inst.children.length; i++) {
+        this.parentNode.insertBefore(inst.children[i], beforeNode);
       }
+      this.__instances.splice(idx, 0, inst);
+      inst._setPendingProperty(this.as, item);
+      inst._setPendingProperty(this.indexAs, idx);
+      inst._setPendingProperty(this.itemsIndexAs, itemIdx);
+      inst._flushProperties();
+    }
+
+    __attachInstance(inst) {
+      this.parentNode.insertBefore(inst.root, this);
+    }
+
+    __detachAndRemoveInstanceAt(idx) {
+      this.__detachInstance(this.__instances[idx]);
       this.__instances.splice(idx, 1);
     }
 
@@ -597,21 +670,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     __insertInstance(item, instIdx, itemIdx) {
-      let inst = this.__pool.pop();
-      if (inst) {
-        // TODO(kschaaf): If the pool is shared across turns, hostProps
-        // need to be re-set to reused instances in addition to item
-        inst._setPendingProperty(this.as, item);
-        inst._setPendingProperty(this.indexAs, instIdx);
-        inst._setPendingProperty(this.itemsIndexAs, itemIdx);
-        inst._flushProperties();
-      } else {
-        inst = this.__stampInstance(item, instIdx, itemIdx);
-      }
-      let beforeRow = this.__instances[instIdx + 1];
+      let inst = this.__stampInstance(item, instIdx, itemIdx);
+      let beforeRow = this.__instances[instIdx];
       let beforeNode = beforeRow ? beforeRow.children[0] : this;
       this.parentNode.insertBefore(inst.root, beforeNode);
-      this.__instances[instIdx] = inst;
+      this.__instances.splice(instIdx, 0, inst);
       return inst;
     }
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -60,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/path.html',
       'unit/templatize.html',
       'unit/dom-repeat.html',
+      'unit/dom-repeat.html?restamp',
       'unit/dom-if.html',
       'unit/dom-bind.html',
       'unit/array-selector.html',

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -147,6 +147,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       stamped[38] .. 3-3-3
     */
 
+    function setupFixture(fixtureName) {
+      var el = fixture(fixtureName);
+      if (document.location.search.indexOf('restamp') >= 0) {
+        el.restamp = true;
+      }
+      return el;
+    }
+
     function arrayDelete(el, path, item) {
       var array = el.get(path);
       var idx = array.indexOf(item);
@@ -170,7 +178,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let configured;
 
       setup(function() {
-        configured = fixture('configured');
+        configured = setupFixture('configured');
         Polymer.flush();
       });
 
@@ -302,6 +310,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // reset sort fn
         configured.$.repeater.sort = null;
         configured.$.repeater.render();
+        stamped = configured.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 3 + 3*3 + 3*3*3, 'total stamped count incorrect');
         assert.equal(stamped[0].itemaProp, 'prop-1');
         assert.equal(stamped[0].indexa, 0);
@@ -328,6 +337,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // reset sort fn
         configured.$.repeater.sort = null;
         configured.$.repeater.render();
+        stamped = configured.root.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(stamped.length, 3 + 3*3 + 3*3*3, 'total stamped count incorrect');
         assert.equal(stamped[0].itemaProp, 'prop-1');
         assert.equal(stamped[0].indexa, 0);
@@ -697,7 +707,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         unconfigured.$.el1.prop = 'outer';
         unconfigured.$.el1.item = {prop: 'outerItem'};
@@ -830,7 +840,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
       });
@@ -918,7 +928,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
         unconfigured.$.el1.domUpdateHandlerCount = 0;
@@ -1171,7 +1181,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.filter = function(o) {
           return o.prop.indexOf('2') < 0;
@@ -1381,7 +1391,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.sort = function(a, b) {
           return b.prop == a.prop ? 0 : b.prop < a.prop ? -1 : 1;
@@ -1590,7 +1600,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.sort = function(a, b) {
           return b.prop == a.prop ? 0 : b.prop < a.prop ? -1 : 1;
@@ -1789,7 +1799,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured-mutable');
+        unconfigured = setupFixture('unconfigured-mutable');
         unconfigured.items = window.getData();
         Polymer.flush();
       });
@@ -2089,7 +2099,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured-mutable');
+        unconfigured = setupFixture('unconfigured-mutable');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.filter = function(o) {
           return o.prop.indexOf('2') < 0;
@@ -2306,7 +2316,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured-mutable');
+        unconfigured = setupFixture('unconfigured-mutable');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.sort = function(a, b) {
           return b.prop == a.prop ? 0 : b.prop < a.prop ? -1 : 1;
@@ -2522,7 +2532,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured-mutable');
+        unconfigured = setupFixture('unconfigured-mutable');
         unconfigured.items = window.getData();
         unconfigured.$.el1.$.repeater.sort = function(a, b) {
           return b.prop == a.prop ? 0 : b.prop < a.prop ? -1 : 1;
@@ -2728,7 +2738,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let primitive;
 
       setup(function() {
-        primitive = fixture('primitive');
+        primitive = setupFixture('primitive');
         Polymer.flush();
       });
 
@@ -3274,7 +3284,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let primitive;
 
       setup(function() {
-        primitive = fixture('primitive');
+        primitive = setupFixture('primitive');
         Polymer.flush();
       });
 
@@ -3331,7 +3341,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('structured values - initial stamping', function() {
-        let unconfigured = fixture('unconfigured');
+        let unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
         var stamped1 = unconfigured.$.el1.root.querySelectorAll('*:not(template):not(dom-repeat)');
@@ -3341,7 +3351,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('structured values - change from inside', function() {
-        let unconfigured = fixture('unconfigured');
+        let unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
         var stamped1 = unconfigured.$.el1.root.querySelectorAll('*:not(template):not(dom-repeat)');
@@ -3358,7 +3368,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('structured values - sorted', function() {
-        let unconfigured = fixture('unconfigured');
+        let unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
         unconfigured.$.el1.$.repeater.sort = function(a, b) {
@@ -3394,7 +3404,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           836, 564, 721, 540, 372,
           244, 145, 525, 958, 595,
           207, 103, 602, 769, 190];
-        let primitive = fixture('primitive');
+        let primitive = setupFixture('primitive');
         primitive.items = items;
         setTimeout(function() {
           var stamped1 = primitive.$.container1.querySelectorAll('*:not(template):not(dom-repeat)');
@@ -3404,10 +3414,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var prev = items.slice();
           items.sort();
           var splices = Polymer.ArraySplice.calculateSplices(items, prev);
-          var change = {
-            indexSplices: splices
-          };
-          primitive.set('items.splices', change);
+          primitive.notifySplices('items', splices);
           setTimeout(function() {
             var stamped1 = primitive.$.container1.querySelectorAll('*:not(template):not(dom-repeat)');
             for (var i=0; i<items.length; i++) {
@@ -3424,7 +3431,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let unconfigured;
 
       setup(function() {
-        unconfigured = fixture('unconfigured');
+        unconfigured = setupFixture('unconfigured');
         unconfigured.items = window.getData();
         Polymer.flush();
       });
@@ -3533,7 +3540,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('renderedItemCount', function() {
-        let primitive = fixture('primitive');
+        let primitive = setupFixture('primitive');
         Polymer.flush();
         var repeater1 = primitive.$.repeater1;
         primitive.items = [ 'a', 'b', 'c', 'd', 'e' ];
@@ -3553,7 +3560,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('_showHideChildren', function() {
         // Initially all showing
-        let primitive = fixture('primitive');
+        let primitive = setupFixture('primitive');
         Polymer.flush();
         var stamped1 = primitive.$.container1.querySelectorAll('*:not(template):not(dom-repeat)');
         assert.equal(getComputedStyle(stamped1[0]).display, 'block');
@@ -4096,7 +4103,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('misc', function() {
 
       test('large splice', function(done) {
-        let primitiveLarge = fixture('primitiveLarge');
+        let primitiveLarge = setupFixture('primitiveLarge');
         Polymer.flush();
         primitiveLarge.splice('items', 0, 10);
         setTimeout(function() {
@@ -4112,7 +4119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!window.ShadyDOM) {
           this.skip();
         }
-        let simple = fixture('simple');
+        let simple = setupFixture('simple');
         Polymer.flush();
         var removed;
         // Confirm initial scoping
@@ -4143,7 +4150,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('paths update on observed properties', function() {
-        let simple = fixture('simple');
+        let simple = setupFixture('simple');
         Polymer.flush();
         //debugger;
         var stamped = simple.root.querySelectorAll('*:not(template):not(dom-repeat)');
@@ -4173,7 +4180,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('dom-change composed', function() {
 
       test('dom-change event composed, bubbles outside dom-if scope', function() {
-        var el = fixture('simple');
+        var el = setupFixture('simple');
         var domChangeFired = 0;
         el.addEventListener('dom-change', function() {
           domChangeFired++;


### PR DESCRIPTION
(this is a "take two" of https://github.com/Polymer/polymer/pull/4363)

Fixes #1713

When restamp is true, template instances are never reused with different items. Instances mapping to current items are moved to their new location, new instances are created for any new items, and instances for removed items are discarded. This mode is generally more expensive than restamp: false as it results in more instances to be created and discarded during updates and disconnection/reconnection churn. By default, object identity is used for mapping instances to items. Set restampKey to provide key based identity.

When restamp: true is used, restampKey can be used to provide a path into the item object that serves as a unique key for the item rather than using object identity, for purposes of mapping instances to items. Instances for items with the same key will be reused, while all others will be either restamped or discarded.