### PR TITLE
Make dom-elements work inside svgs

### DIFF
--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -16,6 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
+  const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
   // 1.x backwards-compatible auto-wrapper for template type extensions
   // This is a clear layering violation and gives favored-nation status to
   // dom-if and dom-repeat templates.  This is a conceit we're choosing to keep
@@ -313,6 +315,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   metadata to `nodeInfo`
        */
       static _parseTemplateNestedTemplate(node, outerTemplateInfo, nodeInfo) {
+        // If a `<dom-repeat>` or a `<dom-if>` is inside of an svg, we need
+        // to create all elements in a different namespace. To do so, make an svg,
+        // let the HTML parser parse in that namespace, and then put back all
+        // created children in a fresh template.
+        if (node.parentElement.localName && templateExtensions[node.parentElement.localName]
+              && node.parentElement.parentElement && node.parentElement.parentElement.namespaceURI === SVG_NAMESPACE) {
+          const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+          svg.innerHTML = node.innerHTML;
+
+          const template = /** @type {HTMLTemplateElement} */ (document.createElement('template'));
+
+          while (svg.firstChild) {
+            template.content.appendChild(svg.removeChild(svg.firstChild));
+          }
+
+          node.parentNode.replaceChild(template, node);
+
+          // Clean up, such that `_parseTemplateChildNodes` does not run again
+          // on the old template children
+          while (node.firstChild) {
+            node.removeChild(node.firstChild);
+          }
+
+          node = template;
+        }
+
         let templateInfo = this._parseTemplate(node, outerTemplateInfo);
         let content = templateInfo.content =
           node.content.ownerDocument.createDocumentFragment();

--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -319,8 +319,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // to create all elements in a different namespace. To do so, make an svg,
         // let the HTML parser parse in that namespace, and then put back all
         // created children in a fresh template.
-        if (node.parentElement.localName && templateExtensions[node.parentElement.localName]
-              && node.parentElement.parentElement && node.parentElement.parentElement.namespaceURI === SVG_NAMESPACE) {
+        if (node.parentNode.localName && templateExtensions[node.parentNode.localName]
+              && node.parentNode.parentNode && node.parentNode.parentNode.namespaceURI === SVG_NAMESPACE) {
           const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
           svg.innerHTML = node.innerHTML;
 

--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -16,8 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
-  const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
-
   // 1.x backwards-compatible auto-wrapper for template type extensions
   // This is a clear layering violation and gives favored-nation status to
   // dom-if and dom-repeat templates.  This is a conceit we're choosing to keep
@@ -97,6 +95,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     };
     return handler;
+  }
+
+  /**
+   * If a <template> is not HTML-namespaced (meaning it's not a real template
+   * with a .content fragment), replaces it with an HTMLTemplateElement
+   * containing the original content (in the original namespace)
+   * 
+   * @param {Element} template Template to replace
+   * @return {HTMLTemplateElement} Replaced template
+   */
+  function replaceNamespacedTemplate(template) {
+    if (!template.content && template.namespaceURI !==
+        document.documentElement.namespaceURI) {
+      const htmlTemplate = /** @type {HTMLTemplateElement} */
+        (document.createElement('template'));
+      while (template.firstChild) {
+        htmlTemplate.content.appendChild(template.firstChild);
+      }
+      template.parentNode.replaceChild(htmlTemplate, template);
+      return htmlTemplate;
+    }
+    return /** @type {HTMLTemplateElement} */ (template);
   }
 
   /**
@@ -231,6 +251,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let noted;
         let element = /** @type {Element} */(node);
         if (element.localName == 'template' && !element.hasAttribute('preserve-content')) {
+          element = replaceNamespacedTemplate(element);
           noted = this._parseTemplateNestedTemplate(element, templateInfo, nodeInfo) || noted;
         } else if (element.localName === 'slot') {
           // For ShadyDom optimization, indicating there is an insertion point
@@ -315,32 +336,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *   metadata to `nodeInfo`
        */
       static _parseTemplateNestedTemplate(node, outerTemplateInfo, nodeInfo) {
-        // If a `<dom-repeat>` or a `<dom-if>` is inside of an svg, we need
-        // to create all elements in a different namespace. To do so, make an svg,
-        // let the HTML parser parse in that namespace, and then put back all
-        // created children in a fresh template.
-        if (node.parentNode.localName && templateExtensions[node.parentNode.localName]
-              && node.parentNode.parentNode && node.parentNode.parentNode.namespaceURI === SVG_NAMESPACE) {
-          const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
-          svg.innerHTML = node.innerHTML;
-
-          const template = /** @type {HTMLTemplateElement} */ (document.createElement('template'));
-
-          while (svg.firstChild) {
-            template.content.appendChild(svg.removeChild(svg.firstChild));
-          }
-
-          node.parentNode.replaceChild(template, node);
-
-          // Clean up, such that `_parseTemplateChildNodes` does not run again
-          // on the old template children
-          while (node.firstChild) {
-            node.removeChild(node.firstChild);
-          }
-
-          node = template;
-        }
-
         let templateInfo = this._parseTemplate(node, outerTemplateInfo);
         let content = templateInfo.content =
           node.content.ownerDocument.createDocumentFragment();

--- a/test/runner.html
+++ b/test/runner.html
@@ -79,7 +79,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dir.html',
       'unit/disable-upgrade.html',
       'unit/shady-unscoped-style.html',
-      'unit/html-tag.html'
+      'unit/html-tag.html',
+      'unit/svg-compatibility.html'
       // 'unit/multi-style.html'
     ];
 

--- a/test/smoke/svg-compatibility.html
+++ b/test/smoke/svg-compatibility.html
@@ -1,0 +1,51 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+  <dom-module id="test-element">
+    <template>
+      <svg class="clock" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <template is="dom-repeat" items="[[positions]]" as="cx">
+          <ellipse rx="25" ry="25" cx$="[[cx]]" cy="25" stroke="black" />
+        </template>
+        <template is="dom-if" if="[[condition]]">
+          <circle cx="150" cy="150" r="100" fill="blue" />
+        </template>
+        <g stroke="green" fill="white" stroke-width="5">
+          <template is="dom-if" if="[[pulsing]]">
+            <rect x="10" y="10" width="50" height="50" rx="15" ry="15" fill="red"/>
+          </template>
+        </g>
+      </svg>
+    </template>
+    <script>
+      class TestElement extends Polymer.Element {
+        static get is() { return 'test-element'; }
+        constructor() {
+          super();
+          this.positions = [0, 100, 200, 300];
+          this.condition = true;
+          setInterval(() => {
+            this.pulsing = !this.pulsing;
+          }, 1000);
+        }
+      }
+      customElements.define(TestElement.is, TestElement);
+    </script>
+  </dom-module>
+
+  <test-element></test-element>
+</body>
+</html>

--- a/test/unit/svg-compatibility.html
+++ b/test/unit/svg-compatibility.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+
+  <title>svg-compatibility</title>
+
+  <link rel="import" href="../../polymer.html">
+</head>
+<body>
+  <dom-module id="svg-element">
+    <template>
+      <svg id="svg" class="clock" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <template is="dom-repeat" items="[[positions]]" as="cx">
+          <ellipse rx="25" ry="25" cx$="[[cx]]" cy="25" stroke="black" />
+        </template>
+        <template is="dom-if" if="[[condition]]">
+          <circle cx="150" cy="150" r="100" fill="blue" />
+        </template>
+        <g stroke="green" fill="white" stroke-width="5">
+          <template is="dom-if" if="[[nestedCondition]]">
+            <rect x="10" y="10" width="50" height="50" rx="15" ry="15" fill="red"/>
+          </template>
+        </g>
+      </svg>
+    </template>
+    <script>
+      class SVGElement extends Polymer.Element {
+        static get is() { return 'svg-element'; }
+        constructor() {
+          super();
+          this.positions = [0, 100, 200, 300];
+          this.condition = true;
+          this.nestedCondition = true;
+        }
+      }
+      customElements.define(SVGElement.is, SVGElement);
+    </script>
+  </dom-module>
+
+  <script>
+  suite('can handle templates inside svg', function() {
+    let el;
+
+    setup(function() {
+      el = document.createElement('svg-element');
+      document.body.appendChild(el);
+
+      Polymer.flush();
+    });
+
+    teardown(function() {
+      document.body.removeChild(el);
+    });
+
+    suite('dom-repeat', function() {
+      test('creates multiple svg elements', function() {
+        const ellipses = el.$.svg.querySelectorAll('ellipse');
+        assert.equal(ellipses.length, 4);
+        assert.deepEqual(Array.from(ellipses, e => parseInt(e.getAttribute('cx'))), el.positions);
+      });
+
+      test('updates elements when array changes', function() {
+        el.pop('positions');
+        Polymer.flush();
+
+        let ellipses = el.$.svg.querySelectorAll('ellipse');
+        assert.equal(ellipses.length, 3);
+
+        el.push('positions', 400);
+        Polymer.flush();
+
+        ellipses = el.$.svg.querySelectorAll('ellipse');
+        assert.equal(ellipses.length, 4);
+        assert.deepEqual(Array.from(ellipses, e => parseInt(e.getAttribute('cx'))), [0, 100, 200, 400]);
+      });
+    });
+
+    suite('dom-if', function() {
+      test('stamps direct element child', function() {
+        assert.isOk(el.$.svg.querySelector('circle'));
+      });
+
+      test('stamps nested element child inside group', function() {
+        assert.isOk(el.$.svg.querySelector('rect'));
+      });
+
+      test('toggling negation works', function() {
+        el.condition = false;
+        Polymer.flush();
+
+        assert.equal(el.$.svg.querySelector('circle').style.display, 'none');
+
+        el.condition = true;
+        Polymer.flush();
+        assert.equal(el.$.svg.querySelector('circle').style.display, '');
+      });
+    });
+  });
+  </script>
+</body>
+</html>

--- a/test/unit/svg-compatibility.html
+++ b/test/unit/svg-compatibility.html
@@ -38,20 +38,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </svg>
     </template>
     <script>
-      class SVGElement extends Polymer.Element {
-        static get is() { return 'svg-element'; }
-        constructor() {
-          super();
-          this.positions = [0, 100, 200, 300];
-          this.condition = true;
-          this.nestedCondition = true;
+      HTMLImports.whenReady(() => {
+        class SVGElement extends Polymer.Element {
+          static get is() { return 'svg-element'; }
+          constructor() {
+            super();
+            this.positions = [0, 100, 200, 300];
+            this.condition = true;
+            this.nestedCondition = true;
+          }
         }
-      }
-      customElements.define(SVGElement.is, SVGElement);
+        customElements.define(SVGElement.is, SVGElement);
+      });
     </script>
   </dom-module>
 
   <script>
+  const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
   suite('can handle templates inside svg', function() {
     let el;
 
@@ -71,6 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         const ellipses = el.$.svg.querySelectorAll('ellipse');
         assert.equal(ellipses.length, 4);
         assert.deepEqual(Array.from(ellipses, e => parseInt(e.getAttribute('cx'))), el.positions);
+        assert.deepEqual(Array.from(ellipses, e => e.namespaceURI), Array(4).fill(SVG_NAMESPACE));
       });
 
       test('updates elements when array changes', function() {
@@ -86,16 +91,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ellipses = el.$.svg.querySelectorAll('ellipse');
         assert.equal(ellipses.length, 4);
         assert.deepEqual(Array.from(ellipses, e => parseInt(e.getAttribute('cx'))), [0, 100, 200, 400]);
+        assert.deepEqual(Array.from(ellipses, e => e.namespaceURI), Array(4).fill(SVG_NAMESPACE));
       });
     });
 
     suite('dom-if', function() {
       test('stamps direct element child', function() {
         assert.isOk(el.$.svg.querySelector('circle'));
+        assert.equal(el.$.svg.querySelector('circle').namespaceURI, SVG_NAMESPACE);
       });
 
       test('stamps nested element child inside group', function() {
         assert.isOk(el.$.svg.querySelector('rect'));
+        assert.equal(el.$.svg.querySelector('rect').namespaceURI, SVG_NAMESPACE);
       });
 
       test('toggling negation works', function() {


### PR DESCRIPTION
Use the `template` and `svg` innerHTML trick to let the HTML parser create the elements in the correct namespace. Then swap back the elements in a new template and continue iterating on that.

If you run the smoke test, you should see the following output (with the red square pulsing):

![image](https://user-images.githubusercontent.com/5948271/36794491-ca321bd2-1ca0-11e8-99fa-fbc8329585c8.png)

*Note*: This does not address #1951 yet, as I am not certain what the expected behavior is there. Since custom elements can nest svg elements, they would all need to stamp in the lightdom of the parent (e.g. the `svg`), but that seems like the wrong approach.

### Reference Issue
Fixes #1976
