### PR TITLE
Fix shady test regressions (3.x)

### DIFF
--- a/test/unit/shady.html
+++ b/test/unit/shady.html
@@ -456,7 +456,8 @@ function getEffectiveChildNodes(node) {
 }
 
 function getComposedHTML(node) {
-  return ShadyDOM.nativeTree.innerHTML(node);
+  // Ignore shady CSS scoping
+  return ShadyDOM.nativeTree.innerHTML(node).replace(/ class="[^"]*"/g, '');
 }
 
 function getComposedChildAtIndex(node, index) {

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -769,7 +769,7 @@ test('variables in @keyframes', function(done) {
 });
 
 test('instances of scoped @keyframes', function(done) {
-  if (navigator.userAgent.match(/Safari\/60(3|4)/) && ShadyCSS.nativeCss && ShadyCSS.nativeShadow) {
+  if (navigator.userAgent.match(/Safari/) && ShadyCSS.nativeCss && ShadyCSS.nativeShadow) {
     // `:nth-of-type` is broken in shadow roots on Safari 10.1
     // https://bugs.webkit.org/show_bug.cgi?id=166748
     this.skip();


### PR DESCRIPTION
### Reference Issue
Fixes shady CSS test regressions that occurred based on changes in https://github.com/webcomponents/shadycss/pull/187.

Since on browsers without custom properties, shadycss scoping may be flushed synchronous to custom element upgrade, this changed the timing that scoping classes could be applied to elements.  The `getComposedHTML` helper function in the shady tests has been updated to strip scoping classes, so that the test assertions don't need to care about this timing difference.

This change also applies changes already made on master to extend 3 Edge test skips beyond just Edge 16 to all versions of Edge. Same for Safari keyframe tests.