### PR TITLE
[1.x] Do not set touchend listeners to passive

### DIFF
--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -58,7 +58,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   })();
 
   // decide whether to use {passive: true} for gestures listening for touch events
-  function PASSIVE_TOUCH() {
+  function PASSIVE_TOUCH(eventName) {
+    if (isMouseEvent(eventName) || eventName === 'touchend') {
+      return;
+    }
     if (HAS_NATIVE_TA && SUPPORTS_PASSIVE && Polymer.Settings.passiveTouchGestures) {
       return {passive: true};
     }
@@ -349,8 +352,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          var options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
-          node.addEventListener(dep, this.handleNative, options);
+          node.addEventListener(dep, this.handleNative, PASSIVE_TOUCH(dep));
         }
         gd[name] = (gd[name] || 0) + 1;
         gd._count = (gd._count || 0) + 1;
@@ -377,8 +379,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              var options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
-              node.removeEventListener(dep, this.handleNative, options);
+              node.removeEventListener(dep, this.handleNative, PASSIVE_TOUCH(dep));
             }
           }
         }

--- a/src/standard/gestures.html
+++ b/src/standard/gestures.html
@@ -349,7 +349,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           gobj[dep] = gd = {_count: 0};
         }
         if (gd._count === 0) {
-          var options = !isMouseEvent(dep) && PASSIVE_TOUCH();
+          var options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
           node.addEventListener(dep, this.handleNative, options);
         }
         gd[name] = (gd[name] || 0) + 1;
@@ -377,7 +377,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             gd[name] = (gd[name] || 1) - 1;
             gd._count = (gd._count || 1) - 1;
             if (gd._count === 0) {
-              var options = !isMouseEvent(dep) && PASSIVE_TOUCH();
+              var options = !isMouseEvent(dep) && dep !== 'touchend' && PASSIVE_TOUCH();
               node.removeEventListener(dep, this.handleNative, options);
             }
           }

--- a/test/smoke/passive-gestures.html
+++ b/test/smoke/passive-gestures.html
@@ -40,11 +40,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'x-passive',
       listeners: {
         'down': 'prevent',
-        'move': 'prevent'
+        'move': 'prevent',
+        'up': 'prevent',
+        'tap': 'allowed',
+        'click': 'allowed'
       },
       prevent: function(e) {
         e.preventDefault();
-        console.log('prevented!');
+        console.log('prevented?: ' + e.type + ' ' + e.defaultPrevented);
+      },
+      allowed: function(e) {
+        console.log(e.type + ' allowed');
       }
     });
   </script>


### PR DESCRIPTION
`touchend` listeners do not need to be passive to enable more performant
scrolling.

With this change, most of the tradeoffs with enabling
`passiveTouchGestures` disappear, leaving only the inability to control
scrolling from `track`, `down`, and `move` gestures.

1.x port of #4962

Related to #4961 