### PR TITLE
Convert object to class for better compilation

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2772,35 +2772,33 @@ export const PropertyEffects = dedupingMixin(superClass => {
  *
  * @private
  */
-let hostStack = {
-
-  stack: [],
+class HostStack {
+  constructor() {
+    this.stack = [];
+  }
 
   /**
    * @param {*} inst Instance to add to hostStack
    * @return {void}
-   * @this {hostStack}
    */
   registerHost(inst) {
     if (this.stack.length) {
       let host = this.stack[this.stack.length-1];
       host._enqueueClient(inst);
     }
-  },
+  }
 
   /**
    * @param {*} inst Instance to begin hosting
    * @return {void}
-   * @this {hostStack}
    */
   beginHosting(inst) {
     this.stack.push(inst);
-  },
+  }
 
   /**
    * @param {*} inst Instance to end hosting
    * @return {void}
-   * @this {hostStack}
    */
   endHosting(inst) {
     let stackLen = this.stack.length;
@@ -2808,5 +2806,5 @@ let hostStack = {
       this.stack.pop();
     }
   }
-
-};
+}
+const hostStack = new HostStack();


### PR DESCRIPTION
Under some closure flags the hostStack object was being split out into three unrelated functions. Converting it to a class makes the code more regular, and compile with more optimizations on.

There's almost definitely a way to express what we were doing with closure annotations, but this seems more robust to me.
