### PR TITLE
[1.x] Allow adding type="custom" to avoid deprecation warning. Fixes #5017

### DIFF
--- a/src/lib/custom-style.html
+++ b/src/lib/custom-style.html
@@ -134,6 +134,11 @@ Note, all features of `custom-style` are available when defining styles as part 
       cases of ordering w.r.t the main document styles.
       */
       if (this.ownerDocument !== window.document && this.__appliedElement === this) {
+        // Allow users to add `type="custom"` to <style> tags to avoid deprecation warning
+        var type = this.getAttribute('type');
+        if (type == 'custom') {
+          this.removeAttribute('type');
+        }
         document.head.appendChild(this);
       }
       // needed becuase elements in imports do not get 'attached'

--- a/test/unit/custom-style-import.html
+++ b/test/unit/custom-style-import.html
@@ -21,7 +21,7 @@
 <link rel="import" href="sub/style-import.html">
 
 <style is="custom-style" include="shared-style style-import
-    style-import2">
+    style-import2" type="custom" id="type-was-custom">
   :root {
 
     --import-mixin: {

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -480,6 +480,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertComputed(m, '4px');
       });
 
+      test('imported custom-style style with type="custom" has type removed', function() {
+        const style = document.head.querySelector('style#type-was-custom');
+        assert.isFalse(style.hasAttribute('type'));
+      });
+
       test('dynamic custom-styles apply', function() {
         var dynamic = document.querySelector('.dynamic');
         assertComputed(dynamic, '0px');

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -481,7 +481,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('imported custom-style style with type="custom" has type removed', function() {
-        const style = document.head.querySelector('style#type-was-custom');
+        var style = document.head.querySelector('style#type-was-custom');
         assert.isFalse(style.hasAttribute('type'));
       });
 


### PR DESCRIPTION
Remove `type="custom"` when moving `custom-style` to main document.  Allows users to add `type="custom"` to avoid the deprecation warning.

Fixes #5017