### PR TITLE
[3.x] Make event notification handler read the value from currentTarget,

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -353,7 +353,7 @@ function handleNotification(event, inst, fromProp, toPath, negate) {
     toPath = translate(fromProp, toPath, fromPath);
     value = detail && detail.value;
   } else {
-    value = event.target[fromProp];
+    value = event.currentTarget[fromProp];
   }
   value = negate ? !value : value;
   if (!inst[TYPES.READ_ONLY] || !inst[TYPES.READ_ONLY][toPath]) {

--- a/test/unit/property-effects.html
+++ b/test/unit/property-effects.html
@@ -341,6 +341,16 @@ suite('single-element binding effects', function() {
     assert.equal(el.customEventObject.value, 84, 'custom bound path incorrect');
     assert.equal(el.observerCounts.customEventObjectValueChanged, 1, 'custom bound path observer not called');
   });
+  
+  test('custom notification bubbling event to property', function() {
+    const child = document.createElement('div');
+    el.$.boundChild.appendChild(child);
+
+    el.$.boundChild.customEventValue = 42;
+    child.dispatchEvent(new Event('custom', {bubbles: true}));
+    assert.equal(el.customEventValue, 42, 'custom bound property incorrect');
+    assert.equal(el.observerCounts.customEventValueChanged, 1, 'custom bound property observer not called');
+  });
 
   test('computed property with negative number', function() {
     assert.equal(el.$.boundChild.computedNegativeNumber, -1);


### PR DESCRIPTION
instead of target which may not be bound to any data.

### Reference Issue
Fixes https://github.com/Polymer/polymer/issues/5308

Clone of https://github.com/Polymer/polymer/pull/5309
