### PR TITLE
dispatchEvent returns boolean

### DIFF
--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -246,7 +246,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * dispatch events safely no-op.
        *
        * @param {Event} event Event to dispatch
-       * @return {boolean}
+       * @return {boolean} Always true.
        */
        dispatchEvent(event) { // eslint-disable-line no-unused-vars
          return true;

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -246,8 +246,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * dispatch events safely no-op.
        *
        * @param {Event} event Event to dispatch
+       * @return {boolean}
        */
        dispatchEvent(event) { // eslint-disable-line no-unused-vars
+         return true;
       }
     }
 

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -71,8 +71,9 @@ declare class TemplateInstanceBase extends
    * dispatch events safely no-op.
    *
    * @param event Event to dispatch
+   * @returns Always true.
    */
-  dispatchEvent(event: Event|null): any;
+  dispatchEvent(event: Event|null): boolean;
 }
 
 declare namespace templateInfo {


### PR DESCRIPTION
This came up in the TypeScript declarations. Since we extend both `Element` and `TemplateInstanceBase`, the signatures on these two interfaces need to be compatible. `Element.dispatchEvent` returns a `boolean`, but `TemplateInstanceBase.dispatchEvent` currently returns `void`.

I don't really understand how this implementation of `dispatchEvent` is supposed to work and when it is called, so is it ok to always return `true` (meaning `preventDefault()` was not called) as I have done here?

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent