### PR TITLE
Add example for flattened-nodes-observer

### DIFF
--- a/lib/utils/flattened-nodes-observer.html
+++ b/lib/utils/flattened-nodes-observer.html
@@ -44,6 +44,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * `MutationObserver` and the `<slot>` element's `slotchange` event which
    * are asynchronous.
    *
+   * An example:
+   * ```js
+   * class TestSelfObserve extends Polymer.Element {
+   *   static get is() { return 'test-self-observe';}
+   *   connectedCallback() {
+   *     super.connectedCallback();
+   *     this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
+   *       this.info = info;
+   *     });
+   *   }
+   *   disconnectedCallback() {
+   *     super.disconnectedCallback();
+   *     this._observer.disconnect();
+   *   }
+   * }
+   * customElements.define(TestSelfObserve.is, TestSelfObserve);
+   * ```
+   *
    * @memberof Polymer
    * @summary Class that listens for changes (additions or removals) to
    * "flattened nodes" on a given `node`.


### PR DESCRIPTION
Add the example from the test suite in the docs. I was not able to figure out how to locally serve the docs, but this should be the correct notation.
### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #4872