### PR TITLE
Tighten a type. Bump TS generator version. Format Travis type error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ before_script:
 - npm install -g bower gulp-cli@1
 - bower install
 - gulp lint-eslint
-- gulp update-types
-- git diff --exit-code
+- >-
+  npm run update-types && git diff --exit-code || (echo -e
+  '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
+  update-types".' && false)
 script:
 - wct -l chrome -l firefox
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then travis_wait 30 ./util/travis-sauce-test.sh; fi

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,5 +1,5 @@
 {
-  "exclude": [
+  "excludeFiles": [
     "dist/**",
     "externs/**",
     "gulpfile.js",

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -282,7 +282,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Returns the `composedPath` for this event.
-     * @return {!Array<EventTarget>} The nodes this event propagated through
+     * @return {!Array<!EventTarget>} The nodes this event propagated through
      */
     get path() {
       return this.event.composedPath();

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,6 +587,15 @@
         "ansi-wrap": "0.1.0"
       }
     },
+    "ansi-escape-sequences": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "dev": true,
+      "requires": {
+        "array-back": "2.0.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -2240,7 +2249,9 @@
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
       "dev": true,
       "requires": {
+        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
+        "table-layout": "0.4.2",
         "typical": "2.6.1"
       }
     },
@@ -2536,6 +2547,12 @@
       "requires": {
         "type-detect": "4.0.7"
       }
+    },
+    "deep-extend": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
+      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5755,6 +5772,12 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -9208,6 +9231,19 @@
         }
       }
     },
+    "table-layout": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
+      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "dev": true,
+      "requires": {
+        "array-back": "2.0.0",
+        "deep-extend": "0.5.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
+      }
+    },
     "tar-stream": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
@@ -10540,6 +10576,16 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wordwrapjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "dev": true,
+      "requires": {
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,20 +15,22 @@
       }
     },
     "@polymer/gen-typescript-declarations": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-0.3.6.tgz",
-      "integrity": "sha512-cHPjrmhwqVcBl/HQMuuLmH4yKgtH1F5enOHWhytAWWymTu7QKJEg3WfqthFLHgajOSwlViVre6C3+sPA9VOZ3w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.1.1.tgz",
+      "integrity": "sha512-rUfH6USpiPYSHl2dC+/rGb3RYK8LPyqNhiuZCLv13F0fhYr01jdTogGuSphEoSLklm1gKRsDsrfZq7OvpzPYEg==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "4.0.7",
-        "command-line-args": "4.0.7",
+        "@types/fs-extra": "5.0.0",
+        "@types/glob": "5.0.35",
+        "command-line-args": "5.0.1",
         "command-line-usage": "4.1.0",
         "doctrine": "2.1.0",
         "escodegen": "1.9.0",
-        "fs-extra": "4.0.3",
+        "fs-extra": "5.0.0",
+        "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.7"
+        "polymer-analyzer": "3.0.0-pre.10"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -37,6 +39,17 @@
           "integrity": "sha1-6JLSk8ksnB0/mvcsFaVU+8fgiVo=",
           "dev": true
         },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
         "parse5": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
@@ -44,9 +57,9 @@
           "dev": true
         },
         "polymer-analyzer": {
-          "version": "3.0.0-pre.7",
-          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.7.tgz",
-          "integrity": "sha512-R9wAvlkvq1vrjPI3N7frF2pzMpZhrgyDIgkqBAZIZtQvOuZ6Hyp5qTFPEiX6SR5wU8UBI4dqSpYXoCBmhIT8PA==",
+          "version": "3.0.0-pre.10",
+          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.10.tgz",
+          "integrity": "sha1-9vCd15PdL0IomsAdoCb8q6ZfGYw=",
           "dev": true,
           "requires": {
             "@types/babel-generator": "6.25.1",
@@ -291,9 +304,9 @@
       "optional": true
     },
     "@types/fs-extra": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.7.tgz",
-      "integrity": "sha512-BN48b/2F3kL0Ual7tjcHjj0Fl+nuYKtHa0G/xT3Q43HuCpN7rQD5vIx6Aqnl9x10oBI5xMJh8Ly+FQpP205JlA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
       "dev": true,
       "requires": {
         "@types/node": "6.0.96"
@@ -574,15 +587,6 @@
         "ansi-wrap": "0.1.0"
       }
     },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
