### PR TITLE
Fix closure for forwardHostProp in Polymer.Templatize.templatize

### DIFF
--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -306,12 +306,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let userForwardHostProp = options.forwardHostProp;
       if (userForwardHostProp) {
         // Provide data API and property effects on memoized template class
-        let klass = templateInfo.templatizeTemplateClass;
-        if (!klass || klass.__cachedUserForwardHostProp !== userForwardHostProp) {
+        let klass = userForwardHostProp.templatizeTemplateClass;
+        if (!klass) {
           let base = options.mutableData ? MutableDataTemplate : DataTemplate;
-          klass = templateInfo.templatizeTemplateClass =
+          klass = userForwardHostProp.templatizeTemplateClass =
             class TemplatizedTemplate extends base {};
-          klass.__cachedUserForwardHostProp = userForwardHostProp;
           // Add template - >instances effects
           // and host <- template effects
           let hostProps = templateInfo.hostProps;

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -307,7 +307,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (userForwardHostProp) {
         // Provide data API and property effects on memoized template class
         let klass = templateInfo.templatizeTemplateClass;
-        if (!klass) {
+        if (!klass || klass.userForwardHostProp !== userForwardHostProp) {
           let base = options.mutableData ? MutableDataTemplate : DataTemplate;
           klass = templateInfo.templatizeTemplateClass =
             class TemplatizedTemplate extends base {};

--- a/lib/utils/templatize.html
+++ b/lib/utils/templatize.html
@@ -307,10 +307,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (userForwardHostProp) {
         // Provide data API and property effects on memoized template class
         let klass = templateInfo.templatizeTemplateClass;
-        if (!klass || klass.userForwardHostProp !== userForwardHostProp) {
+        if (!klass || klass.__cachedUserForwardHostProp !== userForwardHostProp) {
           let base = options.mutableData ? MutableDataTemplate : DataTemplate;
           klass = templateInfo.templatizeTemplateClass =
             class TemplatizedTemplate extends base {};
+          klass.__cachedUserForwardHostProp = userForwardHostProp;
           // Add template - >instances effects
           // and host <- template effects
           let hostProps = templateInfo.hostProps;

--- a/test/unit/templatize-elements.html
+++ b/test/unit/templatize-elements.html
@@ -7,6 +7,8 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+<link rel="import" href="../../polymer.html">
+
 <dom-module id="x-host">
   <template>
 
@@ -243,3 +245,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </script>
 
+<dom-module id="owner-templatize-caching">
+  <template>
+    <template id="ref">
+      [[hostValue]]
+    </template>
+  </template>
+  <script>
+    class Owner extends Polymer.Element {
+      static get is() { return 'owner-templatize-caching'; }
+      static get properties() {
+        return {
+          hostValue: String
+        };
+      }
+    }
+    customElements.define(Owner.is, Owner);
+  </script>
+</dom-module>

--- a/test/unit/templatize.html
+++ b/test/unit/templatize.html
@@ -199,6 +199,55 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   });
 
+  suite('templatize caching', function() {
+    let ownerOne, ownerTwo;
+
+    setup(function() {
+      ownerOne = document.createElement('owner-templatize-caching');
+      ownerTwo = document.createElement('owner-templatize-caching');
+
+      document.body.appendChild(ownerOne);
+      document.body.appendChild(ownerTwo);
+    });
+
+    teardown(function() {
+      document.body.removeChild(ownerOne);
+      document.body.removeChild(ownerTwo);
+    });
+
+    test('uses correct closure for forwardHostProp when reusing a template', function() {
+      let capturedClosureValueOne, capturedClosureValueTwo;
+
+      (function() {
+        const closureValue = 1;
+
+        return Polymer.Templatize.templatize(ownerOne.$.ref, ownerOne, {
+          forwardHostProp(prop, value) {
+            capturedClosureValueOne = closureValue;
+            assert.equal(value, 'host1');
+          },
+        });
+      })();
+
+      (function() {
+        const closureValue = 2;
+
+        return Polymer.Templatize.templatize(ownerTwo.$.ref, ownerTwo, {
+          forwardHostProp(prop, value) {
+            capturedClosureValueTwo = closureValue;
+            assert.equal(value, 'host2');
+          },
+        });
+      })();
+
+      ownerOne.hostValue = 'host1';
+      ownerTwo.hostValue = 'host2';
+
+      assert.equal(capturedClosureValueOne, 1);
+      assert.equal(capturedClosureValueTwo, 2);
+    })
+  });
+
   suite('templatizer behavior', function() {
 
     let host;
@@ -352,7 +401,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(div.prop, 'prop');
       assert.equal(div.textContent, 'text');
     });
- 
+
     test('notifies path data changes', function() {
       const template = document.getElementById('standalone').cloneNode(true);
       const Template = Polymer.Templatize.templatize(template);
@@ -363,7 +412,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       inst.set('prop.foo', false);
       assert.equal(div.prop.foo, false);
     });
- 
+
   });
 
 </script>

--- a/test/unit/templatize.html
+++ b/test/unit/templatize.html
@@ -245,7 +245,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       assert.equal(capturedClosureValueOne, 1);
       assert.equal(capturedClosureValueTwo, 2);
-    })
+    });
   });
 
   suite('templatizer behavior', function() {

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -75,7 +75,7 @@ declare class TemplateInstanceBase extends
   dispatchEvent(event: Event|null): any;
 }
 
-declare namespace templateInfo {
+declare namespace userForwardHostProp {
 
   class templatizeTemplateClass {
   }


### PR DESCRIPTION
When creating multiple constructors on the same template with `Polymer.Templatize.templatize`, the caching in `templateInfo.templatizeTemplateClass` would not correctly use the closure of `forwardHostProp` if this was different between calls. Therefore, do a dirty check on `klass.__cachedUserForwardHostProp`, which will be different if the function references are different as well.
### Reference Issue
Fixes #5063
