### PR TITLE
Remove unnecessary mutableData property from MutableData mixin

### DIFF
--- a/lib/mixins/mutable-data.html
+++ b/lib/mixins/mutable-data.html
@@ -104,8 +104,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
-    /** @type {boolean} */
-    MutableData.prototype.mutableData = false;
 
     return MutableData;
 


### PR DESCRIPTION
Why is this set to `false`? I don't get it :)
If this is actually supposed to be set to `false`, then I'd like to add a comment why in this PR. But, as it's the MutableData mixin I'm assuming that the value should be `true`. I don't think that it's used anywhere. I think it was just added to make the Closure compiler happy.