### PR TITLE
add correct return type for `querySelectorAll`

### DIFF
--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -345,7 +345,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * @function
    * @param {string} selector
-   * @return {!NodeList}
+   * @return {!NodeList<!Node>}
    */
   Polymer.DomApi.prototype.querySelectorAll;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@polymer/gen-typescript-declarations": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.5.tgz",
-      "integrity": "sha512-Fyb58xk6bTr6tSYjNB7zSC6X+8X6WoNQcQBZ18J3qlwaljo+CfgjdpYJ9U91ci2YDv0y5v51s6k1uN+Uo9BSAw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.6.tgz",
+      "integrity": "sha512-cHPjrmhwqVcBl/HQMuuLmH4yKgtH1F5enOHWhytAWWymTu7QKJEg3WfqthFLHgajOSwlViVre6C3+sPA9VOZ3w==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@polymer/gen-closure-declarations": "^0.4.0",
-    "@polymer/gen-typescript-declarations": "^0.3.5",
+    "@polymer/gen-typescript-declarations": "^0.3.6",
     "@webcomponents/shadycss": "^1.1.0",
     "@webcomponents/webcomponentsjs": "^1.0.22",
     "babel-preset-minify": "^0.2.0",

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -138,7 +138,7 @@ declare namespace Polymer {
     setAttribute(name: string, value: string): void;
     removeAttribute(name: string): void;
     querySelector(selector: string): Element|null;
-    querySelectorAll(selector: string): NodeList;
+    querySelectorAll(selector: string): NodeListOf<Node>;
   }
 
 


### PR DESCRIPTION
Just a quick fix now that we have a new version of the generator released.

Changing `NodeList` to the correct parameterised type, `NodeList<Node>`.