### PR TITLE
add void return type annotations

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -234,7 +234,7 @@ Polymer_TemplateStamp.prototype._addEventListenerToNode = function(node, eventNa
 /**
 * @param {Node} node Node to remove event listener from
 * @param {string} eventName Name of event
-* @param {Function} handler Listener function to remove
+* @param {function (!Event): void} handler Listener function to remove
 * @return {void}
 */
 Polymer_TemplateStamp.prototype._removeEventListenerFromNode = function(node, eventName, handler){};
@@ -896,7 +896,7 @@ Polymer_GestureEventListeners.prototype._addEventListenerToNode = function(node,
 /**
 * @param {!Node} node Node to remove event listener from
 * @param {string} eventName Name of event
-* @param {Function} handler Listener function to remove
+* @param {function (!Event): void} handler Listener function to remove
 * @return {void}
 */
 Polymer_GestureEventListeners.prototype._removeEventListenerFromNode = function(node, eventName, handler){};

--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -227,7 +227,7 @@ Polymer_TemplateStamp.prototype._addMethodEventListenerToNode = function(node, e
 /**
 * @param {!Node} node Node to add event listener to
 * @param {string} eventName Name of event
-* @param {Function} handler Listener function to add
+* @param {function (!Event): void} handler Listener function to add
 * @return {void}
 */
 Polymer_TemplateStamp.prototype._addEventListenerToNode = function(node, eventName, handler){};
@@ -472,7 +472,7 @@ Polymer_PropertyEffects.prototype._hasComputedEffect = function(property){};
 */
 Polymer_PropertyEffects.prototype._setPendingPropertyOrPath = function(path, value, shouldNotify, isPathNotification){};
 /**
-* @param {Node} node The node to set a property on
+* @param {!Node} node The node to set a property on
 * @param {string} prop The property to set
 * @param {*} value The value to set
 * @return {void}
@@ -889,7 +889,7 @@ function Polymer_GestureEventListeners(){}
 /**
 * @param {!Node} node Node to add event listener to
 * @param {string} eventName Name of event
-* @param {Function} handler Listener function to add
+* @param {function (!Event): void} handler Listener function to add
 * @return {void}
 */
 Polymer_GestureEventListeners.prototype._addEventListenerToNode = function(node, eventName, handler){};

--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -129,7 +129,8 @@ Polymer_PropertiesChanged.prototype._serializeValue = function(value){};
 */
 Polymer_PropertiesChanged.prototype._deserializeValue = function(value, type){};
 /**
-* @param {Object} props Object whose keys are names of accessors.
+* @param {!Object} props Object whose keys are names of accessors.
+* @return {void}
 */
 Polymer_PropertiesChanged.createProperties = function(props){};
 /**
@@ -637,7 +638,7 @@ Polymer_PropertyEffects.prototype._createReflectedProperty = function(property){
 */
 Polymer_PropertyEffects.prototype._createComputedProperty = function(property, expression, dynamicFn){};
 /**
-* @param {HTMLTemplateElement} template Template containing binding
+* @param {!HTMLTemplateElement} template Template containing binding
   bindings
 * @param {boolean=} instanceBinding When false (default), performs
   "prototypical" binding of the template and overwrites any previously
@@ -726,9 +727,9 @@ Polymer_PropertyEffects.createReflectedProperty = function(property){};
 */
 Polymer_PropertyEffects.createComputedProperty = function(property, expression, dynamicFn){};
 /**
-* @param {HTMLTemplateElement} template Template containing binding
+* @param {!HTMLTemplateElement} template Template containing binding
   bindings
-* @return {Object}
+* @return {!TemplateInfo}
 */
 Polymer_PropertyEffects.bindTemplate = function(template){};
 /**
@@ -779,7 +780,7 @@ Polymer_PropertiesMixin.prototype.disconnectedCallback = function(){};
 */
 Polymer_PropertiesMixin.typeForProperty = function(name){};
 /**
-* @return {undefined}
+* @return {void}
 */
 Polymer_PropertiesMixin.finalize = function(){};
 /**
@@ -1034,9 +1035,9 @@ Polymer_LegacyElementMixin.prototype.serializeValueToAttribute = function(value,
 */
 Polymer_LegacyElementMixin.prototype.extend = function(prototype, api){};
 /**
-* @param {Object} target Target object to copy properties to.
-* @param {Object} source Source object to copy properties from.
-* @return {Object}
+* @param {!Object} target Target object to copy properties to.
+* @param {!Object} source Source object to copy properties from.
+* @return {!Object}
 */
 Polymer_LegacyElementMixin.prototype.mixin = function(target, source){};
 /**
@@ -1048,7 +1049,7 @@ Polymer_LegacyElementMixin.prototype.mixin = function(target, source){};
 Polymer_LegacyElementMixin.prototype.chainObject = function(object, prototype){};
 /**
 * @param {HTMLTemplateElement} template HTML template element to instance.
-* @return {DocumentFragment}
+* @return {!DocumentFragment}
 */
 Polymer_LegacyElementMixin.prototype.instanceTemplate = function(template){};
 /**
@@ -1059,7 +1060,7 @@ Polymer_LegacyElementMixin.prototype.instanceTemplate = function(template){};
  `bubbles` (boolean, defaults to `true`),
  `cancelable` (boolean, defaults to false), and
  `node` on which to fire the event (HTMLElement, defaults to `this`).
-* @return {Event}
+* @return {!Event}
 */
 Polymer_LegacyElementMixin.prototype.fire = function(type, detail, options){};
 /**
@@ -1139,7 +1140,7 @@ Polymer_LegacyElementMixin.prototype.getContentChildren = function(slctr){};
 */
 Polymer_LegacyElementMixin.prototype.isLightDescendant = function(node){};
 /**
-* @param {Element=} node The element to be checked.
+* @param {!Element} node The element to be checked.
 * @return {boolean}
 */
 Polymer_LegacyElementMixin.prototype.isLocalDescendant = function(node){};
@@ -1160,7 +1161,7 @@ Polymer_LegacyElementMixin.prototype.getComputedStyleValue = function(property){
   context) when the wait time elapses.
 * @param {number} wait Optional wait time in milliseconds (ms) after the
   last signal that must elapse before invoking `callback`
-* @return {Object}
+* @return {!Object}
 */
 Polymer_LegacyElementMixin.prototype.debounce = function(jobName, callback, wait){};
 /**
@@ -1194,16 +1195,16 @@ Polymer_LegacyElementMixin.prototype.async = function(callback, waitTime){};
 Polymer_LegacyElementMixin.prototype.cancelAsync = function(handle){};
 /**
 * @param {string} tag HTML element tag to create.
-* @param {Object} props Object of properties to configure on the
+* @param {Object=} props Object of properties to configure on the
    instance.
-* @return {Element}
+* @return {!Element}
 */
 Polymer_LegacyElementMixin.prototype.create = function(tag, props){};
 /**
 * @param {string} href URL to document to load.
-* @param {!Function=} onload Callback to notify when an import successfully
+* @param {?function (!Event): void=} onload Callback to notify when an import successfully
   loaded.
-* @param {!Function=} onerror Callback to notify when an import
+* @param {?function (!ErrorEvent): void=} onerror Callback to notify when an import
   unsuccessfully loaded.
 * @param {boolean=} optAsync True if the import should be loaded `async`.
   Defaults to `false`.

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -674,7 +674,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * `modelForElement(el).set('item.<sub-prop>', value)`
      * should be used.
      *
-     * @param {HTMLElement} el Element for which to return the item.
+     * @param {!HTMLElement} el Element for which to return the item.
      * @return {*} Item associated with the element.
      */
     itemForElement(el) {
@@ -687,8 +687,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * If `sort` is provided, the index will reflect the sorted order (rather
      * than the original array order).
      *
-     * @param {HTMLElement} el Element for which to return the index.
-     * @return {*} Row index associated with the element (note this may
+     * @param {!HTMLElement} el Element for which to return the index.
+     * @return {?number} Row index associated with the element (note this may
      *   not correspond to the array index if a user `sort` is applied).
      */
     indexForElement(el) {
@@ -709,7 +709,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *     model.set('item.checked', true);
      *   }
      *
-     * @param {HTMLElement} el Element for which to return a template model.
+     * @param {!HTMLElement} el Element for which to return a template model.
      * @return {TemplateInstanceBase} Model representing the binding scope for
      *   the element.
      */

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -33,9 +33,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * to ensure that any legacy behaviors can rely on legacy Polymer API on
      * the underlying element.
      *
-     * @param {!(Object|Array)} behaviors Behavior object or array of behaviors.
-     * @param {!HTMLElement|function(new:HTMLElement)} klass Element class.
-     * @return {function(new:HTMLElement)} Returns a new Element class extended by the
+     * @template T
+     * @param {!(PolymerInit|Array<!PolymerInit>)} behaviors Behavior object or array of behaviors.
+     * @param {function(new:T)} klass Element class.
+     * @return {function(new:T)} Returns a new Element class extended by the
      * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
      * @memberof Polymer
      * @suppress {invalidCasts, checkTypes}

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -316,9 +316,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * properties.  To ensure only `ownProperties` are copied from source
        * to target and that accessor implementations are copied, use `extend`.
        *
-       * @param {Object} target Target object to copy properties to.
-       * @param {Object} source Source object to copy properties from.
-       * @return {Object} Target object that was passed as first argument.
+       * @param {!Object} target Target object to copy properties to.
+       * @param {!Object} source Source object to copy properties from.
+       * @return {!Object} Target object that was passed as first argument.
        */
       mixin(target, source) {
         for (let i in source) {
@@ -352,12 +352,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * returns a document fragment containing the imported content.
        *
        * @param {HTMLTemplateElement} template HTML template element to instance.
-       * @return {DocumentFragment} Document fragment containing the imported
+       * @return {!DocumentFragment} Document fragment containing the imported
        *   template content.
       */
       instanceTemplate(template) {
         let content = this.constructor._contentForTemplate(template);
-        let dom = /** @type {DocumentFragment} */
+        let dom = /** @type {!DocumentFragment} */
           (document.importNode(content, true));
         return dom;
       }
@@ -377,7 +377,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *  `bubbles` (boolean, defaults to `true`),
        *  `cancelable` (boolean, defaults to false), and
        *  `node` on which to fire the event (HTMLElement, defaults to `this`).
-       * @return {Event} The new event that was fired.
+       * @return {!Event} The new event that was fired.
        */
       fire(type, detail, options) {
         options = options || {};
@@ -631,7 +631,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Checks whether an element is in this element's local DOM tree.
        *
-       * @param {Element=} node The element to be checked.
+       * @param {!Element} node The element to be checked.
        * @return {boolean} true if node is in this element's local DOM tree.
        */
       isLocalDescendant(node) {
@@ -679,7 +679,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   context) when the wait time elapses.
        * @param {number} wait Optional wait time in milliseconds (ms) after the
        *   last signal that must elapse before invoking `callback`
-       * @return {Object} Returns a debouncer object on which exists the
+       * @return {!Object} Returns a debouncer object on which exists the
        * following methods: `isActive()` returns true if the debouncer is
        * active; `cancel()` cancels the debouncer if it is active;
        * `flush()` immediately invokes the debounced callback if the debouncer
@@ -768,9 +768,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Convenience method for creating an element and configuring it.
        *
        * @param {string} tag HTML element tag to create.
-       * @param {Object} props Object of properties to configure on the
+       * @param {Object=} props Object of properties to configure on the
        *    instance.
-       * @return {Element} Newly created and configured element.
+       * @return {!Element} Newly created and configured element.
        */
       create(tag, props) {
         let elt = document.createElement(tag);
@@ -795,9 +795,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * element will contain the imported document contents.
        *
        * @param {string} href URL to document to load.
-       * @param {!Function=} onload Callback to notify when an import successfully
+       * @param {?function(!Event):void=} onload Callback to notify when an import successfully
        *   loaded.
-       * @param {!Function=} onerror Callback to notify when an import
+       * @param {?function(!ErrorEvent):void=} onerror Callback to notify when an import
        *   unsuccessfully loaded.
        * @param {boolean=} optAsync True if the import should be loaded `async`.
        *   Defaults to `false`.

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -235,23 +235,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
-  /** @type {function(boolean=):Node} */
+  /**
+   * @function
+   * @param {boolean=} deep
+   * @return {!Node}
+   */
   DomApi.prototype.cloneNode;
-  /** @type {function(Node):!Node} */
+  /**
+   * @function
+   * @param {Node} node
+   * @return {!Node}
+   */
   DomApi.prototype.appendChild;
-  /** @type {function(Node, Node):!Node} */
+  /**
+   * @function
+   * @param {Node} newChild
+   * @param {Node} refChild
+   * @return {!Node}
+   */
   DomApi.prototype.insertBefore;
-  /** @type {function(Node):!Node} */
+  /**
+   * @function
+   * @param {Node} node
+   * @return {!Node}
+   */
   DomApi.prototype.removeChild;
-  /** @type {function(Node, Node):!Node} */
+  /**
+   * @function
+   * @param {Node} oldChild
+   * @param {Node} newChild
+   * @return {!Node}
+   */
   DomApi.prototype.replaceChild;
-  /** @type {function(string, (string|number|boolean)):void} */
+  /**
+   * @function
+   * @param {string} name
+   * @param {string} value
+   * @return {void}
+   */
   DomApi.prototype.setAttribute;
-  /** @type {function(string):void} */
+  /**
+   * @function
+   * @param {string} name
+   * @return {void}
+   */
   DomApi.prototype.removeAttribute;
-  /** @type {function(string):?Element} */
+  /**
+   * @function
+   * @param {string} selector
+   * @return {?Element}
+   */
   DomApi.prototype.querySelector;
-  /** @type {function(string):!NodeList<!Element>} */
+  /**
+   * @function
+   * @param {string} selector
+   * @return {!NodeList<!Element>}
+   */
   DomApi.prototype.querySelectorAll;
 
   forwardMethods(DomApi.prototype, [

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -235,6 +235,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
+  forwardMethods(DomApi.prototype, [
+    'cloneNode', 'appendChild', 'insertBefore', 'removeChild',
+    'replaceChild', 'setAttribute', 'removeAttribute',
+    'querySelector', 'querySelectorAll'
+  ]);
+
+  forwardReadOnlyProperties(DomApi.prototype, [
+    'parentNode', 'firstChild', 'lastChild',
+    'nextSibling', 'previousSibling', 'firstElementChild',
+    'lastElementChild', 'nextElementSibling', 'previousElementSibling',
+    'childNodes', 'children', 'classList'
+  ]);
+
+  forwardProperties(DomApi.prototype, [
+    'textContent', 'innerHTML'
+  ]);
+
+
+  /**
+   * Event API wrapper class returned from `Polymer.dom.(target)` when
+   * `target` is an `Event`.
+   */
+  class EventApi {
+    constructor(event) {
+      this.event = event;
+    }
+
+    /**
+     * Returns the first node on the `composedPath` of this event.
+     *
+     * @return {!EventTarget} The node this event was dispatched to
+     */
+    get rootTarget() {
+      return this.event.composedPath()[0];
+    }
+
+    /**
+     * Returns the local (re-targeted) target for this event.
+     *
+     * @return {!EventTarget} The local (re-targeted) target for this event.
+     */
+    get localTarget() {
+      return this.event.target;
+    }
+
+    /**
+     * Returns the `composedPath` for this event.
+     * @return {!Array<EventTarget>} The nodes this event propagated through
+     */
+    get path() {
+      return this.event.composedPath();
+    }
+  }
+
+  Polymer.DomApi = DomApi;
+
   /**
    * @function
    * @param {boolean=} deep
@@ -292,62 +348,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @return {!Array<!Element>}
    */
   Polymer.DomApi.prototype.querySelectorAll;
-
-  forwardMethods(DomApi.prototype, [
-    'cloneNode', 'appendChild', 'insertBefore', 'removeChild',
-    'replaceChild', 'setAttribute', 'removeAttribute',
-    'querySelector', 'querySelectorAll'
-  ]);
-
-  forwardReadOnlyProperties(DomApi.prototype, [
-    'parentNode', 'firstChild', 'lastChild',
-    'nextSibling', 'previousSibling', 'firstElementChild',
-    'lastElementChild', 'nextElementSibling', 'previousElementSibling',
-    'childNodes', 'children', 'classList'
-  ]);
-
-  forwardProperties(DomApi.prototype, [
-    'textContent', 'innerHTML'
-  ]);
-
-
-  /**
-   * Event API wrapper class returned from `Polymer.dom.(target)` when
-   * `target` is an `Event`.
-   */
-  class EventApi {
-    constructor(event) {
-      this.event = event;
-    }
-
-    /**
-     * Returns the first node on the `composedPath` of this event.
-     *
-     * @return {!EventTarget} The node this event was dispatched to
-     */
-    get rootTarget() {
-      return this.event.composedPath()[0];
-    }
-
-    /**
-     * Returns the local (re-targeted) target for this event.
-     *
-     * @return {!EventTarget} The local (re-targeted) target for this event.
-     */
-    get localTarget() {
-      return this.event.target;
-    }
-
-    /**
-     * Returns the `composedPath` for this event.
-     * @return {!Array<EventTarget>} The nodes this event propagated through
-     */
-    get path() {
-      return this.event.composedPath();
-    }
-  }
-
-  Polymer.DomApi = DomApi;
 
   /**
    * Legacy DOM and Event manipulation API wrapper factory used to abstract

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -237,18 +237,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /**
    * @function
+   * @memberof Polymer
    * @param {boolean=} deep
    * @return {!Node}
    */
   DomApi.prototype.cloneNode;
   /**
    * @function
+   * @memberof Polymer
    * @param {Node} node
    * @return {!Node}
    */
   DomApi.prototype.appendChild;
   /**
    * @function
+   * @memberof Polymer
    * @param {Node} newChild
    * @param {Node} refChild
    * @return {!Node}
@@ -256,12 +259,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   DomApi.prototype.insertBefore;
   /**
    * @function
+   * @memberof Polymer
    * @param {Node} node
    * @return {!Node}
    */
   DomApi.prototype.removeChild;
   /**
    * @function
+   * @memberof Polymer
    * @param {Node} oldChild
    * @param {Node} newChild
    * @return {!Node}
@@ -269,6 +274,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   DomApi.prototype.replaceChild;
   /**
    * @function
+   * @memberof Polymer
    * @param {string} name
    * @param {string} value
    * @return {void}
@@ -276,18 +282,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   DomApi.prototype.setAttribute;
   /**
    * @function
+   * @memberof Polymer
    * @param {string} name
    * @return {void}
    */
   DomApi.prototype.removeAttribute;
   /**
    * @function
+   * @memberof Polymer
    * @param {string} selector
    * @return {?Element}
    */
   DomApi.prototype.querySelector;
   /**
    * @function
+   * @memberof Polymer
    * @param {string} selector
    * @return {!NodeList<!Element>}
    */

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -55,9 +55,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns an instance of `Polymer.FlattenedNodesObserver` that
      * listens for node changes on this element.
      *
-     * @param {Function} callback Called when direct or distributed children
+     * @param {function(!Element, { target: !Element, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Called when direct or distributed children
      *   of this element changes
-     * @return {Polymer.FlattenedNodesObserver} Observer instance
+     * @return {!Polymer.FlattenedNodesObserver} Observer instance
      */
     observeNodes(callback) {
       return new Polymer.FlattenedNodesObserver(this.node, callback);
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Disconnects an observer previously created via `observeNodes`
      *
-     * @param {Polymer.FlattenedNodesObserver} observerHandle Observer instance
+     * @param {!Polymer.FlattenedNodesObserver} observerHandle Observer instance
      *   to disconnect.
      * @return {void}
      */
@@ -119,7 +119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * For slot elements, returns the nodes assigned to the slot; otherwise
      * an empty array. It is equivalent to `<slot>.addignedNodes({flatten:true})`.
      *
-     * @return {Array<Node>} Array of assigned nodes
+     * @return {!Array<!Node>} Array of assigned nodes
      */
     getDistributedNodes() {
       return (this.node.localName === 'slot') ?
@@ -130,7 +130,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Returns an array of all slots this element was distributed to.
      *
-     * @return {Array<HTMLSlotElement>} Description
+     * @return {!Array<!HTMLSlotElement>} Description
      */
     getDestinationInsertionPoints() {
       let ip$ = [];
@@ -145,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Calls `importNode` on the `ownerDocument` for this node.
      *
-     * @param {Node} node Node to import
+     * @param {!Node} node Node to import
      * @param {boolean} deep True if the node should be cloned deeply during
      *   import
      * @return {Node} Clone of given node imported to this owner document
@@ -169,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * on the given selector.
      *
      * @param {string} selector Selector to filter nodes against
-     * @return {Array<HTMLElement>} List of flattened child elements
+     * @return {!Array<!HTMLElement>} List of flattened child elements
      */
     queryDistributedElements(selector) {
       let c$ = this.getEffectiveChildNodes();
@@ -235,6 +235,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
+  /** @type {function(boolean=):Node} */
+  DomApi.prototype.cloneNode;
+  /** @type {function(Node):!Node} */
+  DomApi.prototype.appendChild;
+  /** @type {function(Node, Node):!Node} */
+  DomApi.prototype.insertBefore;
+  /** @type {function(Node):!Node} */
+  DomApi.prototype.removeChild;
+  /** @type {function(Node, Node):!Node} */
+  DomApi.prototype.replaceChild;
+  /** @type {function(string, (string|number|boolean)):void} */
+  DomApi.prototype.setAttribute;
+  /** @type {function(string):void} */
+  DomApi.prototype.removeAttribute;
+  /** @type {function(string):?Element} */
+  DomApi.prototype.querySelector;
+  /** @type {function(string):!NodeList<!Element>} */
+  DomApi.prototype.querySelectorAll;
+
   forwardMethods(DomApi.prototype, [
     'cloneNode', 'appendChild', 'insertBefore', 'removeChild',
     'replaceChild', 'setAttribute', 'removeAttribute',
@@ -265,7 +284,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Returns the first node on the `composedPath` of this event.
      *
-     * @return {Node} The node this event was dispatched to
+     * @return {!EventTarget} The node this event was dispatched to
      */
     get rootTarget() {
       return this.event.composedPath()[0];
@@ -274,7 +293,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Returns the local (re-targeted) target for this event.
      *
-     * @return {Node} The local (re-targeted) target for this event.
+     * @return {!EventTarget} The local (re-targeted) target for this event.
      */
     get localTarget() {
       return this.event.target;
@@ -282,6 +301,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Returns the `composedPath` for this event.
+     * @return {!Array<EventTarget>} The nodes this event propagated through
      */
     get path() {
       return this.event.composedPath();
@@ -303,8 +323,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @summary Legacy DOM and Event manipulation API wrapper factory used to
    * abstract differences between native Shadow DOM and "Shady DOM."
    * @memberof Polymer
-   * @param {!Node|Event} obj Node or event to operate on
-   * @return {DomApi|EventApi} Wrapper providing either node API or event API
+   * @param {(Node|Event)=} obj Node or event to operate on
+   * @return {!DomApi|!EventApi} Wrapper providing either node API or event API
    */
   Polymer.dom = function(obj) {
     obj = obj || document;

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -237,70 +237,61 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /**
    * @function
-   * @memberof Polymer
    * @param {boolean=} deep
    * @return {!Node}
    */
-  DomApi.prototype.cloneNode;
+  Polymer.DomApi.prototype.cloneNode;
   /**
    * @function
-   * @memberof Polymer
-   * @param {Node} node
+   * @param {!Node} node
    * @return {!Node}
    */
-  DomApi.prototype.appendChild;
+  Polymer.DomApi.prototype.appendChild;
   /**
    * @function
-   * @memberof Polymer
-   * @param {Node} newChild
+   * @param {!Node} newChild
    * @param {Node} refChild
    * @return {!Node}
    */
-  DomApi.prototype.insertBefore;
+  Polymer.DomApi.prototype.insertBefore;
   /**
    * @function
-   * @memberof Polymer
-   * @param {Node} node
+   * @param {!Node} node
    * @return {!Node}
    */
-  DomApi.prototype.removeChild;
+  Polymer.DomApi.prototype.removeChild;
   /**
    * @function
-   * @memberof Polymer
-   * @param {Node} oldChild
-   * @param {Node} newChild
+   * @param {!Node} oldChild
+   * @param {!Node} newChild
    * @return {!Node}
    */
-  DomApi.prototype.replaceChild;
+  Polymer.DomApi.prototype.replaceChild;
   /**
    * @function
-   * @memberof Polymer
    * @param {string} name
    * @param {string} value
    * @return {void}
    */
-  DomApi.prototype.setAttribute;
+  Polymer.DomApi.prototype.setAttribute;
   /**
    * @function
-   * @memberof Polymer
    * @param {string} name
    * @return {void}
    */
-  DomApi.prototype.removeAttribute;
+  Polymer.DomApi.prototype.removeAttribute;
   /**
    * @function
-   * @memberof Polymer
    * @param {string} selector
    * @return {?Element}
    */
-  DomApi.prototype.querySelector;
+  Polymer.DomApi.prototype.querySelector;
   /**
    * @function
-   * @memberof Polymer
    * @param {string} selector
-   * @return {!NodeList<!Element>}
+   * @return {!Array<!Element>}
    */
-  DomApi.prototype.querySelectorAll;
+  Polymer.DomApi.prototype.querySelectorAll;
 
   forwardMethods(DomApi.prototype, [
     'cloneNode', 'appendChild', 'insertBefore', 'removeChild',

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -345,7 +345,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * @function
    * @param {string} selector
-   * @return {!Array<!Element>}
+   * @return {!NodeList}
    */
   Polymer.DomApi.prototype.querySelectorAll;
 

--- a/lib/legacy/templatizer-behavior.html
+++ b/lib/legacy/templatizer-behavior.html
@@ -96,7 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * template to prepare an element for stamping the template, followed
        * by `stamp` to create new instances of the template.
        *
-       * @param {HTMLTemplateElement} template Template to prepare
+       * @param {!HTMLTemplateElement} template Template to prepare
        * @param {boolean=} mutableData When `true`, the generated class will skip
        *   strict dirty-checking for objects and arrays (always consider them to
        *   be "dirty"). Defaults to false.

--- a/lib/mixins/gesture-event-listeners.html
+++ b/lib/mixins/gesture-event-listeners.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {!Node} node Node to add event listener to
        * @param {string} eventName Name of event
-       * @param {Function} handler Listener function to add
+       * @param {function(!Event):void} handler Listener function to add
        * @return {void}
        */
       _addEventListenerToNode(node, eventName, handler) {

--- a/lib/mixins/gesture-event-listeners.html
+++ b/lib/mixins/gesture-event-listeners.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {!Node} node Node to remove event listener from
        * @param {string} eventName Name of event
-       * @param {Function} handler Listener function to remove
+       * @param {function(!Event):void} handler Listener function to remove
        * @return {void}
        */
       _removeEventListenerFromNode(node, eventName, handler) {

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -55,7 +55,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         /**
          * Creates property accessors for the given property names.
-         * @param {Object} props Object whose keys are names of accessors.
+         * @param {!Object} props Object whose keys are names of accessors.
+         * @return {void}
          * @protected
          */
         static createProperties(props) {

--- a/lib/mixins/properties-mixin.html
+++ b/lib/mixins/properties-mixin.html
@@ -119,6 +119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * are also finalized. This includes ensuring property
        * accessors exist on the element prototype. This method calls
        * `_finalizeClass` to finalize each constructor in the prototype chain.
+       * @return {void}
        */
       static finalize() {
         if (!this.hasOwnProperty(JSCompiler_renameProperty('__finalized', this))) {

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1412,7 +1412,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * Users may override this method to provide alternate approaches.
        *
-       * @param {Node} node The node to set a property on
+       * @param {!Node} node The node to set a property on
        * @param {string} prop The property to set
        * @param {*} value The value to set
        * @return {void}

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -2294,9 +2294,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * templates are stored in a linked list on the instance so that
        * templates can be efficiently stamped and unstamped.
        *
-       * @param {HTMLTemplateElement} template Template containing binding
+       * @param {!HTMLTemplateElement} template Template containing binding
        *   bindings
-       * @return {Object} Template metadata object
+       * @return {!TemplateInfo} Template metadata object
        * @protected
        */
       static bindTemplate(template) {
@@ -2316,7 +2316,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * create and link an instance of the template metadata associated with a
        * particular stamping.
        *
-       * @param {HTMLTemplateElement} template Template containing binding
+       * @param {!HTMLTemplateElement} template Template containing binding
        *   bindings
        * @param {boolean=} instanceBinding When false (default), performs
        *   "prototypical" binding of the template and overwrites any previously

--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -474,7 +474,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {Node} node Node to remove event listener from
        * @param {string} eventName Name of event
-       * @param {Function} handler Listener function to remove
+       * @param {function(!Event):void} handler Listener function to remove
        * @return {void}
        */
       _removeEventListenerFromNode(node, eventName, handler) {

--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -462,7 +462,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {!Node} node Node to add event listener to
        * @param {string} eventName Name of event
-       * @param {Function} handler Listener function to add
+       * @param {function(!Event):void} handler Listener function to add
        * @return {void}
        */
       _addEventListenerToNode(node, eventName, handler) {

--- a/lib/utils/async.html
+++ b/lib/utils/async.html
@@ -78,7 +78,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Enqueues a function called in the next task.
        *
-       * @function
        * @memberof Polymer.Async.timeOut
        * @param {!Function} fn Callback to run
        * @param {number=} delay Delay in milliseconds
@@ -90,7 +89,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cancels a previously enqueued `timeOut` callback.
        *
-       * @function
        * @memberof Polymer.Async.timeOut
        * @param {number} handle Handle returned from `run` of callback to cancel
        * @return {void}
@@ -111,9 +109,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Enqueues a function called at `requestAnimationFrame` timing.
        *
-       * @function
        * @memberof Polymer.Async.animationFrame
-       * @param {function(number)} fn Callback to run
+       * @param {function(number):void} fn Callback to run
        * @return {number} Handle used for canceling task
        */
       run(fn) {
@@ -122,7 +119,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cancels a previously enqueued `animationFrame` callback.
        *
-       * @function
        * @memberof Polymer.Async.animationFrame
        * @param {number} handle Handle returned from `run` of callback to cancel
        * @return {void}

--- a/lib/utils/flattened-nodes-observer.html
+++ b/lib/utils/flattened-nodes-observer.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * @param {Element} target Node on which to listen for changes.
-     * @param {Function} callback Function called when there are additions
+     * @param {?function(!Element, { target: !Element, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Function called when there are additions
      * or removals from the target's list of flattened nodes.
     */
     constructor(target, callback) {

--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -429,7 +429,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @memberof Polymer.Gestures
      * @param {!Node} node Node to add listener on
      * @param {string} evType Gesture type: `down`, `up`, `track`, or `tap`
-     * @param {!Function} handler Event listener function to call
+     * @param {!function(!Event):void} handler Event listener function to call
      * @return {boolean} Returns true if a gesture event listener was added.
      * @this {Gestures}
      */
@@ -447,7 +447,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @memberof Polymer.Gestures
      * @param {!Node} node Node to remove listener from
      * @param {string} evType Gesture type: `down`, `up`, `track`, or `tap`
-     * @param {!Function} handler Event listener function previously passed to
+     * @param {!function(!Event):void} handler Event listener function previously passed to
      *  `addListener`.
      * @return {boolean} Returns true if a gesture event listener was removed.
      * @this {Gestures}
@@ -466,7 +466,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @private
      * @param {!HTMLElement} node Node on which to add the event.
      * @param {string} evType Event type to add.
-     * @param {function(Event?)} handler Event handler function.
+     * @param {function(!Event)} handler Event handler function.
      * @return {void}
      * @this {Gestures}
      */

--- a/lib/utils/import-href.html
+++ b/lib/utils/import-href.html
@@ -36,9 +36,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @memberof Polymer
    * @param {string} href URL to document to load.
-   * @param {!Function=} onload Callback to notify when an import successfully
+   * @param {?function(!Event):void=} onload Callback to notify when an import successfully
    *   loaded.
-   * @param {!Function=} onerror Callback to notify when an import
+   * @param {?function(!ErrorEvent):void=} onerror Callback to notify when an import
    *   unsuccessfully loaded.
    * @param {boolean=} optAsync True if the import should be loaded `async`.
    *   Defaults to `false`.

--- a/lib/utils/render-status.html
+++ b/lib/utils/render-status.html
@@ -85,8 +85,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.RenderStatus
      * @param {*} context Context object the callback function will be bound to
-     * @param {function():void} callback Callback function
-     * @param {Array} args An array of arguments to call the callback function with
+     * @param {function(...*):void} callback Callback function
+     * @param {!Array=} args An array of arguments to call the callback function with
      * @return {void}
      */
     beforeNextRender: function(context, callback, args) {
@@ -107,8 +107,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.RenderStatus
      * @param {*} context Context object the callback function will be bound to
-     * @param {function():void} callback Callback function
-     * @param {Array} args An array of arguments to call the callback function with
+     * @param {function(...*):void} callback Callback function
+     * @param {!Array=} args An array of arguments to call the callback function with
      * @return {void}
      */
     afterNextRender: function(context, callback, args) {

--- a/lib/utils/render-status.html
+++ b/lib/utils/render-status.html
@@ -85,7 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.RenderStatus
      * @param {*} context Context object the callback function will be bound to
-     * @param {function()} callback Callback function
+     * @param {function():void} callback Callback function
      * @param {Array} args An array of arguments to call the callback function with
      * @return {void}
      */
@@ -107,7 +107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.RenderStatus
      * @param {*} context Context object the callback function will be bound to
-     * @param {function()} callback Callback function
+     * @param {function():void} callback Callback function
      * @param {Array} args An array of arguments to call the callback function with
      * @return {void}
      */

--- a/lib/utils/style-gather.html
+++ b/lib/utils/style-gather.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @memberof Polymer.StyleGather
      * @param {string} moduleIds List of dom-module id's within which to
      * search for css.
-     * @return {Array} Array of contained <style> elements
+     * @return {!Array<!HTMLStyleElement>} Array of contained <style> elements
      * @this {StyleGather}
      */
      stylesFromModules(moduleIds) {
@@ -75,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.StyleGather
      * @param {string} moduleId dom-module id to gather styles from
-     * @return {Array} Array of contained styles.
+     * @return {!Array<!HTMLStyleElement>} Array of contained styles.
      * @this {StyleGather}
      */
     stylesFromModule(moduleId) {
@@ -102,9 +102,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Returns the `<style>` elements within a given template.
      *
      * @memberof Polymer.StyleGather
-     * @param {HTMLTemplateElement} template Template to gather styles from
+     * @param {!HTMLTemplateElement} template Template to gather styles from
      * @param {string} baseURI baseURI for style content
-     * @return {Array} Array of styles
+     * @return {!Array<!HTMLStyleElement>} Array of styles
      * @this {StyleGather}
      */
     stylesFromTemplate(template, baseURI) {
@@ -135,7 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @memberof Polymer.StyleGather
      * @param {string} moduleId Id of `dom-module` to gather CSS from
-     * @return {Array} Array of contained styles.
+     * @return {!Array<!HTMLStyleElement>} Array of contained styles.
      * @this {StyleGather}
      */
      stylesFromModuleImports(moduleId) {
@@ -147,7 +147,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @memberof Polymer.StyleGather
      * @this {StyleGather}
      * @param {!HTMLElement} module dom-module element that could contain `<link rel="import" type="css">` styles
-     * @return {Array} Array of contained styles
+     * @return {!Array<!HTMLStyleElement>} Array of contained styles
      */
     _stylesFromModuleImports(module) {
       const styles = [];
@@ -233,7 +233,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @deprecated
      * @memberof Polymer.StyleGather
-     * @param {HTMLTemplateElement} template Template to gather styles from
+     * @param {!HTMLTemplateElement} template Template to gather styles from
      * @param {string} baseURI Base URI to resolve the URL against
      * @return {string} Concatenated CSS content from specified template
      * @this {StyleGather}

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -129,7 +129,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @param {!Node} node Node to add event listener to
        * @param {string} eventName Name of event
-       * @param {Function} handler Listener function to add
+       * @param {function(!Event):void} handler Listener function to add
        * @return {void}
        */
       _addEventListenerToNode(node, eventName, handler) {
@@ -191,7 +191,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * textContent bindings while children are "hidden" and cache in
        * private storage for later retrieval.
        *
-       * @param {Node} node The node to set a property on
+       * @param {!Node} node The node to set a property on
        * @param {string} prop The property to set
        * @param {*} value The value to set
        * @return {void}
@@ -210,7 +210,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * is either another templatize instance that had option `parentModel: true`,
        * or else the host element.
        *
-       * @return {Polymer_PropertyEffects} The parent model of this instance
+       * @return {!Polymer_PropertyEffects} The parent model of this instance
        */
       get parentModel() {
         let model = this.__parentModel;
@@ -502,7 +502,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @memberof Polymer.Templatize
        * @param {HTMLTemplateElement} template The model will be returned for
        *   elements stamped from this template
-       * @param {Node} node Node for which to return a template model.
+       * @param {Node=} node Node for which to return a template model.
        * @return {TemplateInstanceBase} Template instance representing the
        *   binding scope for the element
        */

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@polymer/gen-typescript-declarations": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.3.tgz",
-      "integrity": "sha512-hCL7uF2UefJDuUU87iUZYohylsKTzb1hAKMeFbFG58c/McliEVxw4RQDdKbllkUOEzIFlsn2mtKY9tlhprSIPw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.4.tgz",
+      "integrity": "sha512-t9xp+kS1CavpVSuzDXav2T27CDzSz37DsFJqAVv9WhE7+zNGiO3L4B5DPRHI2H5vZ9YI90abboWcYQlUN24mLA==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
@@ -444,9 +444,9 @@
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.20.tgz",
-      "integrity": "sha512-Ady8WFcEVcFS/hfMto5EBwqTUViNsVYErbXImD9jH808yjSqELPsRxQ4PlpP0qBObSmKwJyl3jq0C3tZOhbLGQ==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.22.tgz",
+      "integrity": "sha512-VREMJxIe5ydR6LdMpg27ojyfL635jH03680na5X2LNLY2UF1GOzNrNOAVaEf2mr+SDUpc9Rey+gt+qCvtbCGhQ==",
       "dev": true
     },
     "abbrev": {
@@ -9978,7 +9978,7 @@
       "requires": {
         "@polymer/sinonjs": "1.17.1",
         "@polymer/test-fixture": "0.0.3",
-        "@webcomponents/webcomponentsjs": "1.0.20",
+        "@webcomponents/webcomponentsjs": "1.0.22",
         "accessibility-developer-tools": "2.12.0",
         "async": "2.6.0",
         "body-parser": "1.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@polymer/gen-typescript-declarations": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.4.tgz",
-      "integrity": "sha512-t9xp+kS1CavpVSuzDXav2T27CDzSz37DsFJqAVv9WhE7+zNGiO3L4B5DPRHI2H5vZ9YI90abboWcYQlUN24mLA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.5.tgz",
+      "integrity": "sha512-Fyb58xk6bTr6tSYjNB7zSC6X+8X6WoNQcQBZ18J3qlwaljo+CfgjdpYJ9U91ci2YDv0y5v51s6k1uN+Uo9BSAw==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
@@ -28,7 +28,7 @@
         "escodegen": "1.9.0",
         "fs-extra": "4.0.3",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.5"
+        "polymer-analyzer": "3.0.0-pre.7"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -44,9 +44,9 @@
           "dev": true
         },
         "polymer-analyzer": {
-          "version": "3.0.0-pre.5",
-          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.5.tgz",
-          "integrity": "sha512-85+2l0T/lZ9vhTxJ6dOZMe74KCe+lYrni4kJuVgMqm0sIe4gmjeRjG/QqPZhC0EFvjk4fqu9UrNt4QuwxL+r1A==",
+          "version": "3.0.0-pre.7",
+          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.7.tgz",
+          "integrity": "sha512-R9wAvlkvq1vrjPI3N7frF2pzMpZhrgyDIgkqBAZIZtQvOuZ6Hyp5qTFPEiX6SR5wU8UBI4dqSpYXoCBmhIT8PA==",
           "dev": true,
           "requires": {
             "@types/babel-generator": "6.25.1",
@@ -77,7 +77,8 @@
             "polymer-project-config": "3.6.0",
             "shady-css-parser": "0.1.0",
             "stable": "0.1.6",
-            "strip-indent": "2.0.0"
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.1"
           },
           "dependencies": {
             "@types/doctrine": {
@@ -9805,6 +9806,12 @@
       "requires": {
         "source-map": "0.5.7"
       }
+    },
+    "vscode-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+      "dev": true
     },
     "vulcanize": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@polymer/gen-closure-declarations": "^0.4.0",
-    "@polymer/gen-typescript-declarations": "^0.3.4",
+    "@polymer/gen-typescript-declarations": "^0.3.5",
     "@webcomponents/shadycss": "^1.1.0",
     "@webcomponents/webcomponentsjs": "^1.0.22",
     "babel-preset-minify": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "devDependencies": {
     "@polymer/gen-closure-declarations": "^0.4.0",
-    "@polymer/gen-typescript-declarations": "^0.3.3",
+    "@polymer/gen-typescript-declarations": "^0.3.4",
     "@webcomponents/shadycss": "^1.1.0",
-    "@webcomponents/webcomponentsjs": "^1.0.20",
+    "@webcomponents/webcomponentsjs": "^1.0.22",
     "babel-preset-minify": "^0.2.0",
     "del": "^3.0.0",
     "dom5": "^2.3.0",

--- a/types/extra-types.d.ts
+++ b/types/extra-types.d.ts
@@ -13,7 +13,7 @@ interface PolymerElementPropertiesMeta {
   computed?: string;
   reflectToAttribute?: boolean;
   notify?: boolean;
-  observer?: string;
+  observer?: string|((val: any, old: any) => void);
 }
 
 type PolymerElementProperties = {

--- a/types/lib/elements/dom-module.d.ts
+++ b/types/lib/elements/dom-module.d.ts
@@ -33,6 +33,18 @@ declare namespace Polymer {
    *     let img = customElements.get('dom-module').import('foo', 'img');
    */
   class DomModule extends HTMLElement {
+    readonly assetpath: any;
+
+    /**
+     * Retrieves the element specified by the css `selector` in the module
+     * registered by `id`. For example, this.import('foo', 'img');
+     *
+     * @param id The id of the dom-module in which to search.
+     * @param selector The css selector by which to find the element.
+     * @returns Returns the element which matches `selector` in the
+     * module registered at the specified `id`.
+     */
+    static import(id: string, selector?: string): Element|null;
 
     /**
      * @param name Name of attribute.

--- a/types/lib/elements/dom-repeat.d.ts
+++ b/types/lib/elements/dom-repeat.d.ts
@@ -176,7 +176,7 @@ declare namespace Polymer {
      * If "chunking mode" is enabled, `renderedItemCount` is updated each time a
      * set of template instances is rendered.
      */
-    renderedItemCount: number|null|undefined;
+    readonly renderedItemCount: number|null|undefined;
 
     /**
      * Defines an initial count of template instances to render after setting
@@ -200,7 +200,7 @@ declare namespace Polymer {
      * longer time for the remaining items to complete rendering.
      */
     targetFramerate: number|null|undefined;
-    _targetFrameTime: number|null|undefined;
+    readonly _targetFrameTime: number|null|undefined;
     disconnectedCallback(): void;
     connectedCallback(): void;
 

--- a/types/lib/elements/dom-repeat.d.ts
+++ b/types/lib/elements/dom-repeat.d.ts
@@ -234,7 +234,7 @@ declare namespace Polymer {
      * @param el Element for which to return the item.
      * @returns Item associated with the element.
      */
-    itemForElement(el: HTMLElement|null): any;
+    itemForElement(el: HTMLElement): any;
 
     /**
      * Returns the inst index for a given element stamped by this `dom-repeat`.
@@ -245,7 +245,7 @@ declare namespace Polymer {
      * @returns Row index associated with the element (note this may
      *   not correspond to the array index if a user `sort` is applied).
      */
-    indexForElement(el: HTMLElement|null): any;
+    indexForElement(el: HTMLElement): number|null;
 
     /**
      * Returns the template "model" associated with a given element, which
@@ -264,7 +264,7 @@ declare namespace Polymer {
      * @returns Model representing the binding scope for
      *   the element.
      */
-    modelForElement(el: HTMLElement|null): TemplateInstanceBase|null;
+    modelForElement(el: HTMLElement): TemplateInstanceBase|null;
   }
 }
 

--- a/types/lib/legacy/class.d.ts
+++ b/types/lib/legacy/class.d.ts
@@ -23,7 +23,7 @@ declare namespace Polymer {
    * @returns Returns a new Element class extended by the
    * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
    */
-  function mixinBehaviors(behaviors: object|any[]|null, klass: HTMLElement|{new(): HTMLElement}): {new(): HTMLElement};
+  function mixinBehaviors<T>(behaviors: PolymerInit|PolymerInit[]|null, klass: {new(): T}): {new(): T};
 
 
   /**

--- a/types/lib/legacy/legacy-element-mixin.d.ts
+++ b/types/lib/legacy/legacy-element-mixin.d.ts
@@ -37,6 +37,13 @@ declare namespace Polymer {
     _debouncers: {[key: string]: Function|null};
 
     /**
+     * Return the element whose local dom within which this element
+     * is contained. This is a shorthand for
+     * `this.getRootNode().host`.
+     */
+    readonly domHost: any;
+
+    /**
      * Overrides the default `Polymer.PropertyEffects` implementation to
      * add support for installing `hostAttributes` and `listeners`.
      */

--- a/types/lib/legacy/legacy-element-mixin.d.ts
+++ b/types/lib/legacy/legacy-element-mixin.d.ts
@@ -203,7 +203,7 @@ declare namespace Polymer {
      * @param source Source object to copy properties from.
      * @returns Target object that was passed as first argument.
      */
-    mixin(target: object|null, source: object|null): object|null;
+    mixin(target: object, source: object): object;
 
     /**
      * Sets the prototype of an object.
@@ -227,7 +227,7 @@ declare namespace Polymer {
      * @returns Document fragment containing the imported
      *   template content.
      */
-    instanceTemplate(template: HTMLTemplateElement|null): DocumentFragment|null;
+    instanceTemplate(template: HTMLTemplateElement|null): DocumentFragment;
 
     /**
      * Dispatches a custom event with an optional detail value.
@@ -241,7 +241,7 @@ declare namespace Polymer {
      *  `node` on which to fire the event (HTMLElement, defaults to `this`).
      * @returns The new event that was fired.
      */
-    fire(type: string, detail?: any, options?: {bubbles?: boolean, cancelable?: boolean, composed?: boolean}): Event|null;
+    fire(type: string, detail?: any, options?: {bubbles?: boolean, cancelable?: boolean, composed?: boolean}): Event;
 
     /**
      * Convenience method to add an event listener on a given element,
@@ -398,7 +398,7 @@ declare namespace Polymer {
      * @param node The element to be checked.
      * @returns true if node is in this element's local DOM tree.
      */
-    isLocalDescendant(node?: Element|null): boolean;
+    isLocalDescendant(node: Element): boolean;
 
     /**
      * No-op for backwards compatibility. This should now be handled by
@@ -442,7 +442,7 @@ declare namespace Polymer {
      * `flush()` immediately invokes the debounced callback if the debouncer
      * is active.
      */
-    debounce(jobName: string, callback: () => void, wait: number): object|null;
+    debounce(jobName: string, callback: () => void, wait: number): object;
 
     /**
      * Returns whether a named debouncer is active.
@@ -496,7 +496,7 @@ declare namespace Polymer {
      *    instance.
      * @returns Newly created and configured element.
      */
-    create(tag: string, props: object|null): Element|null;
+    create(tag: string, props?: object|null): Element;
 
     /**
      * Convenience method for importing an HTML document imperatively.
@@ -515,7 +515,7 @@ declare namespace Polymer {
      *   Defaults to `false`.
      * @returns The link element for the URL to be loaded.
      */
-    importHref(href: string, onload?: Function, onerror?: Function, optAsync?: boolean): HTMLLinkElement;
+    importHref(href: string, onload?: ((p0: Event) => void)|null, onerror?: ((p0: ErrorEvent) => void)|null, optAsync?: boolean): HTMLLinkElement;
 
     /**
      * Polyfill for Element.prototype.matches, which is sometimes still

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -42,6 +42,12 @@ declare namespace Polymer {
   class DomApi {
 
     /**
+     * For shadow roots, returns the currently focused element within this
+     * shadow root.
+     */
+    readonly activeElement: Node|null|undefined;
+
+    /**
      * Returns an instance of `Polymer.FlattenedNodesObserver` that
      * listens for node changes on this element.
      *
@@ -146,4 +152,19 @@ declare namespace Polymer {
  * `target` is an `Event`.
  */
 declare class EventApi {
+
+  /**
+   * Returns the first node on the `composedPath` of this event.
+   */
+  readonly rootTarget: EventTarget;
+
+  /**
+   * Returns the local (re-targeted) target for this event.
+   */
+  readonly localTarget: EventTarget;
+
+  /**
+   * Returns the `composedPath` for this event.
+   */
+  readonly path: Array<EventTarget|null>;
 }

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -130,6 +130,15 @@ declare namespace Polymer {
      * @returns List of flattened child elements
      */
     queryDistributedElements(selector: string): HTMLElement[];
+    cloneNode(deep?: boolean): Node;
+    appendChild(node: Node): Node;
+    insertBefore(newChild: Node, refChild: Node|null): Node;
+    removeChild(node: Node): Node;
+    replaceChild(oldChild: Node, newChild: Node): Node;
+    setAttribute(name: string, value: string): void;
+    removeAttribute(name: string): void;
+    querySelector(selector: string): Element|null;
+    querySelectorAll(selector: string): Element[];
   }
 
 

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -49,7 +49,7 @@ declare namespace Polymer {
      *   of this element changes
      * @returns Observer instance
      */
-    observeNodes(callback: Function|null): Polymer.FlattenedNodesObserver|null;
+    observeNodes(callback: (p0: Element, p1: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void): Polymer.FlattenedNodesObserver;
 
     /**
      * Disconnects an observer previously created via `observeNodes`
@@ -57,7 +57,7 @@ declare namespace Polymer {
      * @param observerHandle Observer instance
      *   to disconnect.
      */
-    unobserveNodes(observerHandle: Polymer.FlattenedNodesObserver|null): void;
+    unobserveNodes(observerHandle: Polymer.FlattenedNodesObserver): void;
 
     /**
      * Provided as a backwards-compatible API only.  This method does nothing.
@@ -91,14 +91,14 @@ declare namespace Polymer {
      *
      * @returns Array of assigned nodes
      */
-    getDistributedNodes(): Array<Node|null>|null;
+    getDistributedNodes(): Node[];
 
     /**
      * Returns an array of all slots this element was distributed to.
      *
      * @returns Description
      */
-    getDestinationInsertionPoints(): Array<HTMLSlotElement|null>|null;
+    getDestinationInsertionPoints(): HTMLSlotElement[];
 
     /**
      * Calls `importNode` on the `ownerDocument` for this node.
@@ -108,7 +108,7 @@ declare namespace Polymer {
      *   import
      * @returns Clone of given node imported to this owner document
      */
-    importNode(node: Node|null, deep: boolean): Node|null;
+    importNode(node: Node, deep: boolean): Node|null;
 
     /**
      * @returns Returns a flattened list of all child nodes and
@@ -123,7 +123,7 @@ declare namespace Polymer {
      * @param selector Selector to filter nodes against
      * @returns List of flattened child elements
      */
-    queryDistributedElements(selector: string): Array<HTMLElement|null>|null;
+    queryDistributedElements(selector: string): HTMLElement[];
   }
 
 
@@ -138,7 +138,7 @@ declare namespace Polymer {
    *
    * @returns Wrapper providing either node API or event API
    */
-  function dom(obj: Node|Event|null): DomApi|EventApi|null;
+  function dom(obj?: Node|Event|null): DomApi|EventApi;
 }
 
 /**

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -138,7 +138,7 @@ declare namespace Polymer {
     setAttribute(name: string, value: string): void;
     removeAttribute(name: string): void;
     querySelector(selector: string): Element|null;
-    querySelectorAll(selector: string): Element[];
+    querySelectorAll(selector: string): NodeList;
   }
 
 

--- a/types/lib/legacy/templatizer-behavior.d.ts
+++ b/types/lib/legacy/templatizer-behavior.d.ts
@@ -83,7 +83,7 @@ declare namespace Polymer {
      *   strict dirty-checking for objects and arrays (always consider them to
      *   be "dirty"). Defaults to false.
      */
-    templatize(template: HTMLTemplateElement|null, mutableData?: boolean): void;
+    templatize(template: HTMLTemplateElement, mutableData?: boolean): void;
 
     /**
      * Creates an instance of the template prepared by `templatize`.  The object

--- a/types/lib/mixins/gesture-event-listeners.d.ts
+++ b/types/lib/mixins/gesture-event-listeners.d.ts
@@ -48,6 +48,6 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to remove
      */
-    _removeEventListenerFromNode(node: Node, eventName: string, handler: Function|null): void;
+    _removeEventListenerFromNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
   }
 }

--- a/types/lib/mixins/gesture-event-listeners.d.ts
+++ b/types/lib/mixins/gesture-event-listeners.d.ts
@@ -39,7 +39,7 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to add
      */
-    _addEventListenerToNode(node: Node, eventName: string, handler: Function|null): void;
+    _addEventListenerToNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
 
     /**
      * Remove the event listener to the node if it is a gestures event.

--- a/types/lib/mixins/properties-changed.d.ts
+++ b/types/lib/mixins/properties-changed.d.ts
@@ -41,7 +41,7 @@ declare namespace Polymer {
      *
      * @param props Object whose keys are names of accessors.
      */
-    createProperties(props: object|null): any;
+    createProperties(props: object): void;
 
     /**
      * Returns an attribute name that corresponds to the given property.

--- a/types/lib/mixins/properties-mixin.d.ts
+++ b/types/lib/mixins/properties-mixin.d.ts
@@ -46,7 +46,7 @@ declare namespace Polymer {
      * accessors exist on the element prototype. This method calls
      * `_finalizeClass` to finalize each constructor in the prototype chain.
      */
-    finalize(): any;
+    finalize(): void;
 
     /**
      * Finalize an element class. This includes ensuring property

--- a/types/lib/mixins/property-effects.d.ts
+++ b/types/lib/mixins/property-effects.d.ts
@@ -513,7 +513,7 @@ declare namespace Polymer {
      * @param prop The property to set
      * @param value The value to set
      */
-    _setUnmanagedPropertyToNode(node: Node|null, prop: string, value: any): void;
+    _setUnmanagedPropertyToNode(node: Node, prop: string, value: any): void;
 
     /**
      * Enqueues the given client on a list of pending clients, whose

--- a/types/lib/mixins/property-effects.d.ts
+++ b/types/lib/mixins/property-effects.d.ts
@@ -214,7 +214,7 @@ declare namespace Polymer {
      *   bindings
      * @returns Template metadata object
      */
-    bindTemplate(template: HTMLTemplateElement|null): object|null;
+    bindTemplate(template: HTMLTemplateElement): TemplateInfo;
 
     /**
      * Adds a property effect to the given template metadata, which is run
@@ -826,7 +826,7 @@ declare namespace Polymer {
      * @returns Template metadata object; for `runtimeBinding`,
      *   this is an instance of the prototypical template info
      */
-    _bindTemplate(template: HTMLTemplateElement|null, instanceBinding?: boolean): TemplateInfo;
+    _bindTemplate(template: HTMLTemplateElement, instanceBinding?: boolean): TemplateInfo;
 
     /**
      * Removes and unbinds the nodes previously contained in the provided

--- a/types/lib/mixins/property-effects.d.ts
+++ b/types/lib/mixins/property-effects.d.ts
@@ -280,6 +280,7 @@ declare namespace Polymer {
   }
 
   interface PropertyEffects {
+    readonly PROPERTY_EFFECT_TYPES: any;
 
     /**
      * Stamps the provided template and performs instance-time setup for

--- a/types/lib/mixins/template-stamp.d.ts
+++ b/types/lib/mixins/template-stamp.d.ts
@@ -244,7 +244,7 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to add
      */
-    _addEventListenerToNode(node: Node, eventName: string, handler: Function|null): void;
+    _addEventListenerToNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
 
     /**
      * Override point for adding custom or simulated event handling.

--- a/types/lib/mixins/template-stamp.d.ts
+++ b/types/lib/mixins/template-stamp.d.ts
@@ -253,6 +253,6 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to remove
      */
-    _removeEventListenerFromNode(node: Node|null, eventName: string, handler: Function|null): void;
+    _removeEventListenerFromNode(node: Node|null, eventName: string, handler: (p0: Event) => void): void;
   }
 }

--- a/types/lib/utils/async.d.ts
+++ b/types/lib/utils/async.d.ts
@@ -44,20 +44,6 @@ declare namespace Polymer {
 
 
       /**
-       * Enqueues a function called in the next task.
-       *
-       * @returns Handle used for canceling task
-       */
-      function run(fn: Function, delay?: number): number;
-
-
-      /**
-       * Cancels a previously enqueued `timeOut` callback.
-       */
-      function cancel(handle: number): void;
-
-
-      /**
        * Cancels a previously enqueued `timeOut` callback.
        */
       function cancel(handle: number): void;
@@ -74,21 +60,7 @@ declare namespace Polymer {
        *
        * @returns Handle used for canceling task
        */
-      function run(fn: (p0: number) => any): number;
-
-
-      /**
-       * Enqueues a function called at `requestAnimationFrame` timing.
-       *
-       * @returns Handle used for canceling task
-       */
-      function run(fn: (p0: number) => any): number;
-
-
-      /**
-       * Cancels a previously enqueued `animationFrame` callback.
-       */
-      function cancel(handle: number): void;
+      function run(fn: (p0: number) => void): number;
 
 
       /**

--- a/types/lib/utils/gestures.d.ts
+++ b/types/lib/utils/gestures.d.ts
@@ -42,7 +42,7 @@ declare namespace Polymer {
      *
      * @returns Returns true if a gesture event listener was added.
      */
-    function addListener(node: Node, evType: string, handler: Function): boolean;
+    function addListener(node: Node, evType: string, handler: (p0: Event) => void): boolean;
 
 
     /**
@@ -50,7 +50,7 @@ declare namespace Polymer {
      *
      * @returns Returns true if a gesture event listener was removed.
      */
-    function removeListener(node: Node, evType: string, handler: Function): boolean;
+    function removeListener(node: Node, evType: string, handler: (p0: Event) => void): boolean;
 
 
     /**

--- a/types/lib/utils/import-href.d.ts
+++ b/types/lib/utils/import-href.d.ts
@@ -23,5 +23,5 @@ declare namespace Polymer {
    *
    * @returns The link element for the URL to be loaded.
    */
-  function importHref(href: string, onload?: Function, onerror?: Function, optAsync?: boolean): HTMLLinkElement;
+  function importHref(href: string, onload?: ((p0: Event) => void)|null, onerror?: ((p0: ErrorEvent) => void)|null, optAsync?: boolean): HTMLLinkElement;
 }

--- a/types/lib/utils/render-status.d.ts
+++ b/types/lib/utils/render-status.d.ts
@@ -28,7 +28,7 @@ declare namespace Polymer {
      *
      * Tasks in this queue may be flushed by calling `Polymer.RenderStatus.flush()`.
      */
-    function beforeNextRender(context: any, callback: () => void, args: any[]|null): void;
+    function beforeNextRender(context: any, callback: (...p0: any[]) => void, args?: any[]): void;
 
 
     /**
@@ -40,6 +40,6 @@ declare namespace Polymer {
      * first paint.  Typical non-render-critical work may include adding UI
      * event listeners and aria attributes.
      */
-    function afterNextRender(context: any, callback: () => void, args: any[]|null): void;
+    function afterNextRender(context: any, callback: (...p0: any[]) => void, args?: any[]): void;
   }
 }

--- a/types/lib/utils/render-status.d.ts
+++ b/types/lib/utils/render-status.d.ts
@@ -28,7 +28,7 @@ declare namespace Polymer {
      *
      * Tasks in this queue may be flushed by calling `Polymer.RenderStatus.flush()`.
      */
-    function beforeNextRender(context: any, callback: () => any, args: any[]|null): void;
+    function beforeNextRender(context: any, callback: () => void, args: any[]|null): void;
 
 
     /**
@@ -40,6 +40,6 @@ declare namespace Polymer {
      * first paint.  Typical non-render-critical work may include adding UI
      * event listeners and aria attributes.
      */
-    function afterNextRender(context: any, callback: () => any, args: any[]|null): void;
+    function afterNextRender(context: any, callback: () => void, args: any[]|null): void;
   }
 }

--- a/types/lib/utils/style-gather.d.ts
+++ b/types/lib/utils/style-gather.d.ts
@@ -24,7 +24,7 @@ declare namespace Polymer {
      *
      * @returns Array of contained <style> elements
      */
-    function stylesFromModules(moduleIds: string): any[]|null;
+    function stylesFromModules(moduleIds: string): HTMLStyleElement[];
 
 
     /**
@@ -35,7 +35,7 @@ declare namespace Polymer {
      *
      * @returns Array of contained styles.
      */
-    function stylesFromModule(moduleId: string): any[]|null;
+    function stylesFromModule(moduleId: string): HTMLStyleElement[];
 
 
     /**
@@ -43,7 +43,7 @@ declare namespace Polymer {
      *
      * @returns Array of styles
      */
-    function stylesFromTemplate(template: HTMLTemplateElement|null, baseURI: string): any[]|null;
+    function stylesFromTemplate(template: HTMLTemplateElement, baseURI: string): HTMLStyleElement[];
 
 
     /**
@@ -51,13 +51,13 @@ declare namespace Polymer {
      *
      * @returns Array of contained styles.
      */
-    function stylesFromModuleImports(moduleId: string): any[]|null;
+    function stylesFromModuleImports(moduleId: string): HTMLStyleElement[];
 
 
     /**
      * @returns Array of contained styles
      */
-    function _stylesFromModuleImports(module: HTMLElement): any[]|null;
+    function _stylesFromModuleImports(module: HTMLElement): HTMLStyleElement[];
 
 
     /**
@@ -91,7 +91,7 @@ declare namespace Polymer {
      *
      * @returns Concatenated CSS content from specified template
      */
-    function cssFromTemplate(template: HTMLTemplateElement|null, baseURI: string): string;
+    function cssFromTemplate(template: HTMLTemplateElement, baseURI: string): string;
 
 
     /**

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -17,6 +17,14 @@ declare class TemplateInstanceBase extends
   Polymer.Element) {
 
   /**
+   * Find the parent model of this template instance.  The parent model
+   * is either another templatize instance that had option `parentModel: true`,
+   * or else the host element.
+   */
+  readonly parentModel: Polymer.PropertyEffects;
+  _methodHost: Polymer.PropertyEffects;
+
+  /**
    * Override point for adding custom or simulated event handling.
    *
    * @param node Node to add event listener to

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -23,7 +23,7 @@ declare class TemplateInstanceBase extends
    * @param eventName Name of event
    * @param handler Listener function to add
    */
-  _addEventListenerToNode(node: Node, eventName: string, handler: Function|null): void;
+  _addEventListenerToNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
 
   /**
    * Overrides default property-effects implementation to intercept
@@ -34,7 +34,7 @@ declare class TemplateInstanceBase extends
    * @param prop The property to set
    * @param value The value to set
    */
-  _setUnmanagedPropertyToNode(node: Node|null, prop: string, value: any): void;
+  _setUnmanagedPropertyToNode(node: Node, prop: string, value: any): void;
 
   /**
    * Forwards a host property to this instance.  This method should be
@@ -145,6 +145,6 @@ declare namespace Polymer {
      * @returns Template instance representing the
      *   binding scope for the element
      */
-    function modelForElement(template: HTMLTemplateElement|null, node: Node|null): TemplateInstanceBase|null;
+    function modelForElement(template: HTMLTemplateElement|null, node?: Node|null): TemplateInstanceBase|null;
   }
 }


### PR DESCRIPTION
This is just to add a few annotations for improving the types we just merged in #4928.

I wasn't too sure about dom-repeat's `indexForElement` but if you follow it through the source, it seems it can only ever return a number.

---

* Fixes #5010
* Fixes #5012 