### PR TITLE
Fix broken code highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,13 +439,13 @@ Polymer 2.0 elements will target the V1 Custom Elements API, which primarily cha
   For the time being, Polymer (both legacy and class API) will automatically wrap template extensions used in Polymer element templates during template processing for backward-compatibility, although we may decide to remove this auto-wrapping in the future.  Templates used in the main document must be manually wrapped.
 * <a name="breaking-custom-style"></a>The `custom-style` element has also been changed to a standard custom element that must wrap a style element  e.g.
 
-  ```html
+  ```xml
   <style is="custom-style">...</style>
   ```
 
    should change to
 
-   ```html
+   ```xml
    <custom-style>
      <style>...</style>
    </custom-style>


### PR DESCRIPTION
This fixes broken code highlighting in [README.md](https://github.com/Polymer/polymer/blob/master/README.md).

## Before
![Polymer-README-broken](https://user-images.githubusercontent.com/3889017/38276197-86b4d872-3794-11e8-83b4-ff0ef7241a4e.png)

## After
![Polymer-README-fixed](https://user-images.githubusercontent.com/3889017/38276204-8b478d1c-3794-11e8-9c80-62689dbe940e.png)