### PR TITLE
Update template docs.

### DIFF
--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -32,8 +32,7 @@ import { PropertiesMixin } from './properties-mixin.js';
  *
  * - `static get template()`: Users may provide the template directly (as
  *   opposed to via `dom-module`) by implementing a static `template` getter.
- *   The getter may return an `HTMLTemplateElement` or a string, which will
- *   automatically be parsed into a template.
+ *   The getter must return an `HTMLTemplateElement`.
  *
  * - `static get properties()`: Should return an object describing
  *   property-related metadata used by Polymer features (key: property name
@@ -350,8 +349,7 @@ export const ElementMixin = dedupingMixin(base => {
      *
      * Users may override this getter to return an arbitrary template
      * (in which case the `is` getter is unnecessary). The template returned
-     * may be either an `HTMLTemplateElement` or a string that will be
-     * automatically parsed into a template.
+     * must be an `HTMLTemplateElement`.
      *
      * Note that when subclassing, if the super class overrode the default
      * implementation and the subclass would like to provide an alternate


### PR DESCRIPTION
In support of #5222, this updated the `template()` documentation so that it no longer lists support for `typeof template === 'string'` types.

### Reference PR
Follow up: #5222
