### PR TITLE
Fail travis on non updated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 - npm install -g bower gulp-cli@1
 - bower install
 - gulp lint-eslint
+- gulp generate-typescript
 - git diff --exit-code
 script:
 - xvfb-run wct -l chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 - npm install -g bower gulp-cli@1
 - bower install
 - gulp lint-eslint
+- git diff --exit-code
 script:
 - xvfb-run wct -l chrome
 - xvfb-run wct -l firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 - npm install -g bower gulp-cli@1
 - bower install
 - gulp lint-eslint
+- gulp generate-externs
 - gulp generate-typescript
 - git diff --exit-code
 script:

--- a/lib/utils/async.html
+++ b/lib/utils/async.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * delay.
        *
        * @memberof Polymer.Async.timeOut
-       * @param {number} delay Time to wait before calling callbacks in ms
+       * @param {number=} delay Time to wait before calling callbacks in ms
        * @return {!AsyncInterface} An async timeout interface
        */
       after(delay) {

--- a/lib/utils/async.html
+++ b/lib/utils/async.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * delay.
        *
        * @memberof Polymer.Async.timeOut
-       * @param {number=} delay Time to wait before calling callbacks in ms
+       * @param {number} delay Time to wait before calling callbacks in ms
        * @return {!AsyncInterface} An async timeout interface
        */
       after(delay) {


### PR DESCRIPTION
In #4928 we added support for TypeScript by auto-generating types based on the Closure types defined in the library. However, we have to remember that whenever we update our types, that we also regenerate these TypeScript types.

I browsed the man pages of `git diff` and came across `git diff --exit-code`: https://git-scm.com/docs/git-diff#git-diff---exit-code This makes `git diff` fail whenever there are changes.

As such, this PR introduces the `git diff` in the `before_script` stage on Travis. This task now runs the generation script of TypeScript types and then verifies that there are no uncommitted changes. Whenever someone updates any Closure types (or adds them with new features), the Travis build will now fail if the developer forgot to update the TypeScript types.

In the commit history of this PR, you can see that the 2nd commit intentionally failed, by updating 1 of our types and not committing the corresponding TypeScript `d.ts` updates.