### PR TITLE
fix(path.html): split with undefined path

### DIFF
--- a/lib/utils/path.html
+++ b/lib/utils/path.html
@@ -191,7 +191,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (Array.isArray(path)) {
         return this.normalize(path).split('.');
       }
-      return path.toString().split('.');
+      else {
+        return String(path).split('.');
+      }
     },
 
     /**

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -559,6 +559,7 @@ suite('path API', function() {
     assert.equal(el.get('nested.again.there'), 55);
     assert.equal(el.get('nested.again.again'), el.nested.again.again);
     assert.equal(el.get(['nested', 'again.again', 'wayOverThere']), 99);
+    assert.equal(el.get(undefined), undefined);
   });
 
   test('set', function() {

--- a/test/unit/path-effects.html
+++ b/test/unit/path-effects.html
@@ -560,6 +560,7 @@ suite('path API', function() {
     assert.equal(el.get('nested.again.again'), el.nested.again.again);
     assert.equal(el.get(['nested', 'again.again', 'wayOverThere']), 99);
     assert.equal(el.get(undefined), undefined);
+    assert.equal(el.get(null), undefined);
   });
 
   test('set', function() {


### PR DESCRIPTION
We got error on `this.get(path)` when `path` is `undefined`
### Reference Issue
Fixes #5166 
