### PR TITLE
Apply `listeners` in constructor rather than `ready`

### DIFF
--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -81,6 +81,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         /** @type {Object<string, Function>} */
         this._debouncers;
         this.created();
+        // Ensure listeners are applied immediately so that they are
+        // added before declarative event listeners. This allows an element to
+        // decorate itself via an event prior to any declarative listeners
+        // seeing the event. Note, this ensures compatibility with 1.x ordering.
+        this._applyListeners();
       }
 
       /**
@@ -180,7 +185,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       ready() {
         this._ensureAttributes();
-        this._applyListeners();
         super.ready();
       }
 

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -580,7 +580,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     setTouchAction: function(node, value) {
       if (HAS_NATIVE_TA) {
         // NOTE: add touchAction async so that events can be added in
-        // custom element constructors. Otherwise we run afoult of custom
+        // custom element constructors. Otherwise we run afoul of custom
         // elements restriction against settings attributes (style) in the
         // constructor.
         Polymer.Async.microTask.run(() => {

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -579,7 +579,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     setTouchAction: function(node, value) {
       if (HAS_NATIVE_TA) {
-        node.style.touchAction = value;
+        // NOTE: add touchAction async so that events can be added in
+        // custom element constructors. Otherwise we run afoult of custom
+        // elements restriction against settings attributes (style) in the
+        // constructor.
+        Polymer.Async.microTask.run(() => {
+          node.style.touchAction = value;
+        });
       }
       node[TOUCH_ACTION] = value;
     },

--- a/test/unit/events-elements.html
+++ b/test/unit/events-elements.html
@@ -17,6 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._removed = [];
     },
     handle: function(e) {
+      const order = e._handleOrder = e._handleOrder || [];
+      order.push(this.localName);
       this._handled[e.currentTarget.localName] = e.type;
     },
     unlisten: function(node, eventName, handler) {
@@ -50,6 +52,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 </dom-module>
+
+<dom-module id="x-order">
+    <template>
+      <x-listeners id="inner" on-foo="handle"></x-listeners>
+    </template>
+    <script>
+      Polymer({
+        is: 'x-order',
+        behaviors: [EventLoggerImpl]
+      });
+    </script>
+  </dom-module>
 
 <dom-module id="x-dynamic">
   <template>

--- a/test/unit/events.html
+++ b/test/unit/events.html
@@ -78,6 +78,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
+      suite('listeners + on-*', function() {
+        suiteSetup(function() {
+          el = document.createElement('x-order');
+          document.body.appendChild(el);
+        });
+
+        suiteTeardown(function() {
+          document.body.removeChild(el);
+        });
+
+        test('listeners handled before on-* events', function() {
+          const e = el.$.inner.fire('foo', {});
+          assert.deepEqual(e._handleOrder, ['x-listeners', 'x-order']);
+        });
+
+      });
+
       suite('dynamic', function() {
 
         var options;


### PR DESCRIPTION
Fixes #4394. This change allows elements to have "first crack" at their own events (via the `listeners` object) before handlers registered via `on-*` see events. This is both more expected and fixes an inconsistency with 1.x.
