### PR TITLE
Gestures: fall back to event.target when composedPath is empty.

### DIFF
--- a/lib/utils/gestures.html
+++ b/lib/utils/gestures.html
@@ -316,8 +316,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _findOriginalTarget: function(ev) {
       // shadowdom
       if (ev.composedPath) {
-        const target = /** @type {EventTarget} */(ev.composedPath()[0]);
-        return target;
+        const targets = /** @type {!Array<!EventTarget>} */(ev.composedPath());
+        // It shouldn't be, but sometimes targets is empty (window on Safari).
+        return targets.length > 0 ? targets[0] : ev.target;
       }
       // shadydom
       return ev.target;

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -550,6 +550,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         document.dispatchEvent(new MouseEvent('click', { detail: 1, clientX: 100, bubbles: true, composed: true }));
         Polymer.Gestures.remove(document, 'tap', null);
       });
+
+      test('#5030', function() {
+        let count = 0;
+        const increment = function() { count++; }
+        Polymer.Gestures.add(window, 'tap', increment);
+        window.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        assert.equal(count, 1);
+        Polymer.Gestures.remove(window, 'tap', increment);
+      });
     });
   </script>
 

--- a/test/unit/gestures.html
+++ b/test/unit/gestures.html
@@ -553,7 +553,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('#5030', function() {
         let count = 0;
-        const increment = function() { count++; }
+        const increment = function() { count++; };
         Polymer.Gestures.add(window, 'tap', increment);
         window.dispatchEvent(new MouseEvent('click', {bubbles: true}));
         assert.equal(count, 1);


### PR DESCRIPTION
This came up in Safari, where a click event on window ended up crashing gestures. No original target could be found, because `event.composedPath()` returned an empty array, which we assumed couldn't happen.

Found via https://github.com/Polymer/polymer-decorators/issues/27

Fixes #5030
  