### PR TITLE
Update property-effects.html

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -815,6 +815,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     let fn = context[info.methodName];
     if (fn) {
       let args = marshalArgs(inst.__data, info.args, property, props);
+      if (inst.usePolymer1StyleObserver) {
+        for (const arg of args) {
+          if (arg === undefined) {
+            console.warn(`arg is not defined, ensure it has an undefined check`);
+            return;
+          }
+        }
+      }
       return fn.apply(context, args);
     } else if (!info.dynamicFn) {
       console.warn('method `' + info.methodName + '` not defined');


### PR DESCRIPTION
When an computed property or complex observer is triggered and the calling element has a property 'usePolymer1StyleObserver' set to true, require all arguments to be defined to call the function. 

Devs can set their v1 hybrid elements to have this property for a smoother incremental upgrade to Polymer2 (Not meant to be included in Polymer3)

### Reference Issue
https://github.com/Polymer/polymer/issues/5262