### PR TITLE
Add `@const` to elements

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -433,6 +433,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     static get is() { return 'array-selector'; }
   }
   customElements.define(ArraySelector.is, ArraySelector);
+
+  /** @const */
   Polymer.ArraySelector = ArraySelector;
 
 })();

--- a/lib/elements/custom-style.html
+++ b/lib/elements/custom-style.html
@@ -109,6 +109,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   }
 
   window.customElements.define('custom-style', CustomStyle);
+
+  /** @const */
   Polymer.CustomStyle = CustomStyle;
 })();
 </script>

--- a/lib/elements/dom-bind.html
+++ b/lib/elements/dom-bind.html
@@ -132,6 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     customElements.define('dom-bind', DomBind);
 
+    /** @const */
     Polymer.DomBind = DomBind;
 
   })();

--- a/lib/elements/dom-if.html
+++ b/lib/elements/dom-if.html
@@ -282,6 +282,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   customElements.define(DomIf.is, DomIf);
 
+  /** @const */
   Polymer.DomIf = DomIf;
 
 })();

--- a/lib/elements/dom-module.html
+++ b/lib/elements/dom-module.html
@@ -139,7 +139,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   customElements.define('dom-module', DomModule);
 
-  // export
+  /** @const */
   Polymer.DomModule = DomModule;
 
 })();

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -731,6 +731,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   customElements.define(DomRepeat.is, DomRepeat);
 
+  /** @const */
   Polymer.DomRepeat = DomRepeat;
 
 })();


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
Adding `@const` helps JS compiler understand that `Polymer.DomIf` is an alias for the class defined just above that.

With this, the following code can compiled:
```javascript
const /** !Polymer.DomIf */ domIf = /** @type {!Polymer.DomIf} */ (this.$['dom-if']);
domIf.render();
```

Added `@const` to all elements under `lib/elements` to expose their types.