### PR TITLE
Evaluated computed property dependencies first. Fixes #5143

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -353,6 +353,9 @@ Polymer_PropertyEffects.prototype.__dataOld;
 Polymer_PropertyEffects.prototype.__computeEffects;
 
 /** @type {Object} */
+Polymer_PropertyEffects.prototype.__computeInfo;
+
+/** @type {Object} */
 Polymer_PropertyEffects.prototype.__reflectEffects;
 
 /** @type {Object} */

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -43,6 +43,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     READ_ONLY: '__readOnly'
   };
 
+  const COMPUTE_INFO = '__computeInfo';
+
   /**
    * @typedef {{
    * name: (string | undefined),
@@ -82,20 +84,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @param {Object} model Prototype or instance
    * @param {string} type Property effect type
+   * @param {boolean=} cloneArrays Clone any arrays mapped in the map
    * @return {Object} The own-property map of effects for the given type
    * @private
    */
-  function ensureOwnEffectMap(model, type) {
+  function ensureOwnEffectMap(model, type, cloneArrays) {
     let effects = model[type];
     if (!effects) {
       effects = model[type] = {};
     } else if (!model.hasOwnProperty(type)) {
       effects = model[type] = Object.create(model[type]);
-      for (let p in effects) {
-        let protoFx = effects[p];
-        let instFx = effects[p] = Array(protoFx.length);
-        for (let i=0; i<protoFx.length; i++) {
-          instFx[i] = protoFx[i];
+      if (cloneArrays) {
+        for (let p in effects) {
+          let protoFx = effects[p];
+          let instFx = effects[p] = Array(protoFx.length);
+          for (let i=0; i<protoFx.length; i++) {
+            instFx[i] = protoFx[i];
+          }
         }
       }
     }
@@ -411,9 +416,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Object.assign(changedProps, inst.__dataPending);
         inputProps = inst.__dataPending;
         inst.__dataPending = null;
+        // Ensure all computed properties are de-duped against the same turn
+        dedupeId--;
       }
     }
   }
+
+  const TRANSITIVE_DEPENDENCY = '~transitive~dependency~';
 
   /**
    * Implements the "computed property" effect by running the method with the
@@ -422,20 +431,106 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * @param {!PropertyEffectsType} inst The instance the effect will be run on
    * @param {string} property Name of property
-   * @param {Object} props Bag of current property changes
+   * @param {Object} changedProps Bag of current property changes
    * @param {Object} oldProps Bag of previous values for changed properties
    * @param {?} info Effect metadata
    * @return {void}
    * @private
    */
-  function runComputedEffect(inst, property, props, oldProps, info) {
-    let result = runMethodEffect(inst, property, props, oldProps, info);
-    let computedProp = info.methodInfo;
-    if (inst.__dataHasAccessor && inst.__dataHasAccessor[computedProp]) {
-      inst._setPendingProperty(computedProp, result, true);
-    } else {
-      inst[computedProp] = result;
+  function runComputedEffect(inst, property, changedProps, oldProps, info) {
+    // Compute any dependencies first
+    computeDependencies(inst, info, changedProps, oldProps);
+    // Dirty check dependencies and run if any invalid
+    if (property !== TRANSITIVE_DEPENDENCY || 
+        computedPropertyIsDirty(inst, info, changedProps)) {
+      let result = runMethodEffect(inst, property, changedProps, oldProps, info);
+      let computedProp = info.methodInfo;
+      if (inst.__dataHasAccessor && inst.__dataHasAccessor[computedProp]) {
+        inst._setPendingProperty(computedProp, result, true);
+      } else {
+        inst[computedProp] = result;
+      }
     }
+  }
+  
+  /**
+   * Returns any dependencies of a computed property that are themselves
+   * also computed.
+   *
+   * @param {!PropertyEffectsType} inst The instance to test
+   * @param {?} info Computed effect metadata
+   * @return {Array<?>} Array of computed effect metadata for depenencies
+   * @private
+   */
+   function computedDependenciesFor(inst, info) {
+    let deps = info.computedDependencies;
+    if (!deps) {
+      deps = info.computedDependencies = [];
+      info.args.forEach(arg => {
+        const dep = arg.rootProperty || arg.name;
+        const depInfo = inst[COMPUTE_INFO][dep];
+        if (depInfo) {
+          deps.push(depInfo);
+        }
+      });
+    }
+    return deps;
+  }
+
+  /**
+   * Runs computed effects for dependencies of the computed property effect
+   * described by `info`.
+   *
+   * @param {!PropertyEffectsType} inst The instance to test
+   * @param {Object} info Effect metadata
+   * @param {Object} changedProps Bag of current property changes
+   * @param {Object} oldProps Bag of previous values for changed properties
+   * @return {void}
+   * @private
+   */
+   function computeDependencies(inst, info, changedProps, oldProps) {
+    let deps = computedDependenciesFor(inst, info);
+    if (deps.length) {
+      deps.forEach(depInfo => {
+        if (depInfo.lastRun !== info.lastRun) {
+          depInfo.lastRun = info.lastRun;
+          runComputedEffect(inst, TRANSITIVE_DEPENDENCY, changedProps, oldProps, depInfo);
+        }
+      });
+    }
+  }
+
+  /**
+   * Returns whether the computed effect has any changed dependencies.
+   *
+   * @param {!PropertyEffectsType} inst The instance to test
+   * @param {?} info Effect metadata
+   * @param {Object} changedProps Bag of current property changes
+   * @return {boolean} true when the computed effect should be re-calculated
+   * @private
+   */
+  function computedPropertyIsDirty(inst, info, changedProps) {
+    return info.dynamicFn && propertyIsDirty(inst, {name: info.methodName}, changedProps) ||
+      info.args.some(arg => propertyIsDirty(inst, arg, changedProps));
+  }
+
+  /**
+   * Returns whether any changed props match the effect trigger
+   *
+   * @param {!PropertyEffectsType} inst The instance to test
+   * @param {DataTrigger} trigger Descriptor
+   * @param {Object} changedProps Bag of current property changes
+   * @return {boolean} true when the property is dirty
+   * @private
+   */
+  function propertyIsDirty(inst, trigger, changedProps) {
+    return [changedProps, inst.__dataPending].some(props => {
+      for (let p in props) {
+        if (pathMatchesTrigger(p, trigger)) {
+          return true;
+        }
+      }
+    });
   }
 
   /**
@@ -763,7 +858,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @param {boolean|Object=} dynamicFn Boolean or object map indicating whether
    *   method names should be included as a dependency to the effect. Note,
    *   defaults to true if the signature is static (sig.static is true).
-   * @return {void}
+   * @return {Object} Effect metadata for this method effect
    * @private
    */
   function createMethodEffect(model, sig, type, effectFn, methodInfo, dynamicFn) {
@@ -787,6 +882,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         fn: effectFn, info: info
       });
     }
+    return info;
   }
 
   /**
@@ -1168,6 +1264,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         /** @type {Object} */
         this.__computeEffects;
         /** @type {Object} */
