### PR TITLE
Add ability to define importMeta on hybrid elements. Fixes #5163

### DIFF
--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -87,6 +87,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
+       * Forwards `importMeta` from the prototype (i.e. from the info object
+       * passed to `Polymer({...})`) to the static API.
+       *
+       * @return {!Object} The `import.meta` object set on the prototype
+       */
+      static get importMeta() {
+        return this.prototype.importMeta;
+      }
+
+      /**
        * Legacy callback called during the `constructor`, for overriding
        * by the user.
        * @return {void}

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -91,7 +91,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * passed to `Polymer({...})`) to the static API.
        *
        * @return {!Object} The `import.meta` object set on the prototype
-       * @suppress {missingProperties}
+       * @suppress {missingProperties} `this` is always in the instance in
+       *  closure for some reason even in a static method, rather than the class
        */
       static get importMeta() {
         return this.prototype.importMeta;

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -91,6 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * passed to `Polymer({...})`) to the static API.
        *
        * @return {!Object} The `import.meta` object set on the prototype
+       * @suppress {missingProperties}
        */
       static get importMeta() {
         return this.prototype.importMeta;

--- a/lib/legacy/polymer.dom.html
+++ b/lib/legacy/polymer.dom.html
@@ -398,7 +398,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * This method facades to `Polymer.enqueueDebouncer`.
    *
    * @memberof Polymer.dom
-   * @param {Polymer.Debouncer} debouncer Debouncer to enqueue
+   * @param {!Polymer.Debouncer} debouncer Debouncer to enqueue
    */
   Polymer.dom.addDebouncer = Polymer.enqueueDebouncer;
 })();

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -404,7 +404,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * used to create bindings relative to the import path.
        *
        * For elements defined in ES modules, users should implement 
-       * `static get importMeta() { return import.meta; }` and the default
+       * `static get importMeta() { return import.meta; }`, and the default
        * implementation of `importPath` will  return `import.meta.url`'s path.
        * For elements defined in HTML imports, this getter will return the path
        * to the document containing a `dom-module` element matching this
@@ -413,6 +413,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Note, this path should contain a trailing `/`.
        *
        * @return {string} The import path for this element class
+       * @suppress {missingProperties}
        */
       static get importPath() {
         if (!this.hasOwnProperty(JSCompiler_renameProperty('_importPath', this))) {

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -402,11 +402,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * This path is used to resolve url's in template style cssText.
        * The `importPath` property is also set on element instances and can be
        * used to create bindings relative to the import path.
-       * For elements defined in ES modules, users should implement `importMeta`
-       * and this getter will return `import.meta.url`'s path. For elements
-       * defined in HTML imports, this getter will return the path to the
-       * document containing a `dom-module` element matching this element's
-       * static `is` property.
+       *
+       * For elements defined in ES modules, users should implement 
+       * `static get importMeta() { return import.meta; }` and the default
+       * implementation of `importPath` will  return `import.meta.url`'s path.
+       * For elements defined in HTML imports, this getter will return the path
+       * to the document containing a `dom-module` element matching this
+       * element's static `is` property.
        *
        * Note, this path should contain a trailing `/`.
        *
@@ -424,18 +426,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         }
         return this._importPath;
-      }
-
-      /**
-       * When an element definition is being loaded from an ES module, users
-       * may override this getter to return the `import.meta` object from that
-       * module, which will be used to derive the `importPath` for the element.
-       * When implementing `importMeta`, users should not implement `importPath`.
-       *
-       * @return {!Object} The `import.meta` object for the element's module
-       */
-      static get importMeta() {
-        return null;
       }
 
       constructor() {

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -43,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     READ_ONLY: '__readOnly'
   };
 
