### PR TITLE
dom-repeat accepts template provided by slot

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -323,16 +323,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     }
 
+    __getTemplate () {
+      for (let el = this.firstElementChild; el; el = el.nextElementSibling) {
+        if (el.nodeName === 'TEMPLATE') { return el; }
+        if (el.nodeName === 'SLOT') {
+          const assignedNodes =
+            /** @type {HTMLSlotElement} */ (el).assignedNodes({flatten: true});
+          for (let assignedNode of assignedNodes) {
+            if (assignedNode.nodeName === 'TEMPLATE') { return assignedNode; }
+          }
+        }
+      }
+    }
+
     __ensureTemplatized() {
       // Templatizing (generating the instance constructor) needs to wait
       // until ready, since won't have its template content handed back to
       // it until then
       if (!this.__ctor) {
-        let template = this.template = this.querySelector('template');
+        let template = this.template = this.__getTemplate();
         if (!template) {
-          // // Wait until childList changes and template should be there by then
+          // Wait until childList changes and template should be there by then
           let observer = new MutationObserver(() => {
-            if (this.querySelector('template')) {
+            if (this.__getTemplate()) {
               observer.disconnect();
               this.__render();
             } else {

--- a/test/unit/dom-repeat-elements.html
+++ b/test/unit/dom-repeat-elements.html
@@ -528,3 +528,41 @@ window.getData = () => [
     });
   </script>
 </dom-module>
+
+<dom-module id="x-repeat-with-template-through-slot">
+  <template>
+    <x-repeat-with-template-through-slot-inner id="inner" items="{{items}}">
+      <template >
+        <x-foo itema-prop="{{item}}"></x-foo>
+      </template>
+    </x-repeat-with-template-through-slot-inner>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-repeat-with-template-through-slot',
+    properties: {
+      items: {
+        value: function() {
+          return ['a', 'b', 'c'];
+        }
+      }
+    }
+  });
+  </script>
+</dom-module>
+
+<dom-module id="x-repeat-with-template-through-slot-inner">
+  <template>
+    <dom-repeat id="repeater" is="dom-repeat" items="{{items}}">
+      <slot></slot>
+    </dom-repeat>
+  </template>
+  <script>
+  Polymer({
+    is: 'x-repeat-with-template-through-slot-inner',
+    properties: {
+      items: { notify: true }
+    }
+  });
+  </script>
+</dom-module>

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -125,6 +125,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-repeat>
   </div>
 
+  <test-fixture id="template-through-slot">
+    <template>
+      <x-repeat-with-template-through-slot></x-repeat-with-template-through-slot>
+    </template>
+  </test-fixture>
+
   <script>
   (function() {
     'use strict';
@@ -4183,6 +4189,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         el.push('items', {prop: 'added2'});
         Polymer.flush();
         assert.equal(domChangeFired, 2);
+      });
+    });
+
+    suite('provide template through slot', function() {
+      let fixtureInstance;
+
+      setup(function() {
+        fixtureInstance = fixture('template-through-slot');
+        Polymer.flush();
+      });
+
+      test('basic rendering to check whether template can be found', function() {
+        var stamped = fixtureInstance.$.inner.root.querySelectorAll('*:not(template):not(dom-repeat):not(slot)');
+        assert.equal(stamped.length, 3, 'total stamped count incorrect');
+        assert.equal(fixtureInstance.$.inner.$.repeater.renderedItemCount, 3, 'rendered item count incorrect');
+        assert.equal(stamped[0].itemaProp, 'a');
+        assert.equal(stamped[1].itemaProp, 'b');
+        assert.equal(stamped[2].itemaProp, 'c');
       });
     });
 


### PR DESCRIPTION
Makes this work:

```HTML
<my-repeater items="{{items}}">
  <template>[[item]]</template>
</my-repeater>
```

```HTML
<!-- Template for `<my-repeater>` uses a `<slot>`-->
<dom-repeat items="{{items}}">
  <slot></slot>
</dom-repeat>
```