### PR TITLE
Tighten Closure type annotations.

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -1145,7 +1145,7 @@ Polymer_LegacyElementMixin.prototype.flushDebouncer = function(jobName){};
 */
 Polymer_LegacyElementMixin.prototype.cancelDebouncer = function(jobName){};
 /**
-* @param {Function} callback The callback function to run, bound to `this`.
+* @param {!Function} callback The callback function to run, bound to `this`.
 * @param {number=} waitTime Time to wait before calling the
   `callback`.  If unspecified or 0, the callback will be run at microtask
   timing (before paint).
@@ -1167,18 +1167,18 @@ Polymer_LegacyElementMixin.prototype.cancelAsync = function(handle){};
 Polymer_LegacyElementMixin.prototype.create = function(tag, props){};
 /**
 * @param {string} href URL to document to load.
-* @param {Function} onload Callback to notify when an import successfully
+* @param {!Function=} onload Callback to notify when an import successfully
   loaded.
-* @param {Function} onerror Callback to notify when an import
+* @param {!Function=} onerror Callback to notify when an import
   unsuccessfully loaded.
-* @param {boolean} optAsync True if the import should be loaded `async`.
+* @param {boolean=} optAsync True if the import should be loaded `async`.
   Defaults to `false`.
 * @return {HTMLLinkElement}
 */
 Polymer_LegacyElementMixin.prototype.importHref = function(href, onload, onerror, optAsync){};
 /**
 * @param {string} selector Selector to test.
-* @param {Element=} node Element to test the selector against.
+* @param {!Element=} node Element to test the selector against.
 * @return {boolean}
 */
 Polymer_LegacyElementMixin.prototype.elementMatches = function(selector, node){};

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -211,7 +211,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Clears the selection state.
-       *
+       * @returns {void}
        */
       clearSelection() {
         // Unbind previous selection

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -211,7 +211,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Clears the selection state.
-       * @returns {void}
+       * @return {void}
        */
       clearSelection() {
         // Unbind previous selection

--- a/lib/elements/dom-bind.html
+++ b/lib/elements/dom-bind.html
@@ -61,16 +61,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__children = null;
       }
 
-      // assumes only one observed attribute
+      /** @returns {void} */
       attributeChangedCallback() {
+        // assumes only one observed attribute
         this.mutableData = true;
       }
 
+      /** @returns {void} */
       connectedCallback() {
         this.style.display = 'none';
         this.render();
       }
 
+      /** @returns {void} */
       disconnectedCallback() {
         this.__removeChildren();
       }

--- a/lib/elements/dom-bind.html
+++ b/lib/elements/dom-bind.html
@@ -61,19 +61,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.__children = null;
       }
 
-      /** @returns {void} */
+      /** @return {void} */
       attributeChangedCallback() {
         // assumes only one observed attribute
         this.mutableData = true;
       }
 
-      /** @returns {void} */
+      /** @return {void} */
       connectedCallback() {
         this.style.display = 'none';
         this.render();
       }
 
