### PR TITLE
Update property-effects.html - Add support for promises.

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -576,6 +576,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     } else {
       let value = info.evaluator._evaluateBinding(inst, part, path, props, oldProps, hasPaths);
+      if(Promise(value) == value) { // if 'value' is a promise.
+        // Resolve promise & propagate resolvedValue to child
+        value.then(resolvedValue => applyBindingValue(inst, node, binding, part, resolvedValue));
+        return;
+      }
       // Propagate value to child
       applyBindingValue(inst, node, binding, part, value);
     }

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -576,7 +576,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     } else {
       let value = info.evaluator._evaluateBinding(inst, part, path, props, oldProps, hasPaths);
-      if(Promise(value) == value) { // if 'value' is a promise.
+      if(Promise.resolve(value) == value) { // if 'value' is a promise.
         // Resolve promise & propagate resolvedValue to child
         value.then(resolvedValue => applyBindingValue(inst, node, binding, part, resolvedValue));
         return;


### PR DESCRIPTION
Adding support for promises in computed properties: 
A computed property returning a promise will now resolve and the data binding will render to the resolved value, instead of printing the un-resolved promise. Which will allow using async functions as values for properties.

**Before & After Example** 
For the element: 
```
class Element extends Polymer.Element {
    static get template() { return Polymer.html`<h1>[[localize('title')]]</h1>` }
    static get properties() {
        return {
            localize: {
                type: Function,
                value: () => async function(key) {
                    return await getIndexdbData(key) // Asynchronous call.
                }
            }
        } 
    }
}
```

_Before_ template would be rendered as: 
`<h1>{object Promise}</h1>`

_After_ changes template would render: 
`<h1>the resolved string data</h1>`