### PR TITLE
Move absolute url logic to element-mixin

### DIFF
--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -638,6 +638,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {string} Rewritten URL relative to base
        */
       resolveUrl(url, base) {
+        // Preserve backward compatibility with `this.resolveUrl('/foo')` resolving
+        // against the main document per #2448
         if (url && ABS_URL.test(url)) {
           return url;
         }

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -21,6 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   'use strict';
 
+  const ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
+
   /**
    * Element class mixin that provides the core API for Polymer's meta-programming
    * features including template stamping, data-binding, attribute deserialization,
@@ -636,6 +638,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {string} Rewritten URL relative to base
        */
       resolveUrl(url, base) {
+        if (url && ABS_URL.test(url)) {
+          return url;
+        }
         if (!base && this.importPath) {
           base = Polymer.ResolveUrl.resolveUrl(this.importPath);
         }

--- a/lib/utils/resolve-url.html
+++ b/lib/utils/resolve-url.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'use strict';
 
     let CSS_URL_RX = /(url\()([^)]*)(\))/g;
-    let ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
     let workingURL;
     let resolveDoc;
     /**
@@ -27,9 +26,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {string} resolved URL
      */
     function resolveUrl(url, baseURI) {
-      if (url && ABS_URL.test(url)) {
-        return url;
-      }
       // Lazy feature detection.
       if (workingURL === undefined) {
         workingURL = false;

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -157,6 +157,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(actual, expected);
       });
     });
+
+    suite('Polymer.ResolveUrl', function() {
+      test('appends absolute url to basePath', function() {
+        assert.equal(Polymer.ResolveUrl.resolveUrl('/foo', 'http://localhost'), 'http://localhost/foo');
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This is backwards-compatible with the previous URL resolution.
Now, `Polymer.ResolveUrl.resolveUrl` correctly appends the url
to the basePath.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fixes #4788 
