### PR TITLE
Select <style> more strictly

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -417,7 +417,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function processElementStyles(klass, template, is, baseURI) {
       const styles = Polymer.StyleGather.stylesFromModuleImports(is).concat(
         Polymer.StyleGather.stylesFromTemplate(template));
-      let templateStyles = template.content.querySelectorAll('style');
+      let templateStyles = template.content.querySelectorAll(':scope > style');
       let lastStyle = templateStyles[templateStyles.length-1];
       // ensure all gathered styles are actually in this template.
       for (let i=0; i < styles.length; i++) {


### PR DESCRIPTION
Select only direct children because you need to be able to user "insertBefore" later

Fixes #4975

ToDo:
- [ ] confirm x-browser (`:scope` might not be the answer because of that)
- [ ] add tests