### PR TITLE
Pass through fourth namespace param on attributeChangedCallback.

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -105,9 +105,10 @@ Polymer_PropertiesChanged.prototype._shouldPropertyChange = function(property, v
 * @param {string} name Name of attribute that changed
 * @param {?string} old Old attribute value
 * @param {?string} value New attribute value
+* @param {?string} namespace Attribute namespace.
 * @return {void}
 */
-Polymer_PropertiesChanged.prototype.attributeChangedCallback = function(name, old, value){};
+Polymer_PropertiesChanged.prototype.attributeChangedCallback = function(name, old, value, namespace){};
 /**
 * @param {string} attribute Name of attribute to deserialize.
 * @param {?string} value of the attribute.
@@ -972,9 +973,10 @@ Polymer_LegacyElementMixin.prototype._initializeProperties = function(){};
 * @param {string} name Name of attribute.
 * @param {?string} old Old value of attribute.
 * @param {?string} value Current value of attribute.
+* @param {?string} namespace Attribute namespace.
 * @return {void}
 */
-Polymer_LegacyElementMixin.prototype.attributeChangedCallback = function(name, old, value){};
+Polymer_LegacyElementMixin.prototype.attributeChangedCallback = function(name, old, value, namespace){};
 /**
 * @override
 * @return {void}
@@ -1391,7 +1393,7 @@ Polymer_DisableUpgradeMixin.prototype._enableProperties = function(){};
 /**
 * @override
 */
-Polymer_DisableUpgradeMixin.prototype.attributeChangedCallback = function(name, old, value){};
+Polymer_DisableUpgradeMixin.prototype.attributeChangedCallback = function(name, old, value, namespace){};
 /**
 * @override
 */

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -78,9 +78,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {string} name Name of attribute.
      * @param {?string} old Old value of attribute.
      * @param {?string} value Current value of attribute.
+     * @param {?string} namespace Attribute namespace.
      * @return {void}
      */
-    attributeChangedCallback(name, old, value) {
+    attributeChangedCallback(name, old, value, namespace) {
       if (old !== value) {
         this.register();
       }

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -74,6 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return null;
     }
 
+    /* eslint-disable no-unused-vars */
     /**
      * @param {string} name Name of attribute.
      * @param {?string} old Old value of attribute.
@@ -86,6 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.register();
       }
     }
+    /* eslint-enable no-unused-args */
 
     /**
      * The absolute URL of the original location of this `dom-module`.

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -137,12 +137,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} name Name of attribute.
        * @param {?string} old Old value of attribute.
        * @param {?string} value Current value of attribute.
+       * @param {?string} namespace Attribute namespace.
        * @return {void}
        * @override
        */
-      attributeChangedCallback(name, old, value) {
+      attributeChangedCallback(name, old, value, namespace) {
         if (old !== value) {
-          super.attributeChangedCallback(name, old, value);
+          super.attributeChangedCallback(name, old, value, namespace);
           this.attributeChanged(name, old, value);
         }
       }

--- a/lib/mixins/disable-upgrade-mixin.html
+++ b/lib/mixins/disable-upgrade-mixin.html
@@ -60,13 +60,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /** @override */
-      attributeChangedCallback(name, old, value) {
+      attributeChangedCallback(name, old, value, namespace) {
         if (name == DISABLED_ATTR) {
           if (!this.__dataEnabled && value == null && this.isConnected) {
             super.connectedCallback();
           }
         } else {
-          super.attributeChangedCallback(name, old, value);
+          super.attributeChangedCallback(name, old, value, namespace);
         }
       }
 

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -407,15 +407,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          * @param {string} name Name of attribute that changed
          * @param {?string} old Old attribute value
          * @param {?string} value New attribute value
+         * @param {?string} namespace Attribute namespace.
          * @return {void}
          * @suppress {missingProperties} Super may or may not implement the callback
          */
-        attributeChangedCallback(name, old, value) {
+        attributeChangedCallback(name, old, value, namespace) {
           if (old !== value) {
             this._attributeToProperty(name, value);
           }
           if (super.attributeChangedCallback) {
-            super.attributeChangedCallback(name, old, value);
+            super.attributeChangedCallback(name, old, value, namespace);
           }
         }
 

--- a/test/smoke/behavior-mixin.html
+++ b/test/smoke/behavior-mixin.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 </dom-module>
 <script>
+  /** @polymerBehavior */
   var MyBehavior = {
     properties: {
       behaviorProp: {
@@ -37,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   }
 
+  /** @polymerBehavior */
   var MyBehavior2 = {
     ready: function() {
       console.log(this.localName, 'MyBehavior2.ready');

--- a/types/lib/elements/dom-module.d.ts
+++ b/types/lib/elements/dom-module.d.ts
@@ -63,8 +63,9 @@ declare namespace Polymer {
      * @param name Name of attribute.
      * @param old Old value of attribute.
      * @param value Current value of attribute.
+     * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
 
     /**
      * Registers the dom-module at a given id. This method should only be called

--- a/types/lib/legacy/legacy-element-mixin.d.ts
+++ b/types/lib/legacy/legacy-element-mixin.d.ts
@@ -63,8 +63,9 @@ declare namespace Polymer {
      * @param name Name of attribute.
      * @param old Old value of attribute.
      * @param value Current value of attribute.
+     * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
 
     /**
      * Provides an implementation of `connectedCallback`

--- a/types/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/types/lib/mixins/disable-upgrade-mixin.d.ts
@@ -42,7 +42,7 @@ declare namespace Polymer {
   interface DisableUpgradeMixin {
     _initializeProperties(): void;
     _enableProperties(): void;
-    attributeChangedCallback(name: any, old: any, value: any): void;
+    attributeChangedCallback(name: any, old: any, value: any, namespace: any): void;
     connectedCallback(): void;
     disconnectedCallback(): void;
   }

--- a/types/lib/mixins/properties-changed.d.ts
+++ b/types/lib/mixins/properties-changed.d.ts
@@ -235,8 +235,9 @@ declare namespace Polymer {
      * @param name Name of attribute that changed
      * @param old Old attribute value
      * @param value New attribute value
+     * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
 
     /**
      * Deserializes an attribute to its associated property.


### PR DESCRIPTION
This came up when doing some type checking of polymer core. `HTMLElement#attributeChanged` takes a fourth `namespace` param, so we should pass all four through.