### PR TITLE
Add a @const annotation to help the Closure Compiler understand that Polymer.Debouncer is the name of a type.

### DIFF
--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -113,6 +113,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
+  /** @const */
   Polymer.Debouncer = Debouncer;
 })();
 </script>


### PR DESCRIPTION
Original author @MatrixFrog