### PR TITLE
Remove unneeded file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-node_modules/*
-bower_components/*


### PR DESCRIPTION
From [ESLint docs](https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories):

> In addition to any patterns in a .eslintignore file, ESLint always ignores files in `/node_modules/*` and `/bower_components/*`.