### PR TITLE
Fix settings so that its properly picked up by both gen-ts and modulizer

### DIFF
--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @namespace
    * @memberof Polymer
    */
-   Polymer.Settings = Polymer.Settings || {};
+  Polymer.Settings = Polymer.Settings || {};
 
   Polymer.Settings.useShadow = !(window.ShadyDOM);
   Polymer.Settings.useNativeCSSProperties =

--- a/lib/utils/settings.html
+++ b/lib/utils/settings.html
@@ -16,13 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   'use strict';
 
-  const settings = Polymer.Settings || {};
-  settings.useShadow = !(window.ShadyDOM);
-  settings.useNativeCSSProperties =
-    Boolean(!window.ShadyCSS || window.ShadyCSS.nativeCss);
-  settings.useNativeCustomElements =
-    !(window.customElements.polyfillWrapFlushCallback);
-
   /**
    * Sets the global, legacy settings.
    *
@@ -30,7 +23,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @namespace
    * @memberof Polymer
    */
-  Polymer.Settings = settings;
+   Polymer.Settings = Polymer.Settings || {};
+
+  Polymer.Settings.useShadow = !(window.ShadyDOM);
+  Polymer.Settings.useNativeCSSProperties =
+    Boolean(!window.ShadyCSS || window.ShadyCSS.nativeCss);
+  Polymer.Settings.useNativeCustomElements =
+    !(window.customElements.polyfillWrapFlushCallback);
+
 
   /**
    * Globally settable property that is automatically assigned to


### PR DESCRIPTION
#4928 broke polymer-modulizer's ability to properly analyze the `settings.html` file. This file doesn't really work in an es modules world (it references from the `Polymer.Settings` namespace before `Polymer.Settings` is defined) and removing the JSDoc from the namespace definition breaks our special workaround logic in a really tricky way.

Applying the jsdoc to the namespace definition (and not where it is exported) is the pattern we've been following in the rest of the codebase, so with this PR we now match that as well.

- Tested working with the analyzer (no changes)
- Tested working with polymer-modulizer (fixes issue)
- Tested working with gen-ts (no changes)