### PR TITLE
Make event notification handler read the value from currentTarget,

### DIFF
--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -356,7 +356,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       toPath = Polymer.Path.translate(fromProp, toPath, fromPath);
       value = detail && detail.value;
     } else {
-      value = event.target[fromProp];
+      value = event.currentTarget[fromProp];
     }
     value = negate ? !value : value;
     if (!inst[TYPES.READ_ONLY] || !inst[TYPES.READ_ONLY][toPath]) {

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -329,6 +329,16 @@ suite('single-element binding effects', function() {
     assert.equal(el.observerCounts.customEventValueChanged, 1, 'custom bound property observer not called');
   });
 
+  test('custom notification bubbling event to property', function() {
+    const child = document.createElement('div');
+    el.$.boundChild.appendChild(child);
+
+    el.$.boundChild.customEventValue = 42;
+    child.dispatchEvent(new Event('custom', {bubbles: true}));
+    assert.equal(el.customEventValue, 42, 'custom bound property incorrect');
+    assert.equal(el.observerCounts.customEventValueChanged, 1, 'custom bound property observer not called');
+  });
+
   test('custom notification event to path', function() {
     el.clearObserverCounts();
     el.$.boundChild.customEventObjectValue = 84;


### PR DESCRIPTION
instead of the `target` which may not be bound to any data.

### Reference Issue
Fixes https://github.com/Polymer/polymer/issues/5308
Related to 1.x issue https://github.com/Polymer/polymer/issues/2497