### PR TITLE
[PropertiesChanged]: adds _shouldPropertiesChange

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -82,6 +82,15 @@ Polymer_PropertiesChanged.prototype._flushProperties = function(){};
   call to `_propertiesChanged`
 * @param {!Object} oldProps Bag of previous values for each property
   in `changedProps`
+* @return {boolean}
+*/
+Polymer_PropertiesChanged.prototype._shouldPropertiesChange = function(currentProps, changedProps, oldProps){};
+/**
+* @param {!Object} currentProps Bag of all current accessor values
+* @param {!Object} changedProps Bag of properties changed since the last
+  call to `_propertiesChanged`
+* @param {!Object} oldProps Bag of previous values for each property
+  in `changedProps`
 * @return {void}
 */
 Polymer_PropertiesChanged.prototype._propertiesChanged = function(currentProps, changedProps, oldProps){};

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -353,7 +353,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          *   in `changedProps`
          * @return {boolean} true if changedProps is truthy
          */
-        _shouldPropertiesChange(props, changedProps, old) {
+        _shouldPropertiesChange(currentProps, changedProps, oldProps) { // eslint-disable-line no-unused-vars
           return changedProps;
         }
 

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -337,6 +337,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const old = this.__dataOld;
           if (this._shouldPropertiesChange(props, changedProps, old)) {
             this.__dataPending = null;
+            this.__dataOld = null;
             this._propertiesChanged(props, changedProps, old);
           }
         }

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -143,7 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             /* eslint-disable valid-jsdoc */
             /** @this {PropertiesChanged} */
             get() {
-              return this.__data[property];
+              return this._getProperty(property);
             },
             /** @this {PropertiesChanged} */
             set: readOnly ? function () {} : function (value) {
@@ -332,11 +332,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          * @protected
          */
         _flushProperties() {
-          if (this.__dataPending && this.__dataOld) {
-            let changedProps = this.__dataPending;
+          const props = this.__data;
+          const changedProps = this.__dataPending;
+          const old = this.__dataOld;
+          if (this._shouldPropertiesChange(props, changedProps, old)) {
             this.__dataPending = null;
-            this._propertiesChanged(this.__data, changedProps, this.__dataOld);
+            this._propertiesChanged(props, changedProps, old);
           }
+        }
+
+        /**
+         * Called in `_flushProperties` to determine if `_propertiesChanged`
+         * should be called. The default implementation returns true if
+         * properties are pending. Override to customize when
+         * `_propertiesChanged` is called.
+         * @param {!Object} currentProps Bag of all current accessor values
+         * @param {!Object} changedProps Bag of properties changed since the last
+         *   call to `_propertiesChanged`
+         * @param {!Object} oldProps Bag of previous values for each property
+         *   in `changedProps`
+         * @return {boolean} true if changedProps is truthy
+         */
+        _shouldPropertiesChange(props, changedProps, old) {
+          return changedProps;
         }
 
         /**

--- a/test/unit/properties-changed.html
+++ b/test/unit/properties-changed.html
@@ -160,8 +160,7 @@ suite('properties-changed', function() {
         done();
       });
     });
-  })
-
+  });
 });
 
 </script>

--- a/test/unit/properties-changed.html
+++ b/test/unit/properties-changed.html
@@ -56,6 +56,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     window.XFoo = XFoo;
     customElements.define('x-foo', XFoo);
+
+    class ShouldPropertiesChange extends Polymer.PropertiesChanged(HTMLElement) {
+      constructor() {
+        super();
+        this._propertiesChanged = sinon.spy();
+      }
+
+      connectedCallback() {
+        this._enableProperties();
+        //this._flushProperties();
+      }
+
+      _shouldPropertiesChange() {
+        return true;
+      }
+    }
+
+    customElements.define('should-properties-change', ShouldPropertiesChange);
   });
 </script>
 
@@ -128,6 +146,21 @@ suite('properties-changed', function() {
 
     });
   });
+
+  test('shouldPropertiesChange', function(done) {
+    const el = document.createElement('should-properties-change');
+    document.body.appendChild(el);
+    assert.isTrue(el._propertiesChanged.calledOnce);
+    el._invalidateProperties();
+    setTimeout(function() {
+      assert.isTrue(el._propertiesChanged.calledTwice);
+      el._setProperty('foo', true);
+      setTimeout(function() {
+        assert.isTrue(el._propertiesChanged.calledThrice);
+        done();
+      });
+    });
+  })
 
 });
 

--- a/types/lib/mixins/properties-changed.d.ts
+++ b/types/lib/mixins/properties-changed.d.ts
@@ -183,6 +183,21 @@ declare namespace Polymer {
     _flushProperties(): void;
 
     /**
+     * Called in `_flushProperties` to determine if `_propertiesChanged`
+     * should be called. The default implementation returns true if
+     * properties are pending. Override to customize when
+     * `_propertiesChanged` is called.
+     *
+     * @param currentProps Bag of all current accessor values
+     * @param changedProps Bag of properties changed since the last
+     *   call to `_propertiesChanged`
+     * @param oldProps Bag of previous values for each property
+     *   in `changedProps`
+     * @returns true if changedProps is truthy
+     */
+    _shouldPropertiesChange(currentProps: object, changedProps: object, oldProps: object): boolean;
+
+    /**
      * Callback called when any properties with accessors created via
      * `_createPropertyAccessor` have been set.
      *


### PR DESCRIPTION
Fixes https://github.com/Polymer/polymer/issues/5098

Adds `_shouldPropertiesChange` method which can be overridden to customize when the `_propertiesChanged` method is called. This method gets the current, pending, and old property values and by default returns truthy...

