### PR TITLE
Allow legacy element property definitions with only a type. Fixes #5173

### DIFF
--- a/types/extra-types.d.ts
+++ b/types/extra-types.d.ts
@@ -17,7 +17,7 @@ interface PolymerElementPropertiesMeta {
 }
 
 type PolymerElementProperties = {
-  [key: string]: PolymerElementPropertiesMeta
+  [key: string]: PolymerElementPropertiesMeta | Function;
 };
 
 // TODO Document these properties.


### PR DESCRIPTION
Allow legacy element properties also be of type `Function` for shorthand definitions.

### Reference Issue
Fixes #5173