### PR TITLE
Simplify code for <dom-repeat>'s `sort` and `filter` properties

### DIFF
--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -392,22 +392,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return this.__dataHost._methodHost || this.__dataHost;
     }
 
-    __sortChanged(sort) {
-      let methodHost = this.__getMethodHost();
-      this.__sortFn = sort && (typeof sort == 'function' ? sort :
-        function() { return methodHost[sort].apply(methodHost, arguments); });
-      if (this.items) {
-        this.__debounceRender(this.__render);
+    __functionFromPropertyValue(functionOrMethodName) {
+      if (typeof functionOrMethodName === 'string') {
+        let methodName = functionOrMethodName;
+        let obj = this.__getMethodHost();
+        return function() { return obj[methodName].apply(obj, arguments); };
       }
+
+      return functionOrMethodName;
+    }
+
+    __sortChanged(sort) {
+      this.__sortFn = this.__functionFromPropertyValue(sort);
+      if (this.items) { this.__debounceRender(this.__render); }
     }
 
     __filterChanged(filter) {
-      let methodHost = this.__getMethodHost();
-      this.__filterFn = filter && (typeof filter == 'function' ? filter :
-        function() { return methodHost[filter].apply(methodHost, arguments); });
-      if (this.items) {
-        this.__debounceRender(this.__render);
-      }
+      this.__filterFn = this.__functionFromPropertyValue(filter);
+      if (this.items) { this.__debounceRender(this.__render); }
     }
 
     __computeFrameTime(rate) {


### PR DESCRIPTION
This change removes two ternary operators that spanned two lines and replaces them with less complicated code that does the same thing.