### PR TITLE
Fix shady test regressions

### DIFF
--- a/test/unit/custom-style.html
+++ b/test/unit/custom-style.html
@@ -483,8 +483,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertComputed(el, '11px', 'right');
         assertComputed(el, '12px', 'top');
 
-        // Avoid Edge 16 bug with CSS Custom Properties and Fonts.
-        if (navigator.userAgent.match('Edge/16') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
+        // Avoid Edge bug with CSS Custom Properties and Fonts.
+        if (navigator.userAgent.match('Edge') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
           return;
         }
 

--- a/test/unit/shady.html
+++ b/test/unit/shady.html
@@ -459,7 +459,8 @@ function getEffectiveChildNodes(node) {
 }
 
 function getComposedHTML(node) {
-  return ShadyDOM.nativeTree.innerHTML(node);
+  // Ignore shady CSS scoping
+  return ShadyDOM.nativeTree.innerHTML(node).replace(/ class="[^"]*"/g, '');
 }
 
 function getComposedChildAtIndex(node, index) {

--- a/test/unit/styling-cross-scope-apply.html
+++ b/test/unit/styling-cross-scope-apply.html
@@ -588,7 +588,7 @@ suite('scoped-styling-apply', function() {
   });
 
   test('mixins apply to @keyframe rules', function(done) {
-    if (navigator.userAgent.match('Edge/16') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
+    if (navigator.userAgent.match('Edge') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
       // skip test due to missing variable support in keyframes
       // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12084341/
       this.skip();

--- a/test/unit/styling-scoped.html
+++ b/test/unit/styling-scoped.html
@@ -890,7 +890,7 @@ HTMLImports.whenReady(function() {
     });
 
     test('keyframes change scope', function(done) {
-      if (navigator.userAgent.match('Edge/16') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
+      if (navigator.userAgent.match('Edge') && (!window.ShadyCSS || window.ShadyCSS.nativeCss)) {
         // skip test due to missing variable support in keyframes
         // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12084341/
         this.skip();


### PR DESCRIPTION
### Reference Issue
Fixes shady CSS test regressions that occurred based on changes in https://github.com/webcomponents/shadycss/pull/187.

Since on browsers without custom properties, shadycss scoping may be flushed synchronous to custom element upgrade, this changed the timing that scoping classes could be applied to elements.  The `getComposedHTML` helper function in the shady tests has been updated to strip scoping classes, so that the test assertions don't need to care about this timing difference.

This change also applies changes already made on master to extend 3 Edge test skips beyond just Edge 16 to all versions of Edge.