### PR TITLE
change PolymerElement extern to var

### DIFF
--- a/externs/polymer-externs.js
+++ b/externs/polymer-externs.js
@@ -96,9 +96,10 @@ PolymerTelemetry.dumpRegistrations;;
 /** @type {PolymerTelemetry} */
 Polymer.telemetry;
 
+// nb. This is explicitly 'var', as Closure Compiler checks that this is the case.
 /**
  * @constructor
  * @extends {HTMLElement}
  * @implements {Polymer_LegacyElementMixin}
  */
-let PolymerElement = Polymer.LegacyElementMixin();
+var PolymerElement = Polymer.LegacyElementMixin();


### PR DESCRIPTION
Right now, the [Polymer Pass](https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PolymerPassFindExterns.java#L63) expects to find `var` here—so the Polymer pass fails with these externs as it cannot identify them.