### PR TITLE
Handle styles that are not direct children of templates correctly

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -417,18 +417,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function processElementStyles(klass, template, is, baseURI) {
       const styles = Polymer.StyleGather.stylesFromModuleImports(is).concat(
         Polymer.StyleGather.stylesFromTemplate(template));
-      const templateStyles = Array.from(template.content.querySelectorAll('style'));
+      const templateStyles = template.content.querySelectorAll('style');
       // keep track of the last "concrete" style in the template we have encountered
       let templateStyleIndex = 0;
       // ensure all gathered styles are actually in this template.
       for (let i=0; i < styles.length; i++) {
         let s = styles[i];
+        let templateStyle = templateStyles[templateStyleIndex];
         // if the style is not in this template, it's been "included" and
         // we put a clone of it in the template before the style that included it
-        if (templateStyles.indexOf(s) === -1) {
+        if (templateStyle !== s) {
           s = s.cloneNode(true);
-          let importingTemplateStyle = templateStyles[templateStyleIndex];
-          importingTemplateStyle.parentNode.insertBefore(s, importingTemplateStyle);
+          templateStyle.parentNode.insertBefore(s, templateStyle);
         } else {
           templateStyleIndex++;
         }

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -417,16 +417,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function processElementStyles(klass, template, is, baseURI) {
       const styles = Polymer.StyleGather.stylesFromModuleImports(is).concat(
         Polymer.StyleGather.stylesFromTemplate(template));
-      let templateStyles = template.content.querySelectorAll('style');
-      let lastStyle = templateStyles[templateStyles.length-1];
+      const templateStyles = Array.from(template.content.querySelectorAll('style'));
+      // keep track of the last "concrete" style in the template we have encountered
+      let templateStyleIndex = 0;
       // ensure all gathered styles are actually in this template.
       for (let i=0; i < styles.length; i++) {
         let s = styles[i];
         // if the style is not in this template, it's been "included" and
-        // we put a clone of it in the template.
-        if (s.getRootNode() != template.content) {
+        // we put a clone of it in the template before the style that included it
+        if (templateStyles.indexOf(s) === -1) {
           s = s.cloneNode(true);
-          template.content.insertBefore(s, lastStyle);
+          let importingTemplateStyle = templateStyles[templateStyleIndex];
+          importingTemplateStyle.parentNode.insertBefore(s, importingTemplateStyle);
+        } else {
+          templateStyleIndex++;
         }
         s.textContent = klass._processStyleText(s.textContent, baseURI);
       }

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -660,10 +660,20 @@ HTMLImports.whenReady(function() {
   </x-specificity-parent>
   <x-overriding></x-overriding>
 
+  <dom-module id="nested-shared-style">
+    <template>
+      <style>
+        :host {
+          padding-top: 10px;
+        }
+      </style>
+    </template>
+  </dom-module>
+
   <dom-module id="x-nested-style">
     <template>
       <div id="container">
-        <style include="shared-style">
+        <style include="nested-shared-style">
           :host {
             display: block;
             border: 10px solid black;
@@ -675,10 +685,6 @@ HTMLImports.whenReady(function() {
       addEventListener('WebComponentsReady', () => {
         class XNestedStyle extends Polymer.Element {
           static get is() {return 'x-nested-style';}
-          ready() {
-            super.ready();
-            this.classList.add('x-shared1');
-          }
         }
         customElements.define(XNestedStyle.is, XNestedStyle);
       });
@@ -946,7 +952,7 @@ HTMLImports.whenReady(function() {
       var e = document.createElement('x-nested-style');
       document.body.appendChild(e);
       assertComputed(e, '10px');
-      assertComputed(e, '10px', 'top');
+      assertComputed(e, '10px', 'padding-top');
     });
 
   });

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -660,6 +660,31 @@ HTMLImports.whenReady(function() {
   </x-specificity-parent>
   <x-overriding></x-overriding>
 
+  <dom-module id="x-nested-style">
+    <template>
+      <div id="container">
+        <style include="shared-style">
+          :host {
+            display: block;
+            border: 10px solid black;
+          }
+        </style>
+      </div>
+    </template>
+    <script>
+      addEventListener('WebComponentsReady', () => {
+        class XNestedStyle extends Polymer.Element {
+          static get is() {return 'x-nested-style';}
+          ready() {
+            super.ready();
+            this.classList.add('x-shared1');
+          }
+        }
+        customElements.define(XNestedStyle.is, XNestedStyle);
+      });
+    </script>
+  </dom-module>
+
 <script>
 (function() {
   function assertComputed(element, value, property, pseudo) {
@@ -915,6 +940,13 @@ HTMLImports.whenReady(function() {
       var e = document.createElement('x-template-string');
       document.body.appendChild(e);
       assertComputed(e, '1px');
+    });
+
+    test('styles work correctly when not direct children of the template', function() {
+      var e = document.createElement('x-nested-style');
+      document.body.appendChild(e);
+      assertComputed(e, '10px');
+      assertComputed(e, '10px', 'top');
     });
 
   });

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -691,6 +691,30 @@ HTMLImports.whenReady(function() {
     </script>
   </dom-module>
 
+  <dom-module id="x-interleaved-styles">
+    <template>
+      <style include="x-nested-style"></style>
+      <style>
+        :host {
+          padding-top: 5px;
+        }
+      </style>
+      <style>
+        :host {
+          color: blue;
+        }
+      </style>
+    </template>
+    <script>
+      addEventListener('WebComponentsReady', () => {
+        class XInterleaved extends Polymer.Element {
+          static get is() {return 'x-interleaved-styles';}
+        }
+        customElements.define(XInterleaved.is, XInterleaved);
+      });
+    </script>
+  </dom-module>
+
 <script>
 (function() {
   function assertComputed(element, value, property, pseudo) {
@@ -953,6 +977,12 @@ HTMLImports.whenReady(function() {
       document.body.appendChild(e);
       assertComputed(e, '10px');
       assertComputed(e, '10px', 'padding-top');
+    });
+
+    test('interleaved styles and styles with includes work as expected', function() {
+      var e = document.createElement('x-interleaved-styles');
+      document.body.appendChild(e);
+      assertComputed(e, '5px', 'padding-top');
     });
 
   });


### PR DESCRIPTION
Find the correct spot to add "included" styles in the template by
keeping track of which "concrete" style in the template we have
encountered and inserting the "included" styles before them.

Fixes #4975