### PR TITLE
FlattenedNodesObserver: do not fail on node without children

### DIFF
--- a/lib/utils/flattened-nodes-observer.html
+++ b/lib/utils/flattened-nodes-observer.html
@@ -130,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     connect() {
       if (isSlot(this._target)) {
         this._listenSlots([this._target]);
-      } else {
+      } else if (this._target.children) {
         this._listenSlots(this._target.children);
         if (window.ShadyDOM) {
           this._shadyChildrenObserver =
@@ -159,7 +159,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     disconnect() {
       if (isSlot(this._target)) {
         this._unlistenSlots([this._target]);
-      } else {
+      } else if (this._target.children) {
         this._unlistenSlots(this._target.children);
         if (window.ShadyDOM && this._shadyChildrenObserver) {
           ShadyDOM.unobserveChildren(this._shadyChildrenObserver);

--- a/test/unit/flattened-nodes-observer.html
+++ b/test/unit/flattened-nodes-observer.html
@@ -1039,6 +1039,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       document.body.removeChild(host);
     });
 
+    test('should not fail on node without children', function() {
+      var recorded;
+      var el = document;
+      var observer = new Polymer.FlattenedNodesObserver(el, function(info) {
+        recorded = info;
+      });
+      assert.equal(recorded, null);
+      observer.disconnect();
+    });
+
   });
 
 </script>


### PR DESCRIPTION
### Reference Issue
Fixes #4987

### Description
Document doesn't have children in IE:
![](https://i.imgur.com/S1OVerF.png)

For comparison, Chrome:
![](https://i.imgur.com/rFlYlGT.png)