### PR TITLE
Add instructions for locally viewing the source documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist
 # misc
 .DS_Store
 npm-debug.log
+
+# Analyzer output used in the docs
+analysis.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,3 +149,14 @@ to run tests on a subset of available browsers, or to run tests remotely using S
 
 See the [`web-component-tester` README](https://github.com/Polymer/web-component-tester) for
 information on configuring the tool.
+
+### Viewing the source documentation locally
+
+You can view the updates you make to the source documentation locally with the following steps.
+Make sure to rerun step 1 after every change you make.
+
+1. Run `polymer analyze > analysis.json`
+
+1. Run `polymer serve`
+
+1. Open `http://127.0.0.1:PORT/components/polymer/` to view the documentation

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",
-    "test-fixture": "PolymerElements/test-fixture#3.0.0-rc.1"
+    "test-fixture": "PolymerElements/test-fixture#3.0.0-rc.1",
+    "iron-component-page": "PolymerElements/iron-component-page#^3.0.1"
   },
   "private": true,
   "resolutions": {


### PR DESCRIPTION
I have had this multiple times where I forgot how to view this locally. Probably other contributors face the same issue. Therefore add a section to `CONTRIBUTING.md` that explains the workflow.