### PR TITLE
Use sudo to fix chrome testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+sudo: required
 dist: trusty
 node_js: stable
 addons:


### PR DESCRIPTION
There is a bug with the chrome sandbox in the Travis CI container
system, which is fixed by using `sudo: required`.

Related to travis-ci/travis-ci#8836