-      }
-    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -692,6 +696,38 @@
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      }
+    },
+    "argv-tools": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
+      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
+      "dev": true,
+      "requires": {
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1"
+      },
+      "dependencies": {
+        "find-replace": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "test-value": "3.0.0"
+          }
+        },
+        "test-value": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "typical": "2.6.1"
+          }
+        }
       }
     },
     "arr-diff": {
@@ -2164,14 +2200,38 @@
       }
     },
     "command-line-args": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
+      "integrity": "sha512-gRJDcIjFSzMcmG/GrJlgL0wWoAxr11mVzCq32bjka0endupm9meLwvoJUKc4HDeFiEIB2X3GvNrhF5cKO4Bd4A==",
       "dev": true,
       "requires": {
+        "argv-tools": "0.1.1",
         "array-back": "2.0.0",
-        "find-replace": "1.0.3",
+        "find-replace": "2.0.1",
+        "lodash.camelcase": "4.3.0",
         "typical": "2.6.1"
+      },
+      "dependencies": {
+        "find-replace": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "test-value": "3.0.0"
+          }
+        },
+        "test-value": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "2.0.0",
+            "typical": "2.6.1"
+          }
+        }
       }
     },
     "command-line-usage": {
@@ -2180,9 +2240,7 @@
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
         "typical": "2.6.1"
       }
     },
@@ -2478,12 +2536,6 @@
       "requires": {
         "type-detect": "4.0.7"
       }
-    },
-    "deep-extend": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
-      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
-      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5637,6 +5689,12 @@
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
@@ -5697,12 +5755,6 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -9156,19 +9208,6 @@
         }
       }
     },
-    "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "deep-extend": "0.5.0",
-        "lodash.padend": "4.6.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "3.0.0"
-      }
-    },
     "tar-stream": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
@@ -10501,16 +10540,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
-    },
-    "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-      "dev": true,
-      "requires": {
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@polymer/gen-closure-declarations": "^0.4.0",
-    "@polymer/gen-typescript-declarations": "^0.3.6",
+    "@polymer/gen-typescript-declarations": "^1.1.1",
     "@webcomponents/shadycss": "^1.1.0",
     "@webcomponents/webcomponentsjs": "^1.1.0",
     "babel-preset-minify": "^0.2.0",

--- a/types/lib/legacy/mutable-data-behavior.d.ts
+++ b/types/lib/legacy/mutable-data-behavior.d.ts
@@ -66,6 +66,8 @@ declare namespace Polymer {
     _shouldPropertyChange(property: string, value: any, old: any): boolean;
   }
 
+  const MutableDataBehavior: object;
+
   /**
    * Legacy element behavior to add the optional ability to skip strict
    * dirty-checking for objects and arrays (always consider them to be
@@ -128,4 +130,6 @@ declare namespace Polymer {
      */
     _shouldPropertyChange(property: string, value: any, old: any): boolean;
   }
+
+  const OptionalMutableDataBehavior: object;
 }

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -175,5 +175,5 @@ declare class EventApi {
   /**
    * Returns the `composedPath` for this event.
    */
-  readonly path: Array<EventTarget|null>;
+  readonly path: EventTarget[];
 }

--- a/types/lib/legacy/templatizer-behavior.d.ts
+++ b/types/lib/legacy/templatizer-behavior.d.ts
@@ -111,4 +111,6 @@ declare namespace Polymer {
      */
     modelForElement(el: HTMLElement|null): TemplateInstanceBase|null;
   }
+
+  const Templatizer: object;
 }


### PR DESCRIPTION
- Make `EventApi.path`'s `EventTarget` type non-nullable.
- Bump TypeScript generator version.
- Make Travis update-types failure style the same as the elements.