### PR TITLE
Ensure properties is only invoked once

### DIFF
--- a/lib/mixins/properties-mixin.js
+++ b/lib/mixins/properties-mixin.js
@@ -86,8 +86,12 @@ export const PropertiesMixin = dedupingMixin(superClass => {
    if (!constructor.hasOwnProperty(JSCompiler_renameProperty('__ownProperties', constructor))) {
      let props = null;
 
-     if (constructor.hasOwnProperty(JSCompiler_renameProperty('properties', constructor)) && constructor.properties) {
-       props = normalizeProperties(constructor.properties);
+     if (constructor.hasOwnProperty(JSCompiler_renameProperty('properties', constructor))) {
+       const properties = constructor.properties;
+
+       if (properties) {
+        props = normalizeProperties(properties);
+       }
      }
 
      constructor.__ownProperties = props;

--- a/test/unit/polymer.properties-mixin.html
+++ b/test/unit/polymer.properties-mixin.html
@@ -17,8 +17,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script type="module" src="../../lib/mixins/properties-mixin.js"></script>
   <body>
 
-  <dom-module id="my-element">
-    <script type="module">
+  <test-fixture id="my-element-attr">
+    <template>
+      <my-element prop="attr" camelCase="camelCase"></my-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="sub-element-attr">
+    <template>
+      <sub-element prop="attr" prop2="attr" camelCase="camelCase" camelCase2="camelCase2" custom-observed-attr="custom"></sub-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="sub-mixin-element-attr">
+    <template>
+      <sub-mixin-element prop="attr" prop2="attr" prop3="attr" mixin="5" custom-observed-attr="custom"></sub-mixin-element>
+    </template>
+  </test-fixture>
+
+  <script type="module">
 import { PropertiesMixin } from '../../lib/mixins/properties-mixin.js';
 
 class Glar {}
@@ -97,13 +114,6 @@ MyElement.prototype._callAttributeChangedCallback = 0;
 customElements.define('my-element', MyElement);
 
 window.MyElement = MyElement;
-</script>
-  </dom-module>
-
-
-  <dom-module id="sub-element">
-    <script type="module">
-import '../../lib/mixins/properties-mixin.js';
 
 class SubElement extends window.MyElement {
 
@@ -141,12 +151,6 @@ class SubElement extends window.MyElement {
 customElements.define('sub-element', SubElement);
 
 window.SubElement = SubElement;
-</script>
-  </dom-module>
-
-  <dom-module id="sub-mixin-element">
-    <script type="module">
-import '../../lib/mixins/properties-mixin.js';
 
 function MyMixin(Base) {
   return class extends Base {
@@ -208,29 +212,7 @@ class SubMixinElement extends MyMixin(window.SubElement) {
 customElements.define('sub-mixin-element', SubMixinElement);
 
 window.SubMixinElement = SubMixinElement;
-</script>
-  </dom-module>
 
-  <test-fixture id="my-element-attr">
-    <template>
-      <my-element prop="attr" camelCase="camelCase"></my-element>
-    </template>
-  </test-fixture>
-
-  <test-fixture id="sub-element-attr">
-    <template>
-      <sub-element prop="attr" prop2="attr" camelCase="camelCase" camelCase2="camelCase2" custom-observed-attr="custom"></sub-element>
-    </template>
-  </test-fixture>
-
-  <test-fixture id="sub-mixin-element-attr">
-    <template>
-      <sub-mixin-element prop="attr" prop2="attr" prop3="attr" mixin="5" custom-observed-attr="custom"></sub-mixin-element>
-    </template>
-  </test-fixture>
-
-  <script type="module">
-import '../../lib/mixins/properties-mixin.js';
 suite('class extends Polymer.PropertiesMixin', function() {
 
   let el;

--- a/test/unit/polymer.properties-mixin.html
+++ b/test/unit/polymer.properties-mixin.html
@@ -44,6 +44,8 @@ class Blar {}
 class MyElement extends PropertiesMixin(HTMLElement) {
 
   static get properties() {
+    this._calledProperties++;
+
     return {
       prop: String,
       noStomp: String,
@@ -110,6 +112,8 @@ MyElement.prototype._calledConstructor = 0;
 MyElement.prototype._calledConnectedCallback = 0;
 MyElement.prototype._calledReady = 0;
 MyElement.prototype._callAttributeChangedCallback = 0;
+
+MyElement.constructor.prototype._calledProperties = 0;
 
 customElements.define('my-element', MyElement);
 
@@ -236,6 +240,7 @@ suite('class extends Polymer.PropertiesMixin', function() {
     assert.equal(el._calledConnectedCallback, 1);
     assert.equal(el._calledReady, 1);
     assert.equal(el._callAttributeChangedCallback, 0);
+    assert.equal(el.constructor._calledProperties, 1);
   });
 
   test('listeners', function() {


### PR DESCRIPTION
The `static get properties` was invoked twice because of an `if`-guard. Instead, invoke it once and reassign to a variable and use that in the `if`-guard instead.
### Reference Issue
Fixes #5252 