+        this.__computeInfo;
+        /** @type {Object} */
         this.__reflectEffects;
         /** @type {Object} */
         this.__notifyEffects;
@@ -1253,7 +1351,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _addPropertyEffect(property, type, effect) {
         this._createPropertyAccessor(property, type == TYPES.READ_ONLY);
         // effects are accumulated into arrays per property based on type
-        let effects = ensureOwnEffectMap(this, type)[property];
+        let effects = ensureOwnEffectMap(this, type, true)[property];
         if (!effects) {
           effects = this[type][property] = [];
         }
@@ -1269,7 +1367,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @return {void}
        */
       _removePropertyEffect(property, type, effect) {
-        let effects = ensureOwnEffectMap(this, type)[property];
+        let effects = ensureOwnEffectMap(this, type, true)[property];
         let idx = effects.indexOf(effect);
         if (idx >= 0) {
           effects.splice(idx, 1);
@@ -2174,7 +2272,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!sig) {
           throw new Error("Malformed computed expression '" + expression + "'");
         }
-        createMethodEffect(this, sig, TYPES.COMPUTE, runComputedEffect, property, dynamicFn);
+        const info = createMethodEffect(this, sig, TYPES.COMPUTE, runComputedEffect, property, dynamicFn);
+        ensureOwnEffectMap(this, COMPUTE_INFO)[property] = info;
       }
 
       // -- static class methods ------------

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -1073,7 +1073,10 @@ customElements.define(SubObserverElement.is, SubObserverElement);
         d: {type: Number},
         abbcd: {computed: 'computeABBCD(a, b, bcd)', observer: 'abbcdChanged'},
         bcd: {computed: 'computeBCD(bc, d)', observer: 'bcdChanged'},
-        bc: {computed: 'computeBC(b, c)', observer: 'bcChanged'}
+        bc: {computed: 'computeBC(b, c)', observer: 'bcChanged'},
+        circIn: {type: Number},
+        circA: {computed: 'computeCircA(circIn, circB)'},
+        circB: {computed: 'computeCircA(circIn, circA)'},
       };
     }
     constructor() {
@@ -1093,6 +1096,12 @@ customElements.define(SubObserverElement.is, SubObserverElement);
     }
     computeBC(b, c) {
       return b + c;
+    }
+    computeCircA(circIn, circB) {
+      return circIn + (circB || 0);
+    }
+    computeCircB(circIn, circA) {
+      return circIn + (circA || 0);
     }
   });
 </script>

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -1074,7 +1074,7 @@ customElements.define(SubObserverElement.is, SubObserverElement);
         abbcd: {computed: 'computeABBCD(a, b, bcd)', observer: 'abbcdChanged'},
         bcd: {computed: 'computeBCD(bc, d)', observer: 'bcdChanged'},
         bc: {computed: 'computeBC(b, c)', observer: 'bcChanged'}
