### PR TITLE
Update JSDocs to use <dom-repeat> tags

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -373,19 +373,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *   <template>
    *
    *     <div> Employee list: </div>
-   *     <template is="dom-repeat" id="employeeList" items="{{employees}}">
+   *     <dom-repeat id="employeeList" items="{{employees}}">
+   *       <template>
    *         <div>First name: <span>{{item.first}}</span></div>
-   *         <div>Last name: <span>{{item.last}}</span></div>
-   *         <button on-click="toggleSelection">Select</button>
-   *     </template>
+   *           <div>Last name: <span>{{item.last}}</span></div>
+   *           <button on-click="toggleSelection">Select</button>
+   *       </template>
+   *     </dom-repeat>
    *
    *     <array-selector id="selector" items="{{employees}}" selected="{{selected}}" multi toggle></array-selector>
    *
    *     <div> Selected employees: </div>
-   *     <template is="dom-repeat" items="{{selected}}">
+   *     <dom-repeat items="{{selected}}">
+   *       <template>
    *         <div>First name: <span>{{item.first}}</span></div>
    *         <div>Last name: <span>{{item.last}}</span></div>
-   *     </template>
+   *       </template>
+   *     </dom-repeat>
    *
    *   </template>
    *
@@ -393,20 +397,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * ```
    *
    * ```js
-   * Polymer({
-   *   is: 'employee-list',
-   *   ready() {
-   *     this.employees = [
-   *         {first: 'Bob', last: 'Smith'},
-   *         {first: 'Sally', last: 'Johnson'},
-   *         ...
-   *     ];
-   *   },
-   *   toggleSelection(e) {
-   *     let item = this.$.employeeList.itemForElement(e.target);
-   *     this.$.selector.select(item);
-   *   }
-   * });
+   *class EmployeeList extends Polymer.Element {
+   *  static get is() { return 'employee-list'; }
+   *  static get properties() {
+   *    return {
+   *      employees: {
+   *        value() {
+   *          return [
+   *            {first: 'Bob', last: 'Smith'},
+   *            {first: 'Sally', last: 'Johnson'},
+   *            ...
+   *          ];
+   *        }
+   *      }
+   *    };
+   *  }
+   *  toggleSelection(e) {
+   *    let item = this.$.employeeList.itemForElement(e.target);
+   *    this.$.selector.select(item);
+   *  }
+   *}
    * ```
    *
    * @polymer

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -43,10 +43,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *   <template>
    *
    *     <div> Employee list: </div>
-   *     <template is="dom-repeat" items="{{employees}}">
+   *     <dom-repeat items="{{employees}}">
+   *       <template>
    *         <div>First name: <span>{{item.first}}</span></div>
    *         <div>Last name: <span>{{item.last}}</span></div>
-   *     </template>
+   *       </template>
+   *     </dom-repeat>
    *
    *   </template>
    *
@@ -116,8 +118,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * Then the `observe` property should be configured as follows:
    *
    * ```html
-   * <template is="dom-repeat" items="{{employees}}"
-   *           filter="isEngineer" observe="type manager.type">
+   * <dom-repeat items="{{employees}}" filter="isEngineer" observe="type manager.type">
    * ```
    *
    * @customElement

--- a/types/lib/elements/dom-repeat.d.ts
+++ b/types/lib/elements/dom-repeat.d.ts
@@ -32,10 +32,12 @@ declare namespace Polymer {
    *   <template>
    *
    *     <div> Employee list: </div>
-   *     <template is="dom-repeat" items="{{employees}}">
+   *     <dom-repeat items="{{employees}}">
+   *       <template>
    *         <div>First name: <span>{{item.first}}</span></div>
    *         <div>Last name: <span>{{item.last}}</span></div>
-   *     </template>
+   *       </template>
+   *     </dom-repeat>
    *
    *   </template>
    *
@@ -105,8 +107,7 @@ declare namespace Polymer {
    * Then the `observe` property should be configured as follows:
    *
    * ```html
-   * <template is="dom-repeat" items="{{employees}}"
-   *           filter="isEngineer" observe="type manager.type">
+   * <dom-repeat items="{{employees}}" filter="isEngineer" observe="type manager.type">
    * ```
    */
   class DomRepeat extends


### PR DESCRIPTION
Follow-up of #5083, Fixes #5077 

The [documentation page for v2 dom-repeat](https://www.polymer-project.org/2.0/docs/api/elements/Polymer.DomRepeat) still uses Polymer 1 element creation syntax and the `<template is="dom-repeat">` shorthand.

My understanding from https://www.polymer-project.org/2.0/docs/about_20#type-extension is that the wraped element syntax `<dom-repeat>` should now be promoted.