### PR TITLE
Update mixinBehaviors annotation. Behaviors don't satisfy PolymerInit.

### DIFF
--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * the underlying element.
      *
      * @template T
-     * @param {!(PolymerInit|Array<!PolymerInit>)} behaviors Behavior object or array of behaviors.
+     * @param {!Object|!Array<!Object>} behaviors Behavior object or array of behaviors.
      * @param {function(new:T)} klass Element class.
      * @return {function(new:T)} Returns a new Element class extended by the
      * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.

--- a/types/lib/legacy/class.d.ts
+++ b/types/lib/legacy/class.d.ts
@@ -23,7 +23,7 @@ declare namespace Polymer {
    * @returns Returns a new Element class extended by the
    * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
    */
-  function mixinBehaviors<T>(behaviors: PolymerInit|PolymerInit[]|null, klass: {new(): T}): {new(): T};
+  function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): {new(): T};
 
 
   /**


### PR DESCRIPTION
Behaviors don't have an `is`, so this type annotation was slightly off. I think what we really want is something like `PolymerInit` minus the `is`, but for now this at least makes things compile.