-  /** @const {string} */
+  /** @const {RegExp} */
   const capitalAttributeRegex = /[A-Z]/;
 
   /**

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -82,7 +82,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('Urls in styles and attributes', testStylesAndAttributes('p-r', 'sub'));
 
-      test('Urls in styles and attributes (importMeta)', testStylesAndAttributes('p-r-im', 'http://foo.com/mymodule'));
+      test('Urls in styles and attributes (importMeta)', testStylesAndAttributes('p-r-im', 'http://class.com/mymodule'));
+
+      test('Urls in styles and attributes (importMeta, hybrid)', testStylesAndAttributes('p-r-hybrid', 'http://hybrid.com/mymodule'));
 
       test('url changes via setting importPath/rootPath on element instance', function() {
         var el = document.createElement('p-r');

--- a/test/unit/sub/resolveurl-elements.html
+++ b/test/unit/sub/resolveurl-elements.html
@@ -34,31 +34,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 </dom-module>
 <script>
-  class PR extends Polymer.Element {
-    static get is() { return 'p-r'; }
-  }
-  customElements.define(PR.is, PR);
-
-  class PRImportMeta extends Polymer.Element {
-    static get template() {
-      return Polymer.DomModule.import('p-r', 'template').cloneNode(true);
+  window.addEventListener('WebComponentsReady', () => {
+    class PR extends Polymer.Element {
+      static get is() { return 'p-r'; }
     }
-    static get importMeta() {
+    customElements.define(PR.is, PR);
+
+    class PRImportMeta extends Polymer.Element {
+      static get template() {
+        return Polymer.DomModule.import('p-r', 'template').cloneNode(true);
+      }
+      static get importMeta() {
+        // Idiomatically, this would be `return import.meta`, but for purposes
+        // of stubbing the test without actual modules, it's shimmed
+        return { url: 'http://class.com/mymodule/index.js' };
+      }
+    }
+    customElements.define('p-r-im', PRImportMeta);
+
+    const PRHybrid = Polymer({
+      is: 'p-r-hybrid',
+      _template: Polymer.DomModule.import('p-r', 'template').cloneNode(true),
       // Idiomatically, this would be `return import.meta`, but for purposes
       // of stubbing the test without actual modules, it's shimmed
-      return { url: 'http://class.com/mymodule/index.js' };
-    }
-  }
-  customElements.define('p-r-im', PRImportMeta);
+      importMeta: { url: 'http://hybrid.com/mymodule/index.js' }
+    });
 
-  const PRHybrid = Polymer({
-    is: 'p-r-hybrid',
-    _template: Polymer.DomModule.import('p-r', 'template').cloneNode(true),
-    // Idiomatically, this would be `return import.meta`, but for purposes
-    // of stubbing the test without actual modules, it's shimmed
-    importMeta: { url: 'http://hybrid.com/mymodule/index.js' }
   });
-
 </script>
 
 <dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>

--- a/test/unit/sub/resolveurl-elements.html
+++ b/test/unit/sub/resolveurl-elements.html
@@ -39,14 +39,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
   customElements.define(PR.is, PR);
 
-  class PRImportMeta extends PR {
+  class PRImportMeta extends Polymer.Element {
+    static get template() {
+      return Polymer.DomModule.import('p-r', 'template').cloneNode(true);
+    }
     static get importMeta() {
       // Idiomatically, this would be `return import.meta`, but for purposes
       // of stubbing the test without actual modules, it's shimmed
-      return { url: 'http://foo.com/mymodule/index.js' }
+      return { url: 'http://class.com/mymodule/index.js' };
     }
   }
   customElements.define('p-r-im', PRImportMeta);
+
+  const PRHybrid = Polymer({
+    is: 'p-r-hybrid',
+    _template: Polymer.DomModule.import('p-r', 'template').cloneNode(true),
+    // Idiomatically, this would be `return import.meta`, but for purposes
+    // of stubbing the test without actual modules, it's shimmed
+    importMeta: { url: 'http://hybrid.com/mymodule/index.js' }
+  });
+
 </script>
 
 <dom-module id="p-r-ap" assetpath="../../assets/"></dom-module>


### PR DESCRIPTION
After this change, hybrid elements defined in ES modules using legacy API can ensure a correct `importPath` as follows:

```js
Polymer({
  ...
  importMeta: import.meta
});
```

This change also removes the default `static get importMeta()` implementation, for better compatibility with defining element metadata using (compiled) static class fields.

### Reference Issue
Fixes #5163
