### PR TITLE
Do not set touchend listeners to passive

### DIFF
--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -62,9 +62,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Generate settings for event listeners, dependant on `Polymer.passiveTouchGestures`
    *
+   * @param {string} eventName Event name to determine if `{passive}` option is needed
    * @return {{passive: boolean} | undefined} Options to use for addEventListener and removeEventListener
    */
-  function PASSIVE_TOUCH() {
+  function PASSIVE_TOUCH(eventName) {
+    if (isMouseEvent(eventName) || eventName === 'touchend') {
+      return;
+    }
     if (HAS_NATIVE_TA && SUPPORTS_PASSIVE && Polymer.passiveTouchGestures) {
       return {passive: true};
     } else {
@@ -481,8 +485,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          let options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
-          node.addEventListener(dep, this._handleNative, options);
+          node.addEventListener(dep, this._handleNative, PASSIVE_TOUCH(dep));
         }
         gd[name] = (gd[name] || 0) + 1;
         gd._count = (gd._count || 0) + 1;
@@ -515,8 +518,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              let options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
-              node.removeEventListener(dep, this._handleNative, options);
+              node.removeEventListener(dep, this._handleNative, PASSIVE_TOUCH(dep));
             }
           }
         }

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -481,7 +481,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          let options = !isMouseEvent(dep) && PASSIVE_TOUCH();
+          let options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
           node.addEventListener(dep, this._handleNative, options);
         }
         gd[name] = (gd[name] || 0) + 1;
@@ -515,7 +515,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              let options = !isMouseEvent(dep) && PASSIVE_TOUCH();
+              let options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
               node.removeEventListener(dep, this._handleNative, options);
             }
           }

--- a/test/smoke/passive-gestures.html
+++ b/test/smoke/passive-gestures.html
@@ -40,11 +40,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'x-passive',
       listeners: {
         'down': 'prevent',
-        'move': 'prevent'
+        'move': 'prevent',
+        'up': 'prevent',
+        'tap': 'allowed',
+        'click': 'allowed'
       },
       prevent(e) {
         e.preventDefault();
-        console.log('prevented!');
+        console.log('prevented?: ' + e.type + ' ' + e.defaultPrevented);
+      },
+      allowed(e) {
+        console.log(e.type + ' allowed');
       }
     });
   </script>


### PR DESCRIPTION
`touchend` listeners do not need to be passive to enable more performant
scrolling.

With this change, most of the tradeoffs with enabling
`passiveTouchGestures` disappear, leaving only the inability to control
scrolling from `track`, `down`, and `move` gestures.

Fixes #4961