### PR TITLE
Fixes IE11 test issues

### DIFF
--- a/test/unit/custom-style-async-import.js
+++ b/test/unit/custom-style-async-import.js
@@ -1,6 +1,6 @@
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
 
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
 <style is="custom-style">
@@ -24,7 +24,7 @@ $_documentContainer.innerHTML = `<custom-style>
 </template>
 </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 
 Polymer({
   is: 'x-client'

--- a/test/unit/custom-style-import.js
+++ b/test/unit/custom-style-import.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import './sub/style-import.js';
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="shared-style">
@@ -42,4 +42,4 @@ $_documentContainer.innerHTML = `<dom-module id="shared-style">
 </style>
 </custom-style>`;
 
-document.head.appendChild($_documentContainer);
+document.head.appendChild($_documentContainer.content);

--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -27,7 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         See: https://github.com/Polymer/polymer-modulizer/issues/154
         -->
     <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
   <style is="custom-style">
@@ -79,10 +79,10 @@ $_documentContainer.innerHTML = `<custom-style>
   </style>
 </custom-style>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
   <style is="custom-style">
@@ -113,11 +113,11 @@ $_documentContainer.innerHTML = `<custom-style>
   </style>
 </custom-style>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
 <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
   <style is="custom-style" include="shared-style2">
@@ -132,10 +132,10 @@ $_documentContainer.innerHTML = `<custom-style>
   </style>
 </custom-style>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
   <style is="custom-style">
@@ -147,100 +147,100 @@ $_documentContainer.innerHTML = `<custom-style>
   </style>
 </custom-style>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="italic">italic</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="bag">bag</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="mix">mix</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="dynamic">dynamic</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="import-mixin">import-mixin</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="import-var">import-var</div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<x-bar></x-bar>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<x-foo></x-foo>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<x-red-text></x-red-text>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<x-blue-bold-text></x-blue-bold-text>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<parent-variable-with-var></parent-variable-with-var>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<br>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script><script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<br>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div id="after"></div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="foo"></div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="foo--bar"></div>`;
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="x-baz">
     <template>
@@ -253,11 +253,11 @@ $_documentContainer.innerHTML = `<dom-module id="x-baz">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="x-bar">
     <template>
@@ -271,11 +271,11 @@ $_documentContainer.innerHTML = `<dom-module id="x-bar">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="x-foo">
     <template>
@@ -302,11 +302,11 @@ $_documentContainer.innerHTML = `<dom-module id="x-foo">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="x-red-text">
     <template>
@@ -319,11 +319,11 @@ $_documentContainer.innerHTML = `<dom-module id="x-red-text">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="x-blue-bold-text">
     <template>
@@ -334,11 +334,11 @@ $_documentContainer.innerHTML = `<dom-module id="x-blue-bold-text">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="parent-variable-with-var">
     <template>
@@ -359,11 +359,11 @@ $_documentContainer.innerHTML = `<dom-module id="parent-variable-with-var">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="child-variable-with-var">
     <template>
@@ -387,11 +387,11 @@ $_documentContainer.innerHTML = `<dom-module id="child-variable-with-var">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="child-of-child-with-var">
     <template>
@@ -410,7 +410,7 @@ $_documentContainer.innerHTML = `<dom-module id="child-of-child-with-var">
     </template>
   </dom-module>`;
 
-document.body.appendChild($_documentContainer);
+document.body.appendChild($_documentContainer.content);
 </script>
 
   <script type="module">

--- a/test/unit/shady-unscoped-style-import.js
+++ b/test/unit/shady-unscoped-style-import.js
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="global-shared1">
@@ -33,4 +33,4 @@ $_documentContainer.innerHTML = `<dom-module id="global-shared1">
 </dom-module><dom-module id="global-shared2">
 </dom-module>`;
 
-document.head.appendChild($_documentContainer);
+document.head.appendChild($_documentContainer.content);

--- a/test/unit/styling-import-shared-styles.js
+++ b/test/unit/styling-import-shared-styles.js
@@ -8,7 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.setAttribute('style', 'display: none;');
 
 $_documentContainer.innerHTML = `<dom-module id="shared-styles">
@@ -28,4 +28,4 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
   </template>
 </dom-module>`;
 
-document.head.appendChild($_documentContainer);
+document.head.appendChild($_documentContainer.content);

--- a/test/unit/sub/resolveurl-elements.js
+++ b/test/unit/sub/resolveurl-elements.js
@@ -14,11 +14,11 @@ import { DomModule } from '../../../lib/elements/dom-module.js';
 import { Polymer } from '../../../lib/legacy/polymer-fn.js';
 import { pathFromUrl } from '../../../lib/utils/resolve-url.js';
 
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.setAttribute('style', 'display: none;');
 const baseAssetPath = pathFromUrl(import.meta.url);
 $_documentContainer.innerHTML = `<dom-module id="p-r-ap" assetpath="${baseAssetPath}../../assets/"></dom-module>`;
-document.head.appendChild($_documentContainer);
+document.head.appendChild($_documentContainer.content);
 
 class PR extends PolymerElement {
   static get template() {

--- a/test/unit/sub/style-import.js
+++ b/test/unit/sub/style-import.js
@@ -1,6 +1,6 @@
 import { pathFromUrl } from '../../../lib/utils/resolve-url.js';
 
-const $_documentContainer = document.createElement('div');
+const $_documentContainer = document.createElement('template');
 $_documentContainer.setAttribute('style', 'display: none;');
 const baseAssetPath = pathFromUrl(import.meta.url);
 $_documentContainer.innerHTML = `<dom-module id="style-import" assetpath="${baseAssetPath}">
@@ -23,4 +23,4 @@ $_documentContainer.innerHTML = `<dom-module id="style-import" assetpath="${base
   </template>
 </dom-module>`;
 
-document.head.appendChild($_documentContainer);
+document.head.appendChild($_documentContainer.content);


### PR DESCRIPTION
Use `<template>.innerHTML` when adding test elements to main document. Works around a template polyfill issue (https://github.com/webcomponents/template/issues/40) by setting innerHTML on a `<template>` element so that inner templates are correctly updated.

As this code was previously generated using `polymer-modulizer`, https://github.com/Polymer/polymer-modulizer/issues/410 was opened to make the same change to the code generator as well.