### PR TITLE
Add some @function annotations to APIs that are defined by assignment.

### DIFF
--- a/lib/utils/array-splice.html
+++ b/lib/utils/array-splice.html
@@ -298,6 +298,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * perform the more expensive minimum edit distance calculation over the
      * non-shared portions of the arrays.
      *
+     * @function
      * @memberof Polymer.ArraySplice
      * @param {Array} current The "changed" array for which splices will be
      * calculated.

--- a/lib/utils/async.html
+++ b/lib/utils/async.html
@@ -79,6 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Enqueues a function called in the next task.
        *
+       * @function
        * @memberof Polymer.Async.timeOut
        * @param {Function} fn Callback to run
        * @return {number} Handle used for canceling task
@@ -87,6 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cancels a previously enqueued `timeOut` callback.
        *
+       * @function
        * @memberof Polymer.Async.timeOut
        * @param {number} handle Handle returned from `run` of callback to cancel
        */
@@ -104,6 +106,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Enqueues a function called at `requestAnimationFrame` timing.
        *
+       * @function
        * @memberof Polymer.Async.animationFrame
        * @param {Function} fn Callback to run
        * @return {number} Handle used for canceling task
@@ -112,6 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cancels a previously enqueued `animationFrame` callback.
        *
+       * @function
        * @memberof Polymer.Async.timeOut
        * @param {number} handle Handle returned from `run` of callback to cancel
        */


### PR DESCRIPTION
This helps analyzer understand when something is a function despite not having any function-looking syntax on the right-hand-side.

Part of https://github.com/Polymer/gen-typescript-declarations/issues/23