### PR TITLE
Make Polymer gestures library safe for Closure property renaming.

### DIFF
--- a/externs/polymer-internal-shared-types.js
+++ b/externs/polymer-internal-shared-types.js
@@ -166,6 +166,27 @@ AsyncInterface.prototype.run;
 AsyncInterface.prototype.cancel;
 
 /** @record */
+let GestureInfo = function(){};
+/** @type {string|undefined} */
+GestureInfo.prototype.state;
+/** @type {boolean|undefined} */
+GestureInfo.prototype.started;
+/** @type {!Array<?>|undefined} */
+GestureInfo.prototype.moves;
+/** @type {number|undefined} */
+GestureInfo.prototype.x;
+/** @type {number|undefined} */
+GestureInfo.prototype.y;
+/** @type {boolean|undefined} */
+GestureInfo.prototype.prevent;
+/** @type {function(?): void|undefined} */
+GestureInfo.prototype.addMove;
+/** @type {null|undefined} */
+GestureInfo.prototype.movefn;
+/** @type {null|undefined} */
+GestureInfo.prototype.upFn;
+
+/** @record */
 let GestureRecognizer = function(){};
 /** @type {function(): void} */
 GestureRecognizer.prototype.reset;

--- a/externs/polymer-internal-shared-types.js
+++ b/externs/polymer-internal-shared-types.js
@@ -164,3 +164,26 @@ function AsyncInterface(){}
 AsyncInterface.prototype.run;
 /** @type {function(number): void} */
 AsyncInterface.prototype.cancel;
+
+/** @record */
+let GestureRecognizer = function(){};
+/** @type {function(): void} */
+GestureRecognizer.prototype.reset;
+/** @type {function(MouseEvent): void | undefined} */
+GestureRecognizer.prototype.mousedown;
+/** @type {(function(MouseEvent): void | undefined)} */
+GestureRecognizer.prototype.mousemove;
+/** @type {(function(MouseEvent): void | undefined)} */
+GestureRecognizer.prototype.mouseup;
+/** @type {(function(TouchEvent): void | undefined)} */
+GestureRecognizer.prototype.touchstart;
+/** @type {(function(TouchEvent): void | undefined)} */
+GestureRecognizer.prototype.touchmove;
+/** @type {(function(TouchEvent): void | undefined)} */
+GestureRecognizer.prototype.touchend;
+/** @type {(function(MouseEvent): void | undefined)} */
+GestureRecognizer.prototype.click;
+/** @type {!GestureInfo} */
+GestureRecognizer.prototype.info;
+/** @type {!Array<string>} */
+GestureRecognizer.prototype.emits;

--- a/lib/utils/gestures.js
+++ b/lib/utils/gestures.js
@@ -113,29 +113,6 @@ GestureInfo.prototype.movefn;
 /** @type {null|undefined} */
 GestureInfo.prototype.upFn;
 
-/** @record */
-const GestureRecognizer = function(){}; // eslint-disable-line no-unused-vars
-/** @type {function(): void} */
-GestureRecognizer.prototype.reset;
-/** @type {function(MouseEvent): void | undefined} */
-GestureRecognizer.prototype.mousedown;
-/** @type {(function(MouseEvent): void | undefined)} */
-GestureRecognizer.prototype.mousemove;
-/** @type {(function(MouseEvent): void | undefined)} */
-GestureRecognizer.prototype.mouseup;
-/** @type {(function(TouchEvent): void | undefined)} */
-GestureRecognizer.prototype.touchstart;
-/** @type {(function(TouchEvent): void | undefined)} */
-GestureRecognizer.prototype.touchmove;
-/** @type {(function(TouchEvent): void | undefined)} */
-GestureRecognizer.prototype.touchend;
-/** @type {(function(MouseEvent): void | undefined)} */
-GestureRecognizer.prototype.click;
-/** @type {!GestureInfo} */
-GestureRecognizer.prototype.info;
-/** @type {!Array<string>} */
-GestureRecognizer.prototype.emits;
-
 // keep track of any labels hit by the mouseCanceller
 /** @type {!Array<!HTMLLabelElement>} */
 const clickedLabels = [];

--- a/lib/utils/gestures.js
+++ b/lib/utils/gestures.js
@@ -334,7 +334,10 @@ function untrackDocument(stateObj) {
 // Use passive event listeners, if supported, to not affect scrolling performance
 document.addEventListener('touchend', ignoreMouse, SUPPORTS_PASSIVE ? {passive: true} : false);
 
+/** @type {!Object<string, !GestureRecognizer>} */
 export const gestures = {};
+
+/** @type {!Array<!GestureRecognizer>} */
 export const recognizers = [];
 
 /**

--- a/lib/utils/gestures.js
+++ b/lib/utils/gestures.js
@@ -92,27 +92,6 @@ function PASSIVE_TOUCH(eventName) {
 // Check for touch-only devices
 let IS_TOUCH_ONLY = navigator.userAgent.match(/iP(?:[oa]d|hone)|Android/);
 
-/** @record */
-const GestureInfo = function(){}; // eslint-disable-line no-unused-vars
-/** @type {string|undefined} */
-GestureInfo.prototype.state;
-/** @type {boolean|undefined} */
-GestureInfo.prototype.started;
-/** @type {!Array<?>|undefined} */
-GestureInfo.prototype.moves;
-/** @type {number|undefined} */
-GestureInfo.prototype.x;
-/** @type {number|undefined} */
-GestureInfo.prototype.y;
-/** @type {boolean|undefined} */
-GestureInfo.prototype.prevent;
-/** @type {function(?): void|undefined} */
-GestureInfo.prototype.addMove;
-/** @type {null|undefined} */
-GestureInfo.prototype.movefn;
-/** @type {null|undefined} */
-GestureInfo.prototype.upFn;
-
 // keep track of any labels hit by the mouseCanceller
 /** @type {!Array<!HTMLLabelElement>} */
 const clickedLabels = [];


### PR DESCRIPTION
The issue here was that we were assuming that the method for a given gesture would always match the string name of that gesture, e.g. that if the gesture name was "mousedown" that we could call
gestureDefinition.mousedown. In actuality, gestureDefinition.mousedown could be renamed by Closure, which would throw with "undefined is not a function".

The fix is to move the GesturesRecognizer type into our externs, which prevents those methods from being renamed.