-      /** @returns {void} */
+      /** @return {void} */
       disconnectedCallback() {
         this.__removeChildren();
       }

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -75,8 +75,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     /**
-     * @param {string} name
-     * @returns {void}
+     * @param {string} name Name of attribute.
+     * @param {?string} old Old value of attribute.
+     * @param {?string} value Current value of attribute.
+     * @return {void}
      */
     attributeChangedCallback(name, old, value) {
       if (old !== value) {

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -74,6 +74,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return null;
     }
 
+    /**
+     * @param {string} name
+     * @returns {void}
+     */
     attributeChangedCallback(name, old, value) {
       if (old !== value) {
         this.register();

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -134,6 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} name Name of attribute.
        * @param {?string} old Old value of attribute.
        * @param {?string} value Current value of attribute.
+       * @returns {void}
        * @override
        */
       attributeChangedCallback(name, old, value) {
@@ -487,7 +488,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * childNodes list is the same as the element's childNodes except that
        * any `<content>` elements are replaced with the list of nodes distributed
        * to the `<content>`, the result of its `getDistributedNodes` method.
-       * @return {Array<Node>} List of effective child nodes.
+       * @return {!Array<!Node>} List of effective child nodes.
        * @suppress {invalidCasts} LegacyElementMixin must be applied to an HTMLElement
        */
       getEffectiveChildNodes() {
@@ -501,7 +502,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `selector`. These can be dom children or elements distributed to
        * children that are insertion points.
        * @param {string} selector Selector to run.
-       * @return {Array<Node>} List of distributed elements that match selector.
+       * @return {!Array<!Node>} List of distributed elements that match selector.
        * @suppress {invalidCasts} LegacyElementMixin must be applied to an HTMLElement
        */
       queryDistributedElements(selector) {
@@ -516,11 +517,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * any `<content>` elements are replaced with the list of elements
        * distributed to the `<content>`.
        *
-       * @return {Array<Node>} List of effective children.
+       * @return {!Array<!Node>} List of effective children.
        */
       getEffectiveChildren() {
         let list = this.getEffectiveChildNodes();
-        return list.filter(function(/** @type {Node} */ n) {
+        return list.filter(function(/** @type {!Node} */ n) {
           return (n.nodeType === Node.ELEMENT_NODE);
         });
       }
@@ -560,7 +561,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * match `selector`. These can be dom child nodes or elements distributed
        * to children that are insertion points.
        * @param {string} selector Selector to run.
-       * @return {Array<Node>} List of effective child nodes that match selector.
+       * @return {!Array<!Node>} List of effective child nodes that match selector.
        */
       queryAllEffectiveChildren(selector) {
         return this.queryDistributedElements(selector);
@@ -574,7 +575,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {string=} slctr CSS selector to choose the desired
        *   `<slot>`.  Defaults to `content`.
-       * @return {Array<Node>} List of distributed nodes for the `<slot>`.
+       * @return {!Array<!Node>} List of distributed nodes for the `<slot>`.
        */
       getContentChildNodes(slctr) {
         let content = this.root.querySelector(slctr || 'slot');
@@ -592,12 +593,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {string=} slctr CSS selector to choose the desired
        *   `<content>`.  Defaults to `content`.
-       * @return {Array<HTMLElement>} List of distributed nodes for the
+       * @return {!Array<!HTMLElement>} List of distributed nodes for the
        *   `<slot>`.
        * @suppress {invalidCasts}
        */
       getContentChildren(slctr) {
-        let children = /** @type {Array<HTMLElement>} */(this.getContentChildNodes(slctr).filter(function(n) {
+        let children = /** @type {!Array<!HTMLElement>} */(this.getContentChildNodes(slctr).filter(function(n) {
           return (n.nodeType === Node.ELEMENT_NODE);
         }));
         return children;
@@ -657,7 +658,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *     }
        *
        * @param {string} jobName String to identify the debounce job.
-       * @param {function()} callback Function that is called (with `this`
+       * @param {function():void} callback Function that is called (with `this`
        *   context) when the wait time elapses.
        * @param {number} wait Optional wait time in milliseconds (ms) after the
        *   last signal that must elapse before invoking `callback`
@@ -721,7 +722,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * By default (if no waitTime is specified), async callbacks are run at
        * microtask timing, which will occur before paint.
        *
-       * @param {Function} callback The callback function to run, bound to `this`.
+       * @param {!Function} callback The callback function to run, bound to `this`.
        * @param {number=} waitTime Time to wait before calling the
        *   `callback`.  If unspecified or 0, the callback will be run at microtask
        *   timing (before paint).
@@ -777,13 +778,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * element will contain the imported document contents.
        *
        * @param {string} href URL to document to load.
-       * @param {Function} onload Callback to notify when an import successfully
+       * @param {!Function=} onload Callback to notify when an import successfully
        *   loaded.
-       * @param {Function} onerror Callback to notify when an import
+       * @param {!Function=} onerror Callback to notify when an import
        *   unsuccessfully loaded.
-       * @param {boolean} optAsync True if the import should be loaded `async`.
+       * @param {boolean=} optAsync True if the import should be loaded `async`.
        *   Defaults to `false`.
-       * @return {HTMLLinkElement} The link element for the URL to be loaded.
+       * @return {!HTMLLinkElement} The link element for the URL to be loaded.
        */
       importHref(href, onload, onerror, optAsync) { // eslint-disable-line no-unused-vars
         let loadFn = onload ? onload.bind(this) : null;
@@ -796,7 +797,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * prefixed.
        *
        * @param {string} selector Selector to test.
-       * @param {Element=} node Element to test the selector against.
+       * @param {!Element=} node Element to test the selector against.
        * @return {boolean} Whether the element matches the selector.
        */
       elementMatches(selector, node) {

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -134,7 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} name Name of attribute.
        * @param {?string} old Old value of attribute.
        * @param {?string} value Current value of attribute.
-       * @returns {void}
+       * @return {void}
        * @override
        */
       attributeChangedCallback(name, old, value) {

--- a/lib/legacy/polymer-fn.html
+++ b/lib/legacy/polymer-fn.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @function Polymer
      * @param {!PolymerInit} info Object containing Polymer metadata and functions
      *   to become class methods.
-     * @return {!HTMLElement} Generated class
+     * @return {function(new: HTMLElement)} Generated class
      * @suppress {duplicate, invalidCasts, checkTypes}
      */
     window.Polymer._polymerFn = function(info) {

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   const p = Element.prototype;
   /**
-   * @const {function(this:Element, string): boolean}
+   * @const {function(this:Node, string): boolean}
    */
   const normalizedMatchesSelector = p.matches || p.matchesSelector ||
     p.mozMatchesSelector || p.msMatchesSelector ||
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @function matchesSelector
    * @memberof Polymer.dom
-   * @param {!Element} node Node to check selector against
+   * @param {!Node} node Node to check selector against
    * @param {string} selector Selector to match
    * @return {boolean} True if node matched selector
    */
@@ -157,8 +157,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     /**
-     * @return {Array} Returns a flattened list of all child nodes and nodes assigned
-     * to child slots.
+     * @return {!Array<!Node>} Returns a flattened list of all child nodes and
+     * nodes assigned to child slots.
      */
     getEffectiveChildNodes() {
       return Polymer.FlattenedNodesObserver.getFlattenedNodes(this.node);

--- a/lib/utils/async.html
+++ b/lib/utils/async.html
@@ -80,7 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @function
        * @memberof Polymer.Async.timeOut
-       * @param {Function} fn Callback to run
+       * @param {!Function} fn Callback to run
        * @param {number=} delay Delay in milliseconds
        * @return {number} Handle used for canceling task
        */
@@ -145,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Enqueues a function called at `requestIdleCallback` timing.
        *
        * @memberof Polymer.Async.idlePeriod
-       * @param {function(IdleDeadline)} fn Callback to run
+       * @param {function(!IdleDeadline):void} fn Callback to run
        * @return {number} Handle used for canceling task
        */
       run(fn) {
@@ -187,7 +187,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Enqueues a function called at microtask timing.
        *
        * @memberof Polymer.Async.microTask
-       * @param {Function} callback Callback to run
+       * @param {!Function=} callback Callback to run
        * @return {number} Handle used for canceling task
        */
       run(callback) {

--- a/lib/utils/flattened-nodes-observer.html
+++ b/lib/utils/flattened-nodes-observer.html
@@ -102,9 +102,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * or removals from the target's list of flattened nodes.
     */
     constructor(target, callback) {
-      /** @type {MutationObserver} */
+      /**
+       * @type {MutationObserver}
+       * @private
+       */
       this._shadyChildrenObserver = null;
-      /** @type {MutationObserver} */
+      /**
+       * @type {MutationObserver}
+       * @private
+       */
       this._nativeChildrenObserver = null;
       this._connected = false;
       this._target = target;
@@ -112,7 +118,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._effectiveNodes = [];
       this._observer = null;
       this._scheduled = false;
-      /** @type {function()} */
+      /**
+       * @type {function()}
+       * @private
+       */
       this._boundSchedule = () => {
         this._schedule();
       };

--- a/lib/utils/flush.html
+++ b/lib/utils/flush.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Adds a `Polymer.Debouncer` to a list of globally flushable tasks.
    *
    * @memberof Polymer
-   * @param {Polymer.Debouncer} debouncer Debouncer to enqueue
+   * @param {!Polymer.Debouncer} debouncer Debouncer to enqueue
    * @return {void}
    */
   Polymer.enqueueDebouncer = function(debouncer) {

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -427,9 +427,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Adds an event listener to a node for the given gesture type.
      *
      * @memberof Polymer.Gestures
-     * @param {Node} node Node to add listener on
+     * @param {!Node} node Node to add listener on
      * @param {string} evType Gesture type: `down`, `up`, `track`, or `tap`
-     * @param {Function} handler Event listener function to call
+     * @param {!Function} handler Event listener function to call
      * @return {boolean} Returns true if a gesture event listener was added.
      * @this {Gestures}
      */
@@ -445,9 +445,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Removes an event listener from a node for the given gesture type.
      *
      * @memberof Polymer.Gestures
-     * @param {Node} node Node to remove listener from
+     * @param {!Node} node Node to remove listener from
      * @param {string} evType Gesture type: `down`, `up`, `track`, or `tap`
-     * @param {Function} handler Event listener function previously passed to
+     * @param {!Function} handler Event listener function previously passed to
      *  `addListener`.
      * @return {boolean} Returns true if a gesture event listener was removed.
      * @this {Gestures}
@@ -464,7 +464,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * automate the event listeners for the native events
      *
      * @private
-     * @param {HTMLElement} node Node on which to add the event.
+     * @param {!HTMLElement} node Node on which to add the event.
      * @param {string} evType Event type to add.
      * @param {function(Event?)} handler Event handler function.
      * @return {void}
@@ -504,7 +504,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * automate event listener removal for native events
      *
      * @private
-     * @param {HTMLElement} node Node on which to remove the event.
+     * @param {!HTMLElement} node Node on which to remove the event.
      * @param {string} evType Event type to remove.
      * @param {function(Event?)} handler Event handler function.
      * @return {void}
@@ -536,7 +536,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * gesture event types.
      *
      * @memberof Polymer.Gestures
-     * @param {GestureRecognizer} recog Gesture recognizer descriptor
+     * @param {!GestureRecognizer} recog Gesture recognizer descriptor
      * @return {void}
      * @this {Gestures}
      */
@@ -573,7 +573,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * adding event listeners.
      *
      * @memberof Polymer.Gestures
-     * @param {Element} node Node to set touch action setting on
+     * @param {!Element} node Node to set touch action setting on
      * @param {string} value Touch action value
      * @return {void}
      */
@@ -594,9 +594,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Dispatches an event on the `target` element of `type` with the given
      * `detail`.
      * @private
-     * @param {EventTarget} target The element on which to fire an event.
+     * @param {!EventTarget} target The element on which to fire an event.
      * @param {string} type The type of event to fire.
-     * @param {Object=} detail The detail object to populate on the event.
+     * @param {!Object=} detail The detail object to populate on the event.
      * @return {void}
      */
     _fire: function(target, type, detail) {
@@ -712,7 +712,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
     /**
      * @param {string} type
-     * @param {EventTarget} target
+     * @param {!EventTarget} target
      * @param {Event} event
      * @param {Function} preventer
      * @return {void}
@@ -881,7 +881,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * @this {GestureRecognizer}
-     * @param {EventTarget} target
+     * @param {!EventTarget} target
      * @param {Touch} touch
      * @return {void}
      */
@@ -990,6 +990,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let dy = Math.abs(e.clientY - this.info.y);
       // find original target from `preventer` for TouchEvents, or `e` for MouseEvents
       let t = Gestures._findOriginalTarget(/** @type {Event} */(preventer || e));
+      if (!t) {
+        return;
+      }
       // dx,dy can be NaN if `click` has been simulated and there was no `down` for `start`
       if (isNaN(dx) || isNaN(dy) || (dx <= TAP_DISTANCE && dy <= TAP_DISTANCE) || isSyntheticClick(e)) {
         // prevent taps from being generated if an event has canceled them

--- a/lib/utils/import-href.html
+++ b/lib/utils/import-href.html
@@ -36,13 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @memberof Polymer
    * @param {string} href URL to document to load.
-   * @param {Function=} onload Callback to notify when an import successfully
+   * @param {!Function=} onload Callback to notify when an import successfully
    *   loaded.
-   * @param {Function=} onerror Callback to notify when an import
+   * @param {!Function=} onerror Callback to notify when an import
    *   unsuccessfully loaded.
    * @param {boolean=} optAsync True if the import should be loaded `async`.
    *   Defaults to `false`.
-   * @return {HTMLLinkElement} The link element for the URL to be loaded.
+   * @return {!HTMLLinkElement} The link element for the URL to be loaded.
    */
   Polymer.importHref = function(href, onload, onerror, optAsync) {
     let link = /** @type {HTMLLinkElement} */

--- a/lib/utils/mixin.html
+++ b/lib/utils/mixin.html
@@ -38,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @memberof Polymer
    * @template T
    * @param {T} mixin ES6 class expression mixin to wrap
+   * @return {T}
    * @suppress {invalidCasts}
    */
   Polymer.dedupingMixin = function(mixin) {
@@ -68,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return extended;
     }
 
-    return dedupingMixin;
+    return /** @type {T} */ (dedupingMixin);
   };
   /* eslint-enable valid-jsdoc */
 

--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -16,11 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   'use strict';
 
-  /**
-   * Legacy settings.
-   * @namespace
-   * @memberof Polymer
-   */
   const settings = Polymer.Settings || {};
   settings.useShadow = !(window.ShadyDOM);
   settings.useNativeCSSProperties =
@@ -32,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Sets the global, legacy settings.
    *
    * @deprecated
+   * @namespace
    * @memberof Polymer
    */
   Polymer.Settings = settings;

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -257,6 +257,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * @constructor
        * @extends {base}
+       * @private
        */
       let klass = class extends base { };
       klass.prototype.__templatizeOptions = options;
@@ -464,6 +465,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Host property forwarding must be installed onto template instance
         addPropagateEffects(template, templateInfo, options);
         // Subclass base class and add reference for this specific template
+        /** @private */
         let klass = class TemplateInstance extends baseClass {};
         klass.prototype._methodHost = findMethodHost(template);
         klass.prototype.__dataHost = template;


### PR DESCRIPTION
I pulled these changes out of https://github.com/Polymer/polymer/pull/4928. These are various changes to the Polymer core JSDoc annotations that improve the generated TypeScript declarations.

- Adds various `!` non-nullable operators. In Closure, all non-primitive types are non-nullable (we should try to use non-nullable types by default going forward if possible).
- Marked some things `@private` that are not part of our public API.
- Added `@return {void}` to some functions that don't return anything.
- A few other signature changes.

`gulp closure` produces no warnings