### PR TITLE
Export the current Polymer version in polymer-element.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,7 +277,7 @@ gulp.task('lint', gulp.series('lint-eslint'));
 gulp.task('generate-types', gulp.series('generate-typescript'));
 
 gulp.task('update-version', () => {
-  return gulp.src('lib/utils/boot.js')
-  .pipe(replace(/(window.Polymer.version = )'\d+\.\d+\.\d+'/, `$1'${require('./package.json').version}'`))
-  .pipe(gulp.dest('lib/utils'));
+  return gulp.src('polymer-element.js')
+  .pipe(replace(/(export const version = )'\d+\.\d+\.\d+'/, `$1'${require('./package.json').version}'`))
+  .pipe(gulp.dest('.'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,7 +277,7 @@ gulp.task('lint', gulp.series('lint-eslint'));
 gulp.task('generate-types', gulp.series('generate-typescript'));
 
 gulp.task('update-version', () => {
-  return gulp.src('polymer-element.js')
+  return gulp.src('lib/mixins/element-mixin.js')
   .pipe(replace(/(export const version = )'\d+\.\d+\.\d+'/, `$1'${require('./package.json').version}'`))
-  .pipe(gulp.dest('.'));
+  .pipe(gulp.dest('lib/mixins'));
 });

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -18,6 +18,12 @@ import { PropertyEffects } from './property-effects.js';
 import { PropertiesMixin } from './properties-mixin.js';
 
 /**
+ * Current Polymer version in Semver notation.
+ * @type {string} Semver notation of the current version of Polymer.
+ */
+export const version = '3.0.5';
+
+/**
  * Element class mixin that provides the core API for Polymer's meta-programming
  * features including template stamping, data-binding, attribute deserialization,
  * and property change observation.
@@ -277,6 +283,14 @@ export const ElementMixin = dedupingMixin(base => {
    * @implements {Polymer_ElementMixin}
    */
   class PolymerElement extends polymerElementBase {
+
+    /**
+     * Current Polymer version in Semver notation.
+     * @type {string} Semver notation of the current version of Polymer.
+     */
+    static get polymerElementVersion() {
+      return version;
+    }
 
     /**
      * Override of PropertiesMixin _finalizeClass to create observers and

--- a/polymer-element.js
+++ b/polymer-element.js
@@ -28,3 +28,8 @@ export { html } from './lib/utils/html-tag.js';
  */
 export const PolymerElement = ElementMixin(HTMLElement);
 
+/**
+ * Current Polymer version in Semver notation.
+ * @type {String} Semver notation of the current version of Polymer.
+ */
+export const version = '3.0.5';

--- a/polymer-element.js
+++ b/polymer-element.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { ElementMixin } from './lib/mixins/element-mixin.js';
+export { version } from './lib/mixins/element-mixin.js';
 export { html } from './lib/utils/html-tag.js';
 
 /**
@@ -27,9 +28,3 @@ export { html } from './lib/utils/html-tag.js';
  *   attribute deserialization, and property change observation
  */
 export const PolymerElement = ElementMixin(HTMLElement);
-
-/**
- * Current Polymer version in Semver notation.
- * @type {String} Semver notation of the current version of Polymer.
- */
-export const version = '3.0.5';

--- a/test/unit/polymer.element.html
+++ b/test/unit/polymer.element.html
@@ -397,6 +397,9 @@ suite('class extends Polymer.Element', function() {
     assert.equal(fixtureEl.getAttribute('prop'), 'propValue');
   });
 
+  test('version', function() {
+    assert.isOk(el.constructor.polymerElementVersion);
+  });
 });
 
 suite('subclass', function() {


### PR DESCRIPTION
Potential solution for exposing the Polymer version in `polymer-element.js`. Not sure if this is the desired solution, but it seemed like the best option we have.
### Reference Issue
Fixes #5211 