### PR TITLE
Fix several issues in the documentation of dom-* elements

### DIFF
--- a/lib/elements/custom-style.html
+++ b/lib/elements/custom-style.html
@@ -39,12 +39,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * For example:
    *
-   * ```
+   * ```html
    * <!-- import apply shim--only required if using mixins -->
-   * <link rel="import href="bower_components/shadycss/apply-shim.html">
+   * <link rel="import" href="bower_components/shadycss/apply-shim.html">
    * <!-- import custom-style element -->
    * <link rel="import" href="bower_components/polymer/lib/elements/custom-style.html">
-   * ...
+   *
    * <custom-style>
    *   <style>
    *     html {

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -52,26 +52,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    *   </template>
    *
-   *   <script>
-   *     class EmployeeList extends Polymer.Element {
-   *       static get is() { return 'employee-list'; }
-   *       static get properties() {
-   *         return {
-   *           employees: {
-   *             value() {
-   *               return [
-   *                 {first: 'Bob', last: 'Smith'},
-   *                 {first: 'Sally', last: 'Johnson'},
-   *                 ...
-   *               ];
-   *             }
-   *           }
-   *         };
-   *       }
-   *     }
-   *   < /script>
-   *
    * </dom-module>
+   * ```
+   *
+   * With the following custom element definition:
+   *
+   * ```js
+   * class EmployeeList extends Polymer.Element {
+   *   static get is() { return 'employee-list'; }
+   *   static get properties() {
+   *     return {
+   *       employees: {
+   *         value() {
+   *           return [
+   *             {first: 'Bob', last: 'Smith'},
+   *             {first: 'Sally', last: 'Johnson'},
+   *             ...
+   *           ];
+   *         }
+   *       }
+   *     };
+   *   }
+   * }
    * ```
    *
    * Notifications for changes to items sub-properties will be forwarded to template

--- a/types/lib/elements/custom-style.d.ts
+++ b/types/lib/elements/custom-style.d.ts
@@ -34,12 +34,12 @@ declare namespace Polymer {
    *
    * For example:
    *
-   * ```
+   * ```html
    * <!-- import apply shim--only required if using mixins -->
-   * <link rel="import href="bower_components/shadycss/apply-shim.html">
+   * <link rel="import" href="bower_components/shadycss/apply-shim.html">
    * <!-- import custom-style element -->
    * <link rel="import" href="bower_components/polymer/lib/elements/custom-style.html">
-   * ...
+   *
    * <custom-style>
    *   <style>
    *     html {

--- a/types/lib/elements/dom-repeat.d.ts
+++ b/types/lib/elements/dom-repeat.d.ts
@@ -41,26 +41,28 @@ declare namespace Polymer {
    *
    *   </template>
    *
-   *   <script>
-   *     class EmployeeList extends Polymer.Element {
-   *       static get is() { return 'employee-list'; }
-   *       static get properties() {
-   *         return {
-   *           employees: {
-   *             value() {
-   *               return [
-   *                 {first: 'Bob', last: 'Smith'},
-   *                 {first: 'Sally', last: 'Johnson'},
-   *                 ...
-   *               ];
-   *             }
-   *           }
-   *         };
-   *       }
-   *     }
-   *   < /script>
-   *
    * </dom-module>
+   * ```
+   *
+   * With the following custom element definition:
+   *
+   * ```js
+   * class EmployeeList extends Polymer.Element {
+   *   static get is() { return 'employee-list'; }
+   *   static get properties() {
+   *     return {
+   *       employees: {
+   *         value() {
+   *           return [
+   *             {first: 'Bob', last: 'Smith'},
+   *             {first: 'Sally', last: 'Johnson'},
+   *             ...
+   *           ];
+   *         }
+   *       }
+   *     };
+   *   }
+   * }
    * ```
    *
    * Notifications for changes to items sub-properties will be forwarded to template


### PR DESCRIPTION
By splitting the javascript from the HTML we can now have proper formatting and highlighting in the custom element example definition in the `<dom-repeat>` docs. Also add a missing `"` in `<custom-style>` docs.
### Reference Issue
Fixes #4727