-      }
+      };
     }
     constructor() {
       super();

--- a/test/unit/property-effects-elements.html
+++ b/test/unit/property-effects-elements.html
@@ -1062,3 +1062,37 @@ class SubObserverElement extends SuperObserverElement {
 }
 customElements.define(SubObserverElement.is, SubObserverElement);
 </script>
+
+<script>
+  customElements.define('x-computed-ordering', class extends Polymer.Element {
+    static get properties() {
+      return {
+        a: {type: Number},
+        b: {type: Number},
+        c: {type: Number},
+        d: {type: Number},
+        abbcd: {computed: 'computeABBCD(a, b, bcd)', observer: 'abbcdChanged'},
+        bcd: {computed: 'computeBCD(bc, d)', observer: 'bcdChanged'},
+        bc: {computed: 'computeBC(b, c)', observer: 'bcChanged'}
+      }
+    }
+    constructor() {
+      super();
+      sinon.spy(this, 'computeABBCD');
+      sinon.spy(this, 'computeBCD');
+      sinon.spy(this, 'computeBC');
+      this.abbcdChanged = sinon.spy();
+      this.bcdChanged = sinon.spy();
+      this.bcChanged = sinon.spy();
+    }
+    computeABBCD(a, b, bcd) {
+      return a + b + bcd;
+    }
+    computeBCD(bc, d) {
+      return bc + d;
+    }
+    computeBC(b, c) {
+      return b + c;
+    }
+  });
+</script>

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -1793,6 +1793,85 @@ suite('a la carte usage of API', function() {
 
 });
 
+suite('computed property ordering', function() {
+  var el;
+
+  setup(function() {
+    el = document.createElement('x-computed-ordering');
+    document.body.appendChild(el);
+  });
+
+  teardown(function() {
+    document.body.removeChild(el);
+  });
+
+  test('computed property ordering', function() {
+
+    el.setProperties({
+      a: 1000,
+      b: 100,
+      c: 10,
+      d: 1
+    });
+    assert.equal(el.bc, 110);
+    assert.equal(el.bcd, 111);
+    assert.equal(el.abbcd, 1211);
+    assert.equal(el.computeBC.callCount, 1);
+    assert.equal(el.computeBCD.callCount, 1);
+    assert.equal(el.computeABBCD.callCount, 1);
+
+    el.setProperties({
+      b: 200,
+      c: 20
+    });
+    assert.equal(el.bc, 220);
+    assert.equal(el.bcd, 221);
+    assert.equal(el.abbcd, 1421);
+    assert.equal(el.computeBC.callCount, 2);
+    assert.equal(el.computeBCD.callCount, 2);
+    assert.equal(el.computeABBCD.callCount, 2);
+
+    el.a = 2000;
+    assert.equal(el.bc, 220);
+    assert.equal(el.bcd, 221);
+    assert.equal(el.abbcd, 2421);
+    assert.equal(el.computeBC.callCount, 2);
+    assert.equal(el.computeBCD.callCount, 2);
+    assert.equal(el.computeABBCD.callCount, 3);
+
+    el.c = 30;
+    assert.equal(el.bc, 230);
+    assert.equal(el.bcd, 231);
+    assert.equal(el.abbcd, 2431);
+    assert.equal(el.computeBC.callCount, 3);
+    assert.equal(el.computeBCD.callCount, 3);
+    assert.equal(el.computeABBCD.callCount, 4);
+
+    el.d = 2;
+    assert.equal(el.bc, 230);
+    assert.equal(el.bcd, 232);
+    assert.equal(el.abbcd, 2432);
+    assert.equal(el.computeBC.callCount, 3);
+    assert.equal(el.computeBCD.callCount, 4);
+    assert.equal(el.computeABBCD.callCount, 5);
+
+    el.setProperties({
+      a: 1000,
+      b: 100,
+      c: 10,
+      d: 1
+    });
+    assert.equal(el.bc, 110);
+    assert.equal(el.bcd, 111);
+    assert.equal(el.abbcd, 1211);
+    assert.equal(el.computeBC.callCount, 4);
+    assert.equal(el.computeBCD.callCount, 5);
+    assert.equal(el.computeABBCD.callCount, 6);
+
+  });  
+
+});
+
 </script>
 
 </body>

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -1870,6 +1870,15 @@ suite('computed property ordering', function() {
 
   });  
 
+  test('ensure circular dependencies do not iloop', function() {
+    el.circIn = 1;
+    // The answers here don't _really_ matter; it just shouldn't iloop
+    // circA will go first (defined first), which will pull circB, which
+    // has no circA yet, and thus returns 1 for this turn
+    assert.ok(el.circA); // should be equal to 2, based on impl
+    assert.ok(el.circB); // should be equal to 1, based on impl
+  });
+
 });
 
 </script>


### PR DESCRIPTION
Updates the implementation of `runComputedEffect` to recursively walk the graph of dependencies that are themselves computed and re-compute them if needed, which ensures computed properties are not computed out of order.

The initial walk is still kicked off by the normal `runEffects` loop over changed properties, which ensures that no work related to computed properties occurs unless at least one dependency to a computed property has changed.  An alternate implementation of running every computed effect each flush was considered, but it seems worth keeping the "pay-for-play" model intact.  Thus, the effect de-duping mechanism still exists, which prevents a property later in the batch of changes from causing any computed effect that has already run during this flush from running again, and also prevents iloops for circular dependencies.

When walking the graph of computed dependencies to a computed property, we track when a computed effect is being run transitively (vs. directly due to a dependency change in `changedProps`) by passing a sentinel `TRANSITIVE_DEPENDENCY` property name to `runComputedEffect`'s `property` argument (which normally is the _input_ dependency which triggered the change).  This tracking is useful because transitively run computed effects need to dirty-check their dependencies, while effects that were directly run by `runEffects` can skip the expensive argument dirty check to occur since they are already guaranteed to have at least one argument dirty.

### Reference Issue
Fixes #5143


