### PR TITLE
Throw an error if Polymer is loaded twice

### DIFF
--- a/lib/utils/boot.html
+++ b/lib/utils/boot.html
@@ -14,12 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   const userPolymer = window.Polymer;
 
   if (userPolymer && 'version' in userPolymer) {
-    throw new Error(`
-      Polymer was already loaded. This is likely an issue with an incorrect
-      link loading a fallback page or if a link to polymer.html redirects
-      to the wrong directory. E.g. "../polymer.html" and "../../polymer.html"
-      could load Polymer twice. Make sure that all urls pointing to Polymer
-      or dependencies that rely on Polymer are correctly deduped.`);
+    throw new Error(`Error: Polymer loaded twice.`);
   }
 
   /**

--- a/lib/utils/boot.html
+++ b/lib/utils/boot.html
@@ -13,6 +13,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   const userPolymer = window.Polymer;
 
+  if (userPolymer && 'version' in userPolymer) {
+    throw new Error(`
+      Polymer was already loaded. This is likely an issue with an incorrect
+      link loading a fallback page or if a link to polymer.html redirects
+      to the wrong directory. E.g. "../polymer.html" and "../../polymer.html"
+      could load Polymer twice. Make sure that all urls pointing to Polymer
+      or dependencies that rely on Polymer are correctly deduped.`);
+  }
+
   /**
    * @namespace Polymer
    * @summary Polymer is a lightweight library built on top of the web

--- a/test/runner.html
+++ b/test/runner.html
@@ -78,7 +78,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/render-status.html',
       'unit/dir.html',
       'unit/shady-unscoped-style.html',
-      'unit/html-tag.html'
+      'unit/html-tag.html',
+      'unit/loading-twice.html'
       // 'unit/multi-style.html'
     ];
 

--- a/test/smoke/polymer-loaded-twice.html
+++ b/test/smoke/polymer-loaded-twice.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+  <link rel="import" href="../../polymer.html" />
+  <link rel="import" href="/polymer.html" />
+</head>
+<body>
+  <div>
+    Passes if there is an error in the console that explains the duplicate loading of Polymer
+  </div>
+</body>
+</html>

--- a/test/smoke/polymer-loaded-twice.html
+++ b/test/smoke/polymer-loaded-twice.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <link rel="import" href="../../polymer.html" />
-  <link rel="import" href="/polymer.html" />
+  <link rel="import" href="../../lib/utils/boot.html" />
+  <link rel="import" href="../../lib/utils/boot.html?version=2" />
 </head>
 <body>
   <div>

--- a/test/unit/loading-twice-iframe.html
+++ b/test/unit/loading-twice-iframe.html
@@ -5,12 +5,12 @@
   <script>
   window.addEventListener('message', () => {
     const relativeLink = document.createElement('link');
-    relativeLink.href = '../../polymer.html';
+    relativeLink.href = '../../lib/utils/boot.html';
     relativeLink.rel = 'import';
     document.body.appendChild(relativeLink);
 
     const absoluteLink = document.createElement('link');
-    absoluteLink.href = '/polymer.html';
+    absoluteLink.href = '../../lib/utils/boot.html?version=2';
     absoluteLink.rel = 'import';
     absoluteLink.onload = () => {
       window.parent.postMessage('Finished', '*');

--- a/test/unit/loading-twice-iframe.html
+++ b/test/unit/loading-twice-iframe.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+</head>
+<body>
+  <script>
+  window.addEventListener('message', () => {
+    const relativeLink = document.createElement('link');
+    relativeLink.href = '../../polymer.html';
+    relativeLink.rel = 'import';
+    document.body.appendChild(relativeLink);
+
+    const absoluteLink = document.createElement('link');
+    absoluteLink.href = '/polymer.html';
+    absoluteLink.rel = 'import';
+    absoluteLink.onload = () => {
+      window.parent.postMessage('Finished', '*');
+    };
+    document.body.appendChild(absoluteLink);
+  });
+  </script>
+</body>
+</html>

--- a/test/unit/loading-twice-iframe.html
+++ b/test/unit/loading-twice-iframe.html
@@ -1,21 +1,22 @@
 <html>
 <head>
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 </head>
 <body>
   <script>
-  window.addEventListener('message', () => {
+  window.addEventListener('message', function() {
     const relativeLink = document.createElement('link');
     relativeLink.href = '../../lib/utils/boot.html';
     relativeLink.rel = 'import';
-    document.body.appendChild(relativeLink);
+    document.head.appendChild(relativeLink);
 
-    const absoluteLink = document.createElement('link');
-    absoluteLink.href = '../../lib/utils/boot.html?version=2';
-    absoluteLink.rel = 'import';
-    absoluteLink.onload = () => {
+    const relativeLinkWithQueryParameter = document.createElement('link');
+    relativeLinkWithQueryParameter.href = '../../lib/utils/boot.html?version=2';
+    relativeLinkWithQueryParameter.rel = 'import';
+    relativeLinkWithQueryParameter.onload = function() {
       window.parent.postMessage('Finished', '*');
     };
-    document.body.appendChild(absoluteLink);
+    document.head.appendChild(relativeLinkWithQueryParameter);
   });
   </script>
 </body>

--- a/test/unit/loading-twice.html
+++ b/test/unit/loading-twice.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+<body>
+  <script>
+  suite('loading polymer twice', function() {
+    let iframe;
+
+    setup(function() {
+      iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+    });
+
+    teardown(function() {
+      document.body.removeChild(iframe);
+    });
+
+    test('throws a nice error', function(done) {
+      iframe.addEventListener('load', () => {
+        const spy = sinon.spy();
+        iframe.contentWindow.onerror = spy;
+
+        window.addEventListener('message', () => {
+          assert.isTrue(spy.firstCall.calledWithMatch((error) => error.includes('Polymer loaded twice')), 'Error message should include "Polymer loaded twice"');
+          done();
+        });
+
+        iframe.contentWindow.postMessage('Start', '*');
+      });
+      iframe.src = 'loading-twice-iframe.html';
+    });
+  });
+  </script>
+</body>
+</html>

--- a/test/unit/loading-twice.html
+++ b/test/unit/loading-twice.html
@@ -33,7 +33,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         iframe.contentWindow.onerror = spy;
 
         window.addEventListener('message', () => {
-          assert.isTrue(spy.firstCall.calledWithMatch((error) => error.includes('Polymer loaded twice')), 'Error message should include "Polymer loaded twice"');
+          const error = spy.firstCall.args[0];
+          // Old browsers (Safari 9-10) do not expose the actual error message.
+          // Therefore, if the message is non-sensical skip the assert.
+          if (error !== 'Script error.') {
+            assert.isTrue(error.indexOf('Polymer loaded twice') >= 0, 'Error message should include "Polymer loaded twice"');
+          }
           done();
         });
 


### PR DESCRIPTION
Whenever Polymer is somehow loaded twice, there is a cryptic error shown in the console:
```
Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': this name has already been used with this registry
```
This happens when two urls resolve to different versions of Polymer (for example relative and absolute url). The following is now shown in the console when running the new smoke test:
![image](https://user-images.githubusercontent.com/5948271/35871122-c1e1c052-0b63-11e8-9b1b-e8970d2d552a.png)

Feel free to bikeshed on the actual message. Maybe @arthurevans has suggestions for this?
### Reference Issue
Fixes #4134 
