### PR TITLE
[1.x] Ensure template instance isn't cached on prototype. Fixes #5096

### DIFF
--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -198,10 +198,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _customPrepAnnotations: function(archetype, template) {
-      // Don't store the actual template instance to avoid leaking; just
-      // store an object referencing its content
-      archetype._template = {_content: template._content};
-      var c = template._content;
+      // Store a "clone" of the template on the archetype (content has been
+      // pulled into _content property, so copy that also)
+      var t = archetype._template = document.createElement('template');
+      var c = t._content = template._content;
       if (!c._notes) {
         var rootDataHost = archetype._rootDataHost;
         if (rootDataHost) {

--- a/src/lib/template/templatizer.html
+++ b/src/lib/template/templatizer.html
@@ -198,7 +198,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _customPrepAnnotations: function(archetype, template) {
-      archetype._template = template;
+      // Don't store the actual template instance to avoid leaking; just
+      // store an object referencing its content
+      archetype._template = {_content: template._content};
       var c = template._content;
       if (!c._notes) {
         var rootDataHost = archetype._rootDataHost;

--- a/test/unit/templatizer-elements.html
+++ b/test/unit/templatizer-elements.html
@@ -129,6 +129,8 @@
       });
       var parent = Polymer.dom(this).parentNode;
       Polymer.dom(parent).appendChild(this.instance.root);
+      // Ensure templatizer class does not leak reference to dataHost
+      assert.notOk(this.ctor.prototype._template.dataHost, 'templatizer class should not leak reference to dataHost');
     }
   });
 
@@ -196,6 +198,8 @@
       });
       var parent = Polymer.dom(this).parentNode;
       Polymer.dom(parent).appendChild(this.instance.root);
+      // Ensure templatizer class does not leak reference to dataHost
+      assert.notOk(this.ctor.prototype._template.dataHost, 'templatizer class should not leak reference to dataHost');
     }
   });
 


### PR DESCRIPTION
Templatizer was incorrectly caching the `<template>` element from the first call to `templatize` on the templatizer constructor's prototype, which then leaked it but more importantly its `dataHost` (plus anything else up the tree linked via `dataHost`).  Since the templatizer constructor is cached on the `_content` (which is then cached in the prototypical `_notes` of a custom element prototype), this resulted in an arbitrary amount of dom instances being retained via the custom element prototype.

This fix instead caches a "clone" of the template without any of the instance-time references like `dataHost` on the cached constructor.

### Reference Issue
Fixes #5096