### PR TITLE
Exclude index.html from type generation.

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -4,7 +4,8 @@
     "externs/**",
     "gulpfile.js",
     "test/**",
-    "util/**"
+    "util/**",
+    "index.html"
   ],
   "removeReferences": [
     "../shadycss/apply-shim.d.ts",


### PR DESCRIPTION
An upcoming change to gen-typescript-declarations will produce `d.ts` files even for HTML files with no script, so we need to exclude cases like this.

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
