### PR TITLE
Fix issue with not genering the Templatizer docs

### DIFF
--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -416,8 +416,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @summary Module for preparing and stamping instances of templates
      *   utilizing Polymer templating features.
      */
-
-    const Templatize = {
+    Polymer.Templatize = {
 
       /**
        * Returns an anonymous `Polymer.PropertyEffects` class bound to the
@@ -571,7 +570,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     };
 
-    Polymer.Templatize = Templatize;
     Polymer.TemplateInstanceBase = TemplateInstanceBase;
 
   })();

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -83,6 +83,39 @@ declare namespace templateInfo {
 
 declare namespace Polymer {
 
+  /**
+   * Module for preparing and stamping instances of templates that utilize
+   * Polymer's data-binding and declarative event listener features.
+   *
+   * Example:
+   *
+   *     // Get a template from somewhere, e.g. light DOM
+   *     let template = this.querySelector('template');
+   *     // Prepare the template
+   *     let TemplateClass = Polymer.Templatize.templatize(template);
+   *     // Instance the template with an initial data model
+   *     let instance = new TemplateClass({myProp: 'initial'});
+   *     // Insert the instance's DOM somewhere, e.g. element's shadow DOM
+   *     this.shadowRoot.appendChild(instance.root);
+   *     // Changing a property on the instance will propagate to bindings
+   *     // in the template
+   *     instance.myProp = 'new value';
+   *
+   * The `options` dictionary passed to `templatize` allows for customizing
+   * features of the generated template class, including how outer-scope host
+   * properties should be forwarded into template instances, how any instance
+   * properties added into the template's scope should be notified out to
+   * the host, and whether the instance should be decorated as a "parent model"
+   * of any event handlers.
+   *
+   *     // Customize property forwarding and event model decoration
+   *     let TemplateClass = Polymer.Templatize.templatize(template, this, {
+   *       parentModel: true,
+   *       forwardHostProp(property, value) {...},
+   *       instanceProps: {...},
+   *       notifyInstanceProp(instance, property, value) {...},
+   *     });
+   */
   namespace Templatize {
 
 


### PR DESCRIPTION
The docs were not properly generated, for two reasons:

1. The file exports to `Polymer`, but because of variable referencing, the `Polymer.Templatize` had no docs. Simply moving the `const` declaration to `Polymer.Templatize` fixes that issue.
1. There was a new-line between the declaration and the export. This meant that the JSDoc wasn't "attached" to the declaration. Removing the line fixes the generation of the namespace documentation.
### Reference Issue
Fixes #5037 
