### PR TITLE
[WIP] Initial attempt at `this.unset`

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1845,6 +1845,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
+      unset(path, root) {
+        let old = Polymer.Path.get(this, path);
+        let prop = root || this;
+        let parts = Polymer.Path.split(path);
+        // Loop over path parts[0..n-1] and dereference
+        for (let i=0; i<parts.length - 1; i++) {
+          if (!prop) {
+            return;
+          }
+          let part = parts[i];
+          prop = prop[part];
+        }
+        let changed = this._shouldPropertyChange(path, undefined, old);
+        if (changed) {
+          this.__dataPending = this.__dataPending || {};
+          this.__dataPending[path] = undefined;
+          this.__dataHasPaths = true;
+
+          delete prop[parts[parts.length - 1]];
+          this._flushProperties();
+        }
+        return changed;
+      }
+
       /**
        * Adds items onto the end of the array at the path specified.
        *

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -319,6 +319,21 @@ suite('basic path bindings', function() {
     assert.equal(el.$.compose.$.basic1.othervalue, 98);
   });
 
+  test('similarly named properties', function() {
+    var nested = {
+      obj: {
+        value: 41,
+        value2: 99
+      }
+    };
+    el.nested = nested;
+    assert.equal(el.$.compose.$.basic1.notifyingValue, 41);
+    assert.equal(el.$.compose.$.basic1.othervalue, 99);
+    el.unset('nested.obj.value');
+    assert.equal(el.computed, '[undefined]');
+    assert.equal(el.$.compose.$.basic1.notifyingValue, undefined);
+  });
+
 });
 
 suite('path effects', function() {


### PR DESCRIPTION
This is an attempt at issue #2565. The current solution does work, however template propagation does not. E.g. in `<x-stuff>` in the test, all values are correct, excepted for `<x-compose>`. The reason being that `_propagatePropertyChanges` calls all template effects, which in turn call `_shouldPropertyChange`. However, since `delete` already removed the object (it is passed by reference), this function will compare `undefined` to `undefined` and stop working. This means that any composed element will not correctly flush.

We can not move the `delete` call after `flushProperties`, because that will not pass the `_shouldPropertyChange` in the host element.

All feedback is welcome on how to fix this. Random thoughts I had thus far:
1. Use a special value to "force" the property change and then delete after. Symbol (?). However, this will not work when running computed effects.
2. Set to `undefined` first, somehow trigger the `_shouldPropertyChange` and then delete afterwards. Essentially the same problem as (1.), but now that computed will work, but composed are not triggered as we have to set the field to a value other than `undefined`.

Lastly, as you can see a there is quite a bit of duplication copied from other methods. This was necessary, as most of the methods did both the check and assignment, whereas we now only needed the checks.

### Reference Issue
Fixes #2565
