### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test/
+util/
+img/
+\..*


### PR DESCRIPTION
Fixes #5214.

This reduces the package size from 3.2MB to 1.1MB uncompressed.