### PR TITLE
Add {}s to be more consistent with Google style

### DIFF
--- a/polymer-element.html
+++ b/polymer-element.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @memberof Polymer
    * @constructor
    * @implements {Polymer_ElementMixin}
-   * @extends HTMLElement
+   * @extends {HTMLElement}
    * @appliesMixin Polymer.ElementMixin
    * @summary Custom element base class that provides the core API for Polymer's
    *   key meta-programming features including template stamping, data-binding,


### PR DESCRIPTION
Closure Compiler understands both forms, so this isn't blocking us. It's just tripping me up slightly.