### PR TITLE
Remove unnecessary limit check

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -558,7 +558,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let itemIdx = isntIdxToItemsIdx[instIdx];
         let item = items[itemIdx];
         itemsIdxToInstIdx[itemIdx] = instIdx;
-        if (inst && instIdx < this.__limit) {
+        if (inst) {
           inst._setPendingProperty(this.as, item);
           inst._setPendingProperty(this.indexAs, instIdx);
           inst._setPendingProperty(this.itemsIndexAs, itemIdx);


### PR DESCRIPTION
https://github.com/Polymer/polymer/blob/master/lib/elements/dom-repeat.html#L555-L556

```JS
const limit = Math.min(isntIdxToItemsIdx.length, this.__limit);
      for (; instIdx<limit; instIdx++) {
```

So, for each interation of the loop this holds:
```JS
instIdx < Math.min(isntIdxToItemsIdx.length, this.__limit)
```

Which implies:
```JS
instIdx < this.__limit
```

Consequently `&& instIdx < this.__limit` is essentially the same as `&& true` and can be left out.