### PR TITLE
Fix JSDoc example formatting

### DIFF
--- a/lib/utils/html-tag.html
+++ b/lib/utils/html-tag.html
@@ -77,14 +77,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * Example:
      *
-     *   static get template() {
-     *     return Polymer.html`
-     *       <style>:host{ content:"..." }</style>
-     *       <div class="shadowed">${this.partialTemplate}</div>
-     *       ${super.template}
-     *     `;
-     *   }
-     *   static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
+     *     static get template() {
+     *       return Polymer.html`
+     *         <style>:host{ content:"..." }</style>
+     *         <div class="shadowed">${this.partialTemplate}</div>
+     *         ${super.template}
+     *       `;
+     *     }
+     *     static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
      *
      * @memberof Polymer
      * @param {!ITemplateArray} strings Constant parts of tagged template literal
@@ -104,17 +104,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * Example:
      *
-     *   static get template() {
-     *     return Polymer.html`
-     *       <style>
-     *         :host { display: block; }
-     *         ${styleTemplate}
-     *       </style>
-     *       <div class="shadowed">${staticValue}</div>
-     *       ${super.template}
-     *     `;
-     *   }
-     *   static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
+     *     static get template() {
+     *       return Polymer.html`
+     *         <style>
+     *           :host { display: block; }
+     *           ${styleTemplate}
+     *         </style>
+     *         <div class="shadowed">${staticValue}</div>
+     *         ${super.template}
+     *       `;
+     *     }
+     *     static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
      *
      * @memberof Polymer
      * @param {!ITemplateArray} strings Constant parts of tagged template literal

--- a/types/lib/utils/html-tag.d.ts
+++ b/types/lib/utils/html-tag.d.ts
@@ -48,14 +48,14 @@ declare namespace Polymer {
    *
    * Example:
    *
-   *   static get template() {
-   *     return Polymer.html`
-   *       <style>:host{ content:"..." }</style>
-   *       <div class="shadowed">${this.partialTemplate}</div>
-   *       ${super.template}
-   *     `;
-   *   }
-   *   static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
+   *     static get template() {
+   *       return Polymer.html`
+   *         <style>:host{ content:"..." }</style>
+   *         <div class="shadowed">${this.partialTemplate}</div>
+   *         ${super.template}
+   *       `;
+   *     }
+   *     static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
    *
    * @returns Constructed HTMLTemplateElement
    */
@@ -68,17 +68,17 @@ declare namespace Polymer {
    *
    * Example:
    *
-   *   static get template() {
-   *     return Polymer.html`
-   *       <style>
-   *         :host { display: block; }
-   *         ${styleTemplate}
-   *       </style>
-   *       <div class="shadowed">${staticValue}</div>
-   *       ${super.template}
-   *     `;
-   *   }
-   *   static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
+   *     static get template() {
+   *       return Polymer.html`
+   *         <style>
+   *           :host { display: block; }
+   *           ${styleTemplate}
+   *         </style>
+   *         <div class="shadowed">${staticValue}</div>
+   *         ${super.template}
+   *       `;
+   *     }
+   *     static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
    *
    * @returns Constructed literal string
    */


### PR DESCRIPTION
Examples need a 4-space indent to get formatted properly.
