### PR TITLE
Reference dependencies as siblings in tests.

### DIFF
--- a/test/perf/binding-expressions.html
+++ b/test/perf/binding-expressions.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-  <script src="../../bower_components/perf-tester/perf.js"></script>
-  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../perf-tester/perf.js"></script>
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../polymer.html">
   <link rel="import" href="../../lib/mixins/strict-binding-parser.html">
 </head>

--- a/test/perf/perf-tests.html
+++ b/test/perf/perf-tests.html
@@ -3,8 +3,8 @@
 <head>
 
   <meta charset="utf-8">
-  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../bower_components/perf-tester/perf-tester.js"></script>
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../perf-tester/perf-tester.js"></script>
   <link rel="import" href="../../polymer.html">
   <style>
     summary {


### PR DESCRIPTION
There were a couple of tests that reference some dependencies through `bower_components` rather than as if they were sibling directories of the repo which is tripping up modulizer when converting in workspace mode.