### PR TITLE
Add tests with polymer-css-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ polymer-polymer-*.tgz
 # Typings are generated upon publish to NPM, except for one.
 *.d.ts
 !interfaces.d.ts
+
+# Ignore generated css-build tests
+test/css-build/css-build-shadow.html
+test/css-build/css-build-shady.html

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ polymer-polymer-*.tgz
 !interfaces.d.ts
 
 # Ignore generated css-build tests
-test/css-build/css-build-shadow.html
-test/css-build/css-build-shady.html
+test/css-build-shadow
+test/css-build-shady

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_script:
 - gulp lint-eslint
 script:
 - npm run generate-types
+- npm run css-build-shadow
+- npm run css-build-shady
 - node ./node_modules/.bin/polymer test --npm --module-resolution=node -l chrome
 - node ./node_modules/.bin/polymer test --npm --module-resolution=node -l firefox
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then travis_wait 30 ./util/travis-sauce-test.sh; fi

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 import '../utils/boot.js';
 
-import { rootPath as rootPath$0 } from '../utils/settings.js';
+import { rootPath as rootPath$0, useShadow, useNativeCSSProperties } from '../utils/settings.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { stylesFromTemplate, stylesFromModuleImports } from '../utils/style-gather.js';
 import { pathFromUrl, resolveCss, resolveUrl as resolveUrl$0 } from '../utils/resolve-url.js';
@@ -265,7 +265,7 @@ export const ElementMixin = dedupingMixin(base => {
       }
       s.textContent = klass._processStyleText(s.textContent, baseURI);
     }
-    if (window.ShadyCSS) {
+    if (window.ShadyCSS && !hasTargetedBuild(template)) {
       window.ShadyCSS.prepareTemplate(template, is);
     }
   }
@@ -531,7 +531,7 @@ export const ElementMixin = dedupingMixin(base => {
      * @return {void}
      */
     connectedCallback() {
-      if (window.ShadyCSS && this._template) {
+      if (window.ShadyCSS && this._template && !hasTargetedBuild(this._template)) {
         window.ShadyCSS.styleElement(/** @type {!HTMLElement} */(this));
       }
       super.connectedCallback();
@@ -744,3 +744,47 @@ export const updateStyles = function(props) {
     window.ShadyCSS.styleDocument(props);
   }
 };
+
+/**
+ * Return the type of css build applied to this element
+ *
+ * @param {HTMLTemplateElement} template Template for this element
+ * @return {string} Type of css build applied, empty string if no build
+ */
+function getCssBuild(template) {
+  if (template) {
+    const cssBuild = template.getAttribute('css-build');
+    if (cssBuild) {
+      return cssBuild;
+    }
+  }
+  return '';
+}
+
+/**
+ * Return true if this element has a css build that is also optimal for the features
+ * being used.
+ *
+ * Example: shadow build with native ShadowDOM and native CSS Custom Properties enabled.
+ *
+ * @param {HTMLTemplateElement} template Template for this element
+ * @return {boolean} Return true if the build is optimal
+ */
+function hasTargetedBuild(template) {
+  const buildType = getCssBuild(template);
+  // ShadyCSS must always be invoked if not using native CSS Custom Properties
+  if (!useNativeCSSProperties) {
+    return false;
+  }
+  if (buildType) {
+    // build has decomposed `@apply` mixins and is unscoped
+    if (buildType === 'shadow') {
+      return useShadow;
+    }
+    // build has decomposed `@apply` mixins and is shady scoped
+    if (buildType === 'shady') {
+      return !useShadow;
+    }
+  }
+  return false;
+}

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 import '../utils/boot.js';
 
-import { rootPath as rootPath$0, useShadow, useNativeCSSProperties } from '../utils/settings.js';
+import { rootPath as rootPath$0 } from '../utils/settings.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { stylesFromTemplate, stylesFromModuleImports } from '../utils/style-gather.js';
 import { pathFromUrl, resolveCss, resolveUrl as resolveUrl$0 } from '../utils/resolve-url.js';
@@ -265,7 +265,7 @@ export const ElementMixin = dedupingMixin(base => {
       }
       s.textContent = klass._processStyleText(s.textContent, baseURI);
     }
-    if (window.ShadyCSS && !hasTargetedBuild(template)) {
+    if (window.ShadyCSS) {
       window.ShadyCSS.prepareTemplate(template, is);
     }
   }
@@ -531,7 +531,7 @@ export const ElementMixin = dedupingMixin(base => {
      * @return {void}
      */
     connectedCallback() {
-      if (window.ShadyCSS && this._template && !hasTargetedBuild(this._template)) {
+      if (window.ShadyCSS && this._template) {
         window.ShadyCSS.styleElement(/** @type {!HTMLElement} */(this));
       }
       super.connectedCallback();
@@ -744,47 +744,3 @@ export const updateStyles = function(props) {
     window.ShadyCSS.styleDocument(props);
   }
 };
-
-/**
- * Return the type of css build applied to this element
- *
- * @param {HTMLTemplateElement} template Template for this element
- * @return {string} Type of css build applied, empty string if no build
- */
-function getCssBuild(template) {
-  if (template) {
-    const cssBuild = template.getAttribute('css-build');
-    if (cssBuild) {
-      return cssBuild;
-    }
-  }
-  return '';
-}
-
-/**
- * Return true if this element has a css build that is also optimal for the features
- * being used.
- *
- * Example: shadow build with native ShadowDOM and native CSS Custom Properties enabled.
- *
- * @param {HTMLTemplateElement} template Template for this element
- * @return {boolean} Return true if the build is optimal
- */
-function hasTargetedBuild(template) {
-  const buildType = getCssBuild(template);
-  // ShadyCSS must always be invoked if not using native CSS Custom Properties
-  if (!useNativeCSSProperties) {
-    return false;
-  }
-  if (buildType) {
-    // build has decomposed `@apply` mixins and is unscoped
-    if (buildType === 'shadow') {
-      return useShadow;
-    }
-    // build has decomposed `@apply` mixins and is shady scoped
-    if (buildType === 'shady') {
-      return !useShadow;
-    }
-  }
-  return false;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20790,17 +20790,70 @@
       }
     },
     "polymer-css-build": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0.tgz",
-      "integrity": "sha512-AY2gYjJp3ZhaaPJvHG2O3xVr3wUgs4TFnW7HJiU0N5B1lOP5fdqS/LLpxocirO4azsia+CK4xTyvdyftpMF27g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.4.0.tgz",
+      "integrity": "sha512-fkxcHhx1j0kP+bQpIm7BQF78MF/bEyr2IQU0/LE45cLCBds9OnY1GJhR80KzZ1ijF9JVxGA5xnXiuOI/Wvh7CQ==",
       "dev": true,
       "requires": {
-        "@webcomponents/shadycss": "1.4.0",
+        "@webcomponents/shadycss": "1.5.0",
         "command-line-args": "5.0.2",
         "command-line-usage": "5.0.5",
         "dom5": "3.0.1",
         "esm": "3.0.74",
-        "polymer-analyzer": "2.7.0"
+        "polymer-analyzer": "3.1.1"
+      },
+      "dependencies": {
+        "@webcomponents/shadycss": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.5.0.tgz",
+          "integrity": "sha512-jNuC7alo3EfiqZPosCruJuMAaUI9qgiuGxFcFyPWjOpo4BP+vgC7hxpTzQYxbIWUgrqkn9lnfPup2hE9c/h/PQ==",
+          "dev": true
+        },
+        "polymer-analyzer": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.1.1.tgz",
+          "integrity": "sha512-h/szQRobLO/fld2BsvTsmCFwtXQRF/tQcwquBuBl7qzgodaHWdvDIOE+VmzmYzM6W9/DW637O7JaeFnbXK/IgA==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
+            "@types/chai-subset": "1.3.1",
+            "@types/chalk": "0.4.31",
+            "@types/clone": "0.1.30",
+            "@types/cssbeautify": "0.3.1",
+            "@types/doctrine": "0.0.1",
+            "@types/is-windows": "0.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/parse5": "2.2.34",
+            "@types/path-is-inside": "1.0.0",
+            "@types/resolve": "0.0.6",
+            "@types/whatwg-url": "6.4.0",
+            "babylon": "7.0.0-beta.47",
+            "cancel-token": "0.1.1",
+            "chalk": "1.1.3",
+            "clone": "2.1.2",
+            "cssbeautify": "0.3.1",
+            "doctrine": "2.1.0",
+            "dom5": "3.0.1",
+            "indent": "0.0.2",
+            "is-windows": "1.0.2",
+            "jsonschema": "1.2.4",
+            "minimatch": "3.0.4",
+            "parse5": "4.0.0",
+            "path-is-inside": "1.0.2",
+            "resolve": "1.8.1",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.5",
+            "whatwg-url": "6.5.0"
+          }
+        }
       }
     },
     "polymer-project-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20790,9 +20790,9 @@
       }
     },
     "polymer-css-build": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-N76w3KqUocNYb7FuIv/L23uWX/jAExpbcF8x0vfLRU5NYdwsKGNndII6El5jnprC6ND3bG/NX9a9S1mn4WpZnQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0.tgz",
+      "integrity": "sha512-AY2gYjJp3ZhaaPJvHG2O3xVr3wUgs4TFnW7HJiU0N5B1lOP5fdqS/LLpxocirO4azsia+CK4xTyvdyftpMF27g==",
       "dev": true,
       "requires": {
         "@webcomponents/shadycss": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20790,9 +20790,9 @@
       }
     },
     "polymer-css-build": {
-      "version": "0.3.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0-alpha.7.tgz",
-      "integrity": "sha512-T3gOgGnEsCWk84aus5I5n3GAF6e7021g6MJ5mxb6nJ68pn7LuhRMIA5a1y7zwcNQLzdlkK5FMrDAZZfQUPxPyw==",
+      "version": "0.3.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0-alpha.8.tgz",
+      "integrity": "sha512-N76w3KqUocNYb7FuIv/L23uWX/jAExpbcF8x0vfLRU5NYdwsKGNndII6El5jnprC6ND3bG/NX9a9S1mn4WpZnQ==",
       "dev": true,
       "requires": {
         "@webcomponents/shadycss": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,34 +5,34 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.55.tgz",
-      "integrity": "sha1-cfUw57AQr163p993UveJId1X6e4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+      "integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.55"
+        "@babel/highlight": "7.0.0-rc.1"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.55.tgz",
-      "integrity": "sha1-nhfDS1rIVeQnyY9XCRWhf8xrq0o=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
+      "integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/generator": "7.0.0-beta.55",
-        "@babel/helpers": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
-        "convert-source-map": "^1.1.0",
-        "debug": "^3.1.0",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helpers": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "resolve": "1.8.1",
+        "semver": "5.5.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -44,16 +44,16 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-jsERUtzDmLrjXdGBEicEQVw4OgE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.0.0-rc.1",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -65,33 +65,33 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.55.tgz",
-      "integrity": "sha1-PD5MAOFOfeqReTjjXtXZFWzdNc4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.1.tgz",
+      "integrity": "sha512-GOV2UExs9gAvSrZF4rcgocXXeLJplq2kL2AsCrn6DmGwMUEfo/KB7FhedN3X6cVh0gOqqKkVKXrz3Li1wQ84xQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.55.tgz",
-      "integrity": "sha1-TQISis/1w2ii1D6oYIJgzkmu7F0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.1.tgz",
+      "integrity": "sha512-O6/szesBinGoExLl01Qg2vb5FaOfifSilgL5GnCZLz5z3Pg9jRolN6rGzQAOa/K9Y01TAmDf1dC06AKQUv3x8g==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-explode-assignable-expression": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.55.tgz",
-      "integrity": "sha1-E/aMhcKt/ofAL3q00qY9Nc1n1yQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3Z+shHGJTQnc61RCFVrQ3OJRmyL8uk4dWCsP8kT7G4inxv/bs6/zLOipK21VMePGpjUA4tnKxJCevMtp9ko4pw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-hoist-variables": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-define-map": {
@@ -102,7 +102,7 @@
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.35",
         "@babel/types": "7.0.0-beta.35",
-        "lodash": "^4.2.0"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -111,9 +111,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-function-name": {
@@ -145,7 +145,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -154,9 +154,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "ansi-styles": {
@@ -165,7 +165,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "babylon": {
@@ -180,9 +180,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -191,81 +191,81 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.55.tgz",
-      "integrity": "sha1-9cCW8mHKTvxhVLJjMxfuwe2QKeo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hSa+oxKn9bfbc3Ob1U7QJsO++do2Xe8Ft640alRJpEQ3VWy7tL8ZB+2xqo0pgHKo7rITuSxERz72uZji8dTiWg==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.55.tgz",
-      "integrity": "sha1-FqqyE4Ci6rzuMyjSG5WGujQn2+8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.55.tgz",
-      "integrity": "sha1-hVne2W7NO2JvnB9XSU7cT6PMapQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.55.tgz",
-      "integrity": "sha1-qIxdmS3KEJGZz5WyWQdTSpWdxGE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ttcilOh9SM9eqVlzwz2Lv7B5Dwyaa8TIhi1DDEPnC3CarpNPXFdeCOoxoV5qjHRD1klAT86gczeU4lJnSDKmgA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-gj0lS8m9AZpSn+Krf54dJocMXlA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-o263plHxPo1TxDDUx7gHuQ96Y8QyLs2n4968KZvo2l/9rkwn2L9kcIsRVjlhpPPKTz4tWe/7ZV50zkeDorrK9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.55.tgz",
-      "integrity": "sha1-k/knxmMdBom4u9GZHT+yqmPus/I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.1.tgz",
+      "integrity": "sha512-eA8RzanjsZw4X2Cqh3WgVG7zwf1wdSUfXvZOH8Azx1rpwE0hzJ276jDZ3gSOJShsxPVvopHa4h+c2WfEUjW4+Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55",
-        "lodash": "^4.17.10"
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.55.tgz",
-      "integrity": "sha1-K9EvDpGH5daVmf+nwR/po6Z7A9I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.1.tgz",
+      "integrity": "sha512-nz7FTFXlQ9UYp/dBjad4ZOu3Q4/1n86ysw9z9pjunqeKFNm+JHq7j5BeocFKIQAwul7QbIkSXiYm5EiteCHjiQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-simple-access": "7.0.0-beta.55",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
-        "lodash": "^4.17.10"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-simple-access": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -283,39 +283,39 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         }
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.55.tgz",
-      "integrity": "sha1-MfQHd+/WuWHahJapI8ItKwYrP3M=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8ZNzqHXDhT/JjnBvrLKu8AL7NhONVIsnrfyQNm3PJNmufIER5kcIa3OxPMGWgNqox2R8WeQ6YYzYTLNXqq4kgQ==",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-dObAY9Hvn35Yt6hMBubuSlu1pdo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-QXnTXVefioGuXlRMn+MnKKUHwhmdXGKnMvFI1tdHioMnBQEbEHGnmp+aYcddLwJ3KAH/hveaSR95BuWwprW+TA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-52LRuPfwYSHtPkC++x+YR9Rlin0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-skROQSC2fPwmrzAEPT/M7CObnWjJGpdbNLoICZDYHwDiUDe3dk5cQsU9j3tNlBhX14FaC9SjSpCJnSRpXDOWOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.55",
-        "@babel/helper-wrap-function": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-wrap-function": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-replace-supers": {
@@ -336,9 +336,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-function-name": {
@@ -370,7 +370,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/traverse": {
@@ -383,10 +383,10 @@
             "@babel/helper-function-name": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "debug": "^3.0.1",
-            "globals": "^10.0.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.2.0"
+            "debug": "3.1.0",
+            "globals": "10.4.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -395,9 +395,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "ansi-styles": {
@@ -406,7 +406,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "babylon": {
@@ -421,9 +421,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "globals": {
@@ -438,63 +438,63 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.55.tgz",
-      "integrity": "sha1-8/POJ58g/JDBZsT+oWZ2RoV7pVk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mfrHVSG0Dw51ajyL3Ltz+gEYrWAy4+Kl8lb1V/QWR31H7ovha6vNZ4guev/lR4KFu+4hMHogpjh4HB4AShqeMQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
-        "lodash": "^4.17.10"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.55.tgz",
-      "integrity": "sha1-7LgHS/LSLGUYolIoJTXe8TeocE8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.55.tgz",
-      "integrity": "sha1-MFPndkcFeym4jZYlUD4DOxvTSbQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.1.tgz",
+      "integrity": "sha512-LrqRD4+jEkQGVQsCRi7bPkSmYFAUd3pv9tYAC8nsr9Y0Qfus8oycqxDj60QW4dmigRKBRRbVVLr/0kMI2pk0MA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0LS5oyfbpC1YiQAR3rkFyCBzlhc=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.55",
-        "@babel/traverse": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.55.tgz",
-      "integrity": "sha1-mIZTZH1inCYdrhVudNXwJSulIMA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -503,7 +503,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -512,9 +512,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -523,120 +523,120 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.55.tgz",
-      "integrity": "sha1-ClJ+/BSMbIzYXV/92srYF6La7rI=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
+      "integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ==",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.55.tgz",
-      "integrity": "sha1-Xd3+zIQikNL8OcEvvjUEC82iMAg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-g0POypf/vBWEFmNkuwYrWoANrzOL4iSBhFtjSN+0D4BCm4jKtmY6kAOKaqjvWwj5IcqQVQEXqdRUXU0seoBF/g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-USuyjAQBdpgRgY1rRFPOm99fIco=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ewJnWv10AFUh+Yi6axMVQKW8L1pZCm86a44m2biYtXNSyt6FyWgdRloBbR7iCviPkeurfTCVdPS61G/t5cXVkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.55",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-thG7g5Ab8FGWI3xRaouxEXoqk5Y=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-J9qLEkxuZrYh/mel9RA5wDrMGE7jQMOMa1XPZMysih4C0mveeQUExbAPyrVSrFQo5BXLcLIc6ccM24G9xPCCXA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.55.tgz",
-      "integrity": "sha1-5ys4V+uAtpXHfDchI3sUkHLNpGs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.1.tgz",
+      "integrity": "sha512-2F5FYc89TCrqE/8+qFlr5jVMTHfkhEOg9JUx+GXI3inW2OfcY+J6bN8EDc8PLz84PHaR8W630YOuh2PveJu3WA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.55.tgz",
-      "integrity": "sha1-vO+ufo96haXVbeVLAgeZmLmLfNY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9U93f+wnHLOqHYxk1pftQfvWIx4FAKce9C41ZaNPLUffr7+yE+D24rNG0KeG5/ROMbKE3so7d2Qv891ThVZtPw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-import-meta": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.55.tgz",
-      "integrity": "sha1-U7LLOyiML/JhSiTPCUrjQMXIsRs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-rc.1.tgz",
+      "integrity": "sha512-pECmr/Eh3GVtzzJYKOOaTcRvNW2+IOD7M/xPONlQ65KgbpMJVygVXS3lMIrdZx2M3buQeTgLGUplq0r28zA0NA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-mQ6kfnkNfZqdKEaca8wV9YC/Gek=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-stOESgG+lc68DSFvXrqoH5dW91ZtedDoR40g9wJ1ruLahCdr9X5hVLv/ddf/g/1zzjevq59A1Q+xdUREhEnrvQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-6stEb/xn5RNaSimscr/6wa2hgfY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9JnWkl+iKmjNgMFrLjfGJQm3f66SJxwaYjdsm49Vpvo9x7ADHMGMZYa5Yto9WNQBlIdtf+fhypwBcz6IPxdyvg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-SQpHFVQIB72J9YWOiqww0VYb3WU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8oE9Frx07ILINop9hOejXgcDVhmt4FuB3ZjXnIMcSMkAuiT3xLrxFMDo1Qo0kf5mty2jLlnOO6tbbH0kiIWxWA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.55"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.55.tgz",
-      "integrity": "sha1-BnDQoUlDXupz9y4zkqUbON5gcnA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dFEgZqmyWXaVYrFU11IgLX8M1+gK7GSU+CVRv42D7P1FFMNndg1u36jXIa7URExEuTeTUykLM/IWgk5pHWxo6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.55.tgz",
-      "integrity": "sha1-yCb4wgMErDn2zdEdFPHNfZCqVHA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9uGwvSqJcmcKPEkLHA7ffrG0lKXTXprupwGjEKDw27OoRWXHdWUmA4VwpuzMrUsYyV+q+P6mgj6TPzoGJA3fAw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "lodash": "^4.17.10"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "lodash": "4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -658,9 +658,9 @@
           "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -701,7 +701,7 @@
             "@babel/code-frame": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
             "babylon": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -710,9 +710,9 @@
           "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "ansi-styles": {
@@ -721,7 +721,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "babylon": {
@@ -736,9 +736,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -747,244 +747,244 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-oE8QHzBWlQMf/aYVAXKMABgCN7k=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dfJNqbyF6S8nvFzGc6NthqCqopn1PoY3q2E1KcgrFSgxwYAMOLuhu5eA5iFeXwggp6tIo6OVVXC55/Twsolmow==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.55.tgz",
-      "integrity": "sha1-HUQhbLvbXYc4Gau3H+AzwUocFyM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.1.tgz",
+      "integrity": "sha512-YpuGA3cj5+gRD053nWtogo+3wxc10mNAAyf5syXXCVS/cOWpRjc3qPidzHtPodz+v8TgAwwaXwIz/ghLOojRQw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0TAMYHA9W1IF9l6heLe1cV0Lloc=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.1.tgz",
+      "integrity": "sha512-cWyoUi1izJk5JbWFG07GZrZyZgG+DW4axPKI0MA+lSAxjP8VZwFUhJyjT7R4bGN81KTVv1aprKclQnKxN2R0Lw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-3crA6oDmZBaBpHOnAwk80vYjpZ4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5lc0nlX8TPdkHSIX3/3jMtqvvJfzcARcev4qqsaVkXWQ6XNrNnD8ExyTEVgoGhr5Ppz1wA0ymAK8W33uGeKSOg==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.55.tgz",
-      "integrity": "sha1-zzBYxtgaPWnl3whilGiNrCikJxA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.1.tgz",
+      "integrity": "sha512-v09o2ywKHu+b/vkLknjKPV9QXCxuU2cVFxkWhBqcKwl3ERe3clhiab7a/8T9Sc332o4Im6n/LLugKMtpfxqRsQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.55.tgz",
-      "integrity": "sha1-EUOE1W4XOUkr1M6TN90Vis3hSAE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MiUORPQo3kvSCYBn/T6kKIfdDKqFAnEsaiRnTz36Y6M/p6NX7br5MgqPumVNgDboYKQ9kzaFNM8YJvWLcjL6SQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0+b98bKn7qN7NDPWKYsfQ2Iw4pg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-rc.1.tgz",
+      "integrity": "sha512-AZc7Ln5Rk3TAPQ3tkuuqL7/p1cUHoVEXBLX19xNXL+pauQ+vllpEcAQdkugkuojZ5KNmBYNRKoGf9oRSxixwDQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.55.tgz",
-      "integrity": "sha1-i8ks0k5kGTAe84Z+Rme3eqY3ThE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-iI468X7shsmB/oIPi8+UfMcOpcQPEsMAz5hDc0H8dKBGUWbPcAlyQpC8CaNDZ7y1/7lK65wtvXs5OGTQd3OsJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.55.tgz",
-      "integrity": "sha1-yLWbhNb0mHUSZnxvlBCvPd1WLhI=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xKIF2ZAFOZRgIhEeW6zuyieyqfjft59NaHvb2C7+N9omdFDVkrx5ZeHVLb8y163a3mUb2MqJg1PLfZXdwvz1EA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-module-transforms": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.55.tgz",
-      "integrity": "sha1-tRjROpA1ISgZFRTX1duOWnjJmSs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mwoid0Rx+L55NupRE9xs1JAgFRz0JIYS/JR0aqBlLOQwBY1KrbrAtQfNwHQobwZrP9O24VBRfViMsiYLh/UV4A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-replace-supers": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-replace-supers": "7.0.0-rc.1"
       },
       "dependencies": {
         "@babel/helper-optimise-call-expression": {
-          "version": "7.0.0-beta.55",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.55.tgz",
-          "integrity": "sha1-V/3GiYvFPwLaeL9KOVCdTfw7M8s=",
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.1.tgz",
+          "integrity": "sha512-XOKPnL/AJz8ZyY553FsMAVt9g/mE1+RQfg5/m3X0K4+RqYviPGZlxwe5mGSd8s2kPSB6D6nZRUfvZFtmFIXEvA==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.55"
+            "@babel/types": "7.0.0-rc.1"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.0.0-beta.55",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.55.tgz",
-          "integrity": "sha1-1YithjmQ812LD2eqlO+O7CQXGFU=",
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.1.tgz",
+          "integrity": "sha512-mcv+NKCazZfdEw7yBe/xROekR3qlFcy18d//mJTKnZb7xx2qFPjZAafkeIlpvzNHwd/WMTHShC4+3WjOL8FD5g==",
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "7.0.0-beta.55",
-            "@babel/helper-optimise-call-expression": "7.0.0-beta.55",
-            "@babel/traverse": "7.0.0-beta.55",
-            "@babel/types": "7.0.0-beta.55"
+            "@babel/helper-member-expression-to-functions": "7.0.0-rc.1",
+            "@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1"
           }
         }
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.55.tgz",
-      "integrity": "sha1-8hHxilYKTZKNlknaEcKN2J8V7/4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.1.tgz",
+      "integrity": "sha512-PKjm+xf23XvdP0WRj/fIiP3xa5DYOg6qd0150Mpu4JvCIci6vrWvkc+kU9RtwkXLycWRfzdSnnyuSZABxPAP8A==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.55",
-        "@babel/helper-get-function-arity": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-call-delegate": "7.0.0-rc.1",
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.55.tgz",
-      "integrity": "sha1-oSuhN2xkfPC3d96op7Vf5GZe0f8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-a73XZOJGt0Ft8/YbRAUl0Vs1GuPpjB6QVQNYPxWUNXblSiywhkkZxLssHZnao2xTD26kLRfMoXfOtj9FMz5fcw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.55.tgz",
-      "integrity": "sha1-del1dbh8b+McAI/D11X93NbLkIo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-NkUsTSKL8txvPt9vtdkcbJEyiUtcSOAr6ZnAE+Vg4mB0hYI0sWEJCAzl26KDDFgdVSKJSAaenjX5UR3BAF3KaA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.55.tgz",
-      "integrity": "sha1-1aHDIKrIZGnW0xHhNqiftaH2VgA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-/3EkUVVi55i/JCbL2CxXTaoCXCopj3qQMTZ0lvgtpepx1yAMpoHYFBNWLIuQmjG7JhDauOwEdBg8TRsneYRmmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-0LgLLeuLTbA7xkWevnmtizm0BUY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-sXPFGI3GTtSMxVTDwrRmgwmUcq+l0ovzUZFfAd4YK1zJQ7YQCaCjcmLskuiGM20SoteYserDADg0SrLw+8B8hA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.55.tgz",
-      "integrity": "sha1-sApkltTIOEUHVZWYqvSdjBrYkuY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xq9eSNA65VXbMmVEjKUXB0czP8y/CRs88S8HcwZbJ7XGo4FARUJV3aGQfIPvGUmbkQegsxZx5rlTPlw3NPl+Aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.55",
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.55.tgz",
-      "integrity": "sha1-YjJpGFYLdlu+nzYq06TOO8cUd7w=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.1.tgz",
+      "integrity": "sha512-wUKNscuv3WOOFy3tGOBeayeOLyZjixjOSvb0QNXrCDRuENhfPaFQjZt/T0UDAZN0mXvAQ7Ksx2pOtXBsyIBxUA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.55.tgz",
-      "integrity": "sha1-h+e+27oQP3hKeZn4IGT0fAs1x5Y=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3yz7ehk0VFLqoKVV1GbTdH2sfMtYznhllkBDtnybveM6MeFA5WYCf6iWf+I/vF/8QIMDd1b4359GGWKCI+KuIQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.55",
-        "@babel/helper-regex": "7.0.0-beta.55",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.55.tgz",
-      "integrity": "sha1-xsqw4nIrpeM/4DQHO20xZzq6Mm4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
+      "integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "4.17.10"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.55.tgz",
-      "integrity": "sha1-UL5dD8xcxKwCCnsMUZvo2uNF1L4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
+      "integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.55",
-        "@babel/generator": "7.0.0-beta.55",
-        "@babel/helper-function-name": "7.0.0-beta.55",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.55",
-        "@babel/parser": "7.0.0-beta.55",
-        "@babel/types": "7.0.0-beta.55",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "debug": "3.1.0",
+        "globals": "11.7.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.55.tgz",
-      "integrity": "sha1-d1XJ0uWDFaZPBdjPMyI3m+FtkZk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@polymer/app-layout": {
@@ -993,11 +993,11 @@
       "integrity": "sha512-yQpUQR3zFJWb/sS5wU1prcuyjL6yzKD7L+qRoK0TYLcS7kHO6k3vB4ufHg//lN4HHhOvw3Q5dwe2bgVdlm0ELw==",
       "dev": true,
       "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.21",
-        "@polymer/iron-media-query": "^3.0.0-pre.21",
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.21",
-        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-flex-layout": "3.0.0-pre.21",
+        "@polymer/iron-media-query": "3.0.0-pre.21",
+        "@polymer/iron-resizable-behavior": "3.0.0-pre.21",
+        "@polymer/iron-scroll-target-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/esm-amd-loader": {
@@ -1018,8 +1018,8 @@
       "integrity": "sha512-gRDYxL/2nko1dJDIS+l+nc7BBzIz4x5LF+X+fskXcoiH+2A4PdCBeQXbCSpq9Dne5iig6MIr7GaK+Z3Y+5STCA==",
       "dev": true,
       "requires": {
-        "escodegen": "^1.9.0",
-        "polymer-analyzer": "^2.3.0"
+        "escodegen": "1.11.0",
+        "polymer-analyzer": "2.7.0"
       }
     },
     "@polymer/gen-typescript-declarations": {
@@ -1028,23 +1028,23 @@
       "integrity": "sha512-+ckyD5lC6BE00OFlGh2toVm98DE7a2fu0VrBbk+VKXzRVoxBFrOqNBVCw3IJlXNtGvrO+glyhKCVkeMWVtk3gw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0-beta.42",
-        "@types/command-line-args": "^5.0.0",
-        "@types/command-line-usage": "^5.0.1",
+        "@babel/types": "7.0.0-rc.1",
+        "@types/command-line-args": "5.0.0",
+        "@types/command-line-usage": "5.0.1",
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "^5.0.0",
-        "@types/glob": "^5.0.35",
-        "@types/parse5": "^2.2.34",
-        "babylon": "^7.0.0-beta.42",
-        "command-line-args": "^5.0.1",
-        "command-line-usage": "^5.0.2",
-        "doctrine": "^2.0.0",
-        "escodegen": "^1.9.0",
-        "fs-extra": "^6.0.1",
-        "glob": "^7.1.2",
-        "minimatch": "^3.0.4",
-        "polymer-analyzer": "^3.0.2",
-        "vscode-uri": "^1.0.3"
+        "@types/fs-extra": "5.0.4",
+        "@types/glob": "5.0.35",
+        "@types/parse5": "2.2.34",
+        "babylon": "7.0.0-beta.47",
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "doctrine": "2.1.0",
+        "escodegen": "1.11.0",
+        "fs-extra": "6.0.1",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "polymer-analyzer": "3.1.0",
+        "vscode-uri": "1.0.5"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -1054,9 +1054,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "9.6.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz",
-          "integrity": "sha512-o5K0mt8x735EaqS7F2x+5AG0b1Mt3V9jgV5SeW8SD6RNhE++dvwqLf2R2e4c8FmhNLaogz2oXrsiXnqnsBSSIQ==",
+          "version": "9.6.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.26.tgz",
+          "integrity": "sha512-3LKKscYUZdZreOuvnly8oWsCA1TOWtmkV3mbcUnV34f+nqDWJic+4SGjRi1C/sPHnZcSs/x209O+Dgy8aWHt2A==",
           "dev": true
         },
         "fs-extra": {
@@ -1065,9 +1065,9 @@
           "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
           }
         },
         "polymer-analyzer": {
@@ -1076,44 +1076,44 @@
           "integrity": "sha512-TW+SE+dofxSU6+7vJeH//Znjtu1brYE+J4w6M8W+BwoC3FHtBonxp4zCQFf+RnhQGcKIrfHVAxgujzccXer19Q==",
           "dev": true,
           "requires": {
-            "@babel/generator": "^7.0.0-beta.42",
-            "@babel/traverse": "^7.0.0-beta.42",
-            "@babel/types": "^7.0.0-beta.42",
-            "@types/babel-generator": "^6.25.1",
-            "@types/babel-traverse": "^6.25.2",
-            "@types/babel-types": "^6.25.1",
-            "@types/babylon": "^6.16.2",
-            "@types/chai-subset": "^1.3.0",
-            "@types/chalk": "^0.4.30",
-            "@types/clone": "^0.1.30",
-            "@types/cssbeautify": "^0.3.1",
-            "@types/doctrine": "^0.0.1",
-            "@types/is-windows": "^0.2.0",
-            "@types/minimatch": "^3.0.1",
-            "@types/node": "^9.6.4",
-            "@types/parse5": "^2.2.34",
-            "@types/path-is-inside": "^1.0.0",
+            "@babel/generator": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
+            "@types/chai-subset": "1.3.1",
+            "@types/chalk": "0.4.31",
+            "@types/clone": "0.1.30",
+            "@types/cssbeautify": "0.3.1",
+            "@types/doctrine": "0.0.1",
+            "@types/is-windows": "0.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/node": "9.6.26",
+            "@types/parse5": "2.2.34",
+            "@types/path-is-inside": "1.0.0",
             "@types/resolve": "0.0.6",
-            "@types/whatwg-url": "^6.4.0",
-            "babylon": "^7.0.0-beta.42",
-            "cancel-token": "^0.1.1",
-            "chalk": "^1.1.3",
-            "clone": "^2.0.0",
-            "cssbeautify": "^0.3.1",
-            "doctrine": "^2.0.2",
-            "dom5": "^3.0.0",
+            "@types/whatwg-url": "6.4.0",
+            "babylon": "7.0.0-beta.47",
+            "cancel-token": "0.1.1",
+            "chalk": "1.1.3",
+            "clone": "2.1.2",
+            "cssbeautify": "0.3.1",
+            "doctrine": "2.1.0",
+            "dom5": "3.0.1",
             "indent": "0.0.2",
-            "is-windows": "^1.0.2",
-            "jsonschema": "^1.1.0",
-            "minimatch": "^3.0.4",
-            "parse5": "^4.0.0",
-            "path-is-inside": "^1.0.2",
-            "resolve": "^1.5.0",
-            "shady-css-parser": "^0.1.0",
-            "stable": "^0.1.6",
-            "strip-indent": "^2.0.0",
-            "vscode-uri": "^1.0.1",
-            "whatwg-url": "^6.4.0"
+            "is-windows": "1.0.2",
+            "jsonschema": "1.2.4",
+            "minimatch": "3.0.4",
+            "parse5": "4.0.0",
+            "path-is-inside": "1.0.2",
+            "resolve": "1.8.1",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.5",
+            "whatwg-url": "6.5.0"
           },
           "dependencies": {
             "@types/doctrine": {
@@ -1132,7 +1132,7 @@
       "integrity": "sha512-n35ck7y5aQweRxK2JvEe7sFE/LbUd/b5EW8tYPa/96iZw1qcTHWtIKdMJjDH18YroKVFH4Ncz4/0Xg7GChLhvA==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-a11y-keys-behavior": {
@@ -1141,7 +1141,7 @@
       "integrity": "sha512-fdADeKVQsZ7Izg5H6pOM9VVFWMTVUGgMfGr6jzEW0ehZT6N7bTzBIjft2r8sh3qSx2zCUxQEgUUDoeXE9/yROA==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-ajax": {
@@ -1150,7 +1150,7 @@
       "integrity": "sha512-ThdEkmsyAwfEsz8l08uiDp0rHzBe+aCPix+wqsomxoZf7zpUtCr7k8EDhp1u9CLxNO7HRv4SPApM110GVAQA9Q==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-behaviors": {
@@ -1159,8 +1159,8 @@
       "integrity": "sha512-sxdLri6CMNs6kty8sPDYGuAX9LofbEn2r/qI3QkJZUXFZhZUSGwCmoDt9yMWffNSamUsEDURLafYW09jOEhtRQ==",
       "dev": true,
       "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-a11y-keys-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-checked-element-behavior": {
@@ -1169,9 +1169,9 @@
       "integrity": "sha512-ZpyKomXudcOM1vGvfqwFkrlTumChStbNy5rRFKbdCbsUeZsXV83LIHfkXxMhJJ5hEIExvK4pDcnv/wEdFggXPQ==",
       "dev": true,
       "requires": {
-        "@polymer/iron-form-element-behavior": "^3.0.0-pre.21",
-        "@polymer/iron-validatable-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-form-element-behavior": "3.0.0-pre.21",
+        "@polymer/iron-validatable-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-component-page": {
@@ -1180,14 +1180,14 @@
       "integrity": "sha512-dc7P/wCY6J/ApVvQd6gZXVbB3ZGt/pmFtn/uaTbiSNRitzu9Fu+HaQsAtWLu4QbaZjSALTY70i7Im7LGUi6qFA==",
       "dev": true,
       "requires": {
-        "@polymer/app-layout": "^3.0.0-pre.21",
-        "@polymer/iron-ajax": "^3.0.0-pre.21",
-        "@polymer/iron-doc-viewer": "^3.0.0-pre.21",
-        "@polymer/iron-icons": "^3.0.0-pre.21",
-        "@polymer/paper-icon-button": "^3.0.0-pre.21",
-        "@polymer/paper-styles": "^3.0.0-pre.21",
-        "@polymer/paper-toast": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/app-layout": "3.0.0-pre.21",
+        "@polymer/iron-ajax": "3.0.0-pre.21",
+        "@polymer/iron-doc-viewer": "3.0.0-pre.21",
+        "@polymer/iron-icons": "3.0.0-pre.21",
+        "@polymer/paper-icon-button": "3.0.0-pre.21",
+        "@polymer/paper-styles": "3.0.0-pre.21",
+        "@polymer/paper-toast": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-doc-viewer": {
@@ -1196,11 +1196,11 @@
       "integrity": "sha512-9U4Xia/swdrk2BmXx0VUzkOZhncveQDWDZZ2DYFiW3TCSl4zU57o+5bSlZyRXsvr7ddOgqRr5Yw1zhGgFSxGEQ==",
       "dev": true,
       "requires": {
-        "@polymer/iron-location": "^3.0.0-pre.21",
-        "@polymer/marked-element": "^3.0.0-pre.21",
-        "@polymer/paper-styles": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0",
-        "@polymer/prism-element": "^3.0.0-pre.21"
+        "@polymer/iron-location": "3.0.0-pre.21",
+        "@polymer/marked-element": "3.0.0-pre.21",
+        "@polymer/paper-styles": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5",
+        "@polymer/prism-element": "3.0.0-pre.21"
       }
     },
     "@polymer/iron-fit-behavior": {
@@ -1209,7 +1209,7 @@
       "integrity": "sha512-j3F59w4xGfVbmw8PQruQz4b7tHpi2cmgVeuOuQM6eG0+wA6hu5O2I+LYJCQmCLuQN8LzFjATTOCDfhlDb2Pfcg==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-flex-layout": {
@@ -1218,7 +1218,7 @@
       "integrity": "sha512-/GFBWLBhpzycXmdyS+rzQxCa/ssCX5ZGEa0M/oMRsUK/hUKrj/XBNNYZ3BlyHf2NHELNqnwZLcIZB5EPjA0uwg==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-form-element-behavior": {
@@ -1227,7 +1227,7 @@
       "integrity": "sha512-E9oS0ryZw7FPQ/XMmBaKScyv8l/z86kKpIfXm+WLbqapu5FIuNE54z/73QUs5uoKI+H8gR9UL48mzZGCiGEMDw==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-icon": {
@@ -1236,9 +1236,9 @@
       "integrity": "sha512-B/6ncM/JiKYOCkYtIsgztZuMzmMWAR5POGQ0r7TU0RaBzKstqTvn6NfRHeNzYjsOwBMse/wA6/qvgvCRgx6kWw==",
       "dev": true,
       "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.21",
-        "@polymer/iron-meta": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-flex-layout": "3.0.0-pre.21",
+        "@polymer/iron-meta": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-icons": {
@@ -1247,9 +1247,9 @@
       "integrity": "sha512-ExwaHlToVXl3BN3y2sYiutVqf9+vrnVx8/PdaNkwvDaBt1RTyeGN5EP3YGvKsaF17yq9TlJsnLOANvf1koO/XA==",
       "dev": true,
       "requires": {
-        "@polymer/iron-icon": "^3.0.0-pre.21",
-        "@polymer/iron-iconset-svg": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-icon": "3.0.0-pre.21",
+        "@polymer/iron-iconset-svg": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-iconset-svg": {
@@ -1258,8 +1258,8 @@
       "integrity": "sha512-YWdX3QROFHKsGds9wUDbD2u1hN6uG6oG4fEu/F16aHFQg9tu2oiSyRspGsOQlXJ28177Qc2rxQ1Kp8GdlzpMbw==",
       "dev": true,
       "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-meta": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-location": {
@@ -1268,7 +1268,7 @@
       "integrity": "sha512-NIAAGKkvUkfkVg3lge4r66WdcTXTZfhNwADWwh5REcM5rubqMWb6PKb+K/6bumDEODYtI5waL3ewOeFMdONUHA==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-media-query": {
@@ -1277,7 +1277,7 @@
       "integrity": "sha512-hvuNZj53XBU6LDU93VDkOozH3Kn6Gd7hsi/KlOCHPocQFhCz+ChM3uSfC7Jf0cBLvS1VpH0hxUDAvQNlrx9H/w==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-meta": {
@@ -1286,7 +1286,7 @@
       "integrity": "sha512-RR24zD2t4rSJyjisMo5Cfy200FFYrsmRDZSX8wk1JdaDHVWLgq9DM1aa7/B7WI7sEWkckzVZPBthRFVB+PmVwA==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-overlay-behavior": {
@@ -1295,10 +1295,10 @@
       "integrity": "sha512-aHGtygYEXmFu0Y13vLuBfXm/obNlGnb4JdKCycB931ugfrloEwYo+8DcPyWdc3J0dMJDhv7pH8VZJglNdUQjZA==",
       "dev": true,
       "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.21",
-        "@polymer/iron-fit-behavior": "^3.0.0-pre.21",
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-a11y-keys-behavior": "3.0.0-pre.21",
+        "@polymer/iron-fit-behavior": "3.0.0-pre.21",
+        "@polymer/iron-resizable-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-resizable-behavior": {
@@ -1307,7 +1307,7 @@
       "integrity": "sha512-V27DpRXUofbz8K43U5ITC2N/LIrqIrrmaslNxrnasTheiDiienpZDFBTCjO+eGz61Cijjs39VIEYF9TezbDY8A==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-scroll-target-behavior": {
@@ -1316,7 +1316,7 @@
       "integrity": "sha512-bHW5eKtXmSHzZbMAo7cUgORkLKToMawY4+jHQCUyghmX+pRCnedOF56YJW96Ix60/NzU1SLrEin1RMDjlISw/w==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/iron-validatable-behavior": {
@@ -1325,8 +1325,8 @@
       "integrity": "sha512-G4yxCe2xp9+jJ0MkjqC26MKo1FqsvUrnmqpCtJiVBLlpZEUx1b2lZz2ZzynXpnisg9EuZ3xtHtOge5UFTNoG+w==",
       "dev": true,
       "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-meta": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/marked-element": {
@@ -1335,8 +1335,8 @@
       "integrity": "sha512-7DlbJb/l/M87heHvj8lmK6P02fUpoMZLIe6GxbqQscH0uvDtHTyM7topu1hBt0pg0V7wkgC5KInZteftMQSPeQ==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "marked": "~0.3.9"
+        "@polymer/polymer": "3.0.5",
+        "marked": "0.3.19"
       }
     },
     "@polymer/paper-behaviors": {
@@ -1345,10 +1345,10 @@
       "integrity": "sha512-CiS/1K9b+b5qxpykr5P/ZeO5le06H7aaR/ymPWJ/m0ioFcSyzRPWlEwjDwiqqCBCmwmdsLXvLYmB2Z6oLiXqPQ==",
       "dev": true,
       "requires": {
-        "@polymer/iron-behaviors": "^3.0.0-pre.21",
-        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.21",
-        "@polymer/paper-ripple": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-behaviors": "3.0.0-pre.21",
+        "@polymer/iron-checked-element-behavior": "3.0.0-pre.21",
+        "@polymer/paper-ripple": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/paper-icon-button": {
@@ -1357,10 +1357,10 @@
       "integrity": "sha512-H+kx7v6R7+Hd6A6hSt+bsCMzbTPArty8yGFqTKpjsvGFCVfRHcIwoKrHqgQ0CX/JHmn2Zs+tF0IIdtiHjJYegg==",
       "dev": true,
       "requires": {
-        "@polymer/iron-icon": "^3.0.0-pre.21",
-        "@polymer/paper-behaviors": "^3.0.0-pre.21",
-        "@polymer/paper-styles": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-icon": "3.0.0-pre.21",
+        "@polymer/paper-behaviors": "3.0.0-pre.21",
+        "@polymer/paper-styles": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/paper-ripple": {
@@ -1369,8 +1369,8 @@
       "integrity": "sha512-qqNdU1/57WtMr+3NiAVI2zXw4LrEX9QD9jwifIgJXWj+lqe0YMeKrXOvCYHvV8nv9Owq7dRGvhOXM++E+imoLQ==",
       "dev": true,
       "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-a11y-keys-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/paper-styles": {
@@ -1379,9 +1379,9 @@
       "integrity": "sha512-GJB0EirkY17N05kbTMDa8aABvQ2GIE95LMt7aOy16VG6sjh1TFS0gUOnoGgHA7ZUUZsOP3BdNqxKYzgQ+9m/GA==",
       "dev": true,
       "requires": {
-        "@polymer/font-roboto": "^3.0.0-pre.21",
-        "@polymer/iron-flex-layout": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/font-roboto": "3.0.0-pre.21",
+        "@polymer/iron-flex-layout": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/paper-toast": {
@@ -1390,19 +1390,19 @@
       "integrity": "sha512-7jaAfpYxz86CUcgUhE/CCrCSh5kMNIC6c0+rerUozraVOmbbQGO2C4CLu/8aaJjxzqPdnTxyZwME82zHCu2qhw==",
       "dev": true,
       "requires": {
-        "@polymer/iron-a11y-announcer": "^3.0.0-pre.21",
-        "@polymer/iron-fit-behavior": "^3.0.0-pre.21",
-        "@polymer/iron-overlay-behavior": "^3.0.0-pre.21",
-        "@polymer/polymer": "^3.0.0"
+        "@polymer/iron-a11y-announcer": "3.0.0-pre.21",
+        "@polymer/iron-fit-behavior": "3.0.0-pre.21",
+        "@polymer/iron-overlay-behavior": "3.0.0-pre.21",
+        "@polymer/polymer": "3.0.5"
       }
     },
     "@polymer/polymer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.2.tgz",
-      "integrity": "sha512-ow8AAjTe9ps8bantY9IvL0PT+xHf5VN3Cjahfr7gBJAc0lv3jTwGBv7pso65SHyrUJEEHeakhx6iPMl7qY4tfw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",
+      "integrity": "sha512-Zbmhtr5vZ3NoHWwFYLKI4ff7yfE6DZopI8vaS7HvmUIuNqsv/EpEDXfNEYjqePQmkMX5LU9OIKV1eX/+9aveow==",
       "dev": true,
       "requires": {
-        "@webcomponents/shadycss": "^1.2.0"
+        "@webcomponents/shadycss": "1.4.0"
       }
     },
     "@polymer/prism-element": {
@@ -1411,8 +1411,8 @@
       "integrity": "sha512-8ZvgyrVncOOy9EoGIBAdgBTaPVfu4Vg0fHsBOQ9qCpGXYOU+033G9hgrHgNyWKNR1VGmdVEhztTvNIGqH9KzQA==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "prismjs": "^1.11.0"
+        "@polymer/polymer": "3.0.5",
+        "prismjs": "1.15.0"
       }
     },
     "@polymer/sinonjs": {
@@ -1433,7 +1433,7 @@
       "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
       "dev": true,
       "requires": {
-        "@types/estree": "*"
+        "@types/estree": "0.0.37"
       }
     },
     "@types/babel-generator": {
@@ -1442,7 +1442,7 @@
       "integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/babel-traverse": {
@@ -1451,7 +1451,7 @@
       "integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/babel-types": {
@@ -1466,7 +1466,7 @@
       "integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "6.25.2"
       }
     },
     "@types/chai": {
@@ -1481,7 +1481,7 @@
       "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
       "dev": true,
       "requires": {
-        "@types/chai": "*"
+        "@types/chai": "4.1.4"
       }
     },
     "@types/chalk": {
@@ -1538,7 +1538,7 @@
       "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
       "dev": true,
       "requires": {
-        "@types/estree": "*"
+        "@types/estree": "0.0.37"
       }
     },
     "@types/estree": {
@@ -1559,7 +1559,7 @@
       "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/glob": {
@@ -1568,9 +1568,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "6.0.116"
       }
     },
     "@types/glob-stream": {
@@ -1579,8 +1579,8 @@
       "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
       "dev": true,
       "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "@types/glob": "5.0.35",
+        "@types/node": "6.0.116"
       }
     },
     "@types/gulp-if": {
@@ -1589,8 +1589,8 @@
       "integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/vinyl": "*"
+        "@types/node": "6.0.116",
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/html-minifier": {
@@ -1599,9 +1599,9 @@
       "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
       "dev": true,
       "requires": {
-        "@types/clean-css": "*",
-        "@types/relateurl": "*",
-        "@types/uglify-js": "*"
+        "@types/clean-css": "3.4.30",
+        "@types/relateurl": "0.2.28",
+        "@types/uglify-js": "3.0.3"
       }
     },
     "@types/is-windows": {
@@ -1622,13 +1622,13 @@
       "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/node": {
-      "version": "6.0.114",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.114.tgz",
-      "integrity": "sha512-5ViC9dwf1VIAtrOFTvOuN04lJgw28eKjuy0Vg2Bd/fSlxKP2feCSkIw04ZgOENL2ywdWrtbkthp1XVLEjJmouw==",
+      "version": "6.0.116",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.116.tgz",
+      "integrity": "sha512-vToa8YEeulfyYg1gSOeHjvvIRqrokng62VMSj2hoZrwZNcYrp2h3AWo6KeBVuymIklQUaY5zgVJvVsC4KiiLkQ==",
       "dev": true
     },
     "@types/parse5": {
@@ -1637,7 +1637,7 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/path-is-inside": {
@@ -1658,7 +1658,7 @@
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/ua-parser-js": {
@@ -1673,7 +1673,7 @@
       "integrity": "sha512-MAT0BW2ruO0LhQKjvlipLGCF/Yx0y/cj+tT67tK3QIQDrM2+9R78HgJ54VlrE8AbfjYJJBCQCEPM5ZblPVTuww==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       }
     },
     "@types/uuid": {
@@ -1682,7 +1682,7 @@
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/vinyl": {
@@ -1691,18 +1691,19 @@
       "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/vinyl-fs": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.8.tgz",
-      "integrity": "sha512-yE2pN9OOrxJVeO7IZLHAHrh5R4Q0osbn5WQRuQU6GdXoK7dNFrMK3K7YhATkzf3z0yQBkol3+gafs7Rp0s7dDg==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.9.tgz",
+      "integrity": "sha512-Q0EXd6c1fORjiOuK4ZaKdfFcMyFzJlTi56dqktwaWVLIDAzE49wUs3bKnYbZwzyMWoH+NcMWnRuR73S9A0jnRA==",
       "dev": true,
       "requires": {
-        "@types/glob-stream": "*",
-        "@types/node": "*",
-        "@types/vinyl": "*"
+        "@types/events": "1.2.0",
+        "@types/glob-stream": "6.1.0",
+        "@types/node": "6.0.116",
+        "@types/vinyl": "2.0.2"
       }
     },
     "@types/whatwg-url": {
@@ -1711,7 +1712,7 @@
       "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@types/winston": {
@@ -1720,18 +1721,18 @@
       "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.3.5.tgz",
-      "integrity": "sha512-SBGmmpylJaNbWBQ84BvHl0keEhqOgPVG1zCdxtoQXrp3fUxFbjiJPHjvx6oqMjFTzkmKOwo/oKNvZyEtxltKiA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.4.0.tgz",
+      "integrity": "sha512-/OK+M06S9YbnTXAHm1QtHhONo0msBej/V84x3ZpSV+sJa1jp/FfOv0mW0IWdluU94QlVrPnJxK2t+Czggfivig=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.3.tgz",
-      "integrity": "sha512-MAXeE34PaC2gDVNKa+YLkRvnIBezIslR8AHoS/E8nOYuFL0qUcOD4L7/BBZOrNtxMRrNTCvtkXL7TrEmYmyQiQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.4.tgz",
+      "integrity": "sha512-wzPSTmwjAd/0oKW36Yi+cB/BmDrHhcHqGlbqqMjrbPIFkt5Mw7wtvEZQouCrQyBNnRquUhRnSWIBrRijHNBBKg==",
       "dev": true
     },
     "abbrev": {
@@ -1758,7 +1759,7 @@
       "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
       "dev": true,
       "requires": {
-        "acorn": "^5.4.1"
+        "acorn": "5.7.1"
       }
     },
     "acorn-jsx": {
@@ -1767,7 +1768,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -1784,10 +1785,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -1802,7 +1803,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1823,8 +1824,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1833,7 +1834,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1844,7 +1845,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -1910,8 +1911,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       }
     },
     "append-buffer": {
@@ -1920,7 +1921,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "^1.0.0"
+        "buffer-equal": "1.0.0"
       }
     },
     "archy": {
@@ -1935,7 +1936,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "argv-tools": {
@@ -1944,8 +1945,8 @@
       "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1"
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1"
       }
     },
     "arr-diff": {
@@ -1960,7 +1961,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-flatten": {
@@ -1975,7 +1976,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-union": {
@@ -1990,7 +1991,7 @@
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "^2.6.1"
+        "typical": "2.6.1"
       }
     },
     "array-each": {
@@ -2011,8 +2012,8 @@
       "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
-        "array-slice": "^1.0.0",
-        "is-number": "^4.0.0"
+        "array-slice": "1.1.0",
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2029,7 +2030,7 @@
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2052,9 +2053,9 @@
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
       "dev": true,
       "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2071,7 +2072,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -2116,10 +2117,10 @@
       "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.2",
-        "process-nextick-args": "^1.0.7",
-        "stream-exhaust": "^1.0.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0",
+        "process-nextick-args": "1.0.7",
+        "stream-exhaust": "1.0.2"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2142,7 +2143,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "^1.2.2"
+        "async-done": "1.3.1"
       }
     },
     "atob": {
@@ -2157,9 +2158,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -2168,25 +2169,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "babylon": {
@@ -2218,10 +2219,10 @@
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-traverse": "^6.23.1",
-        "babel-types": "^6.23.0",
-        "babylon": "^6.17.0"
+        "babel-code-frame": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0"
       },
       "dependencies": {
         "babylon": {
@@ -2238,14 +2239,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -2310,8 +2311,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -2320,7 +2321,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-minify-builtins": {
@@ -2329,7 +2330,7 @@
       "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.2.0"
+        "babel-helper-evaluate-path": "0.2.0"
       }
     },
     "babel-plugin-minify-constant-folding": {
@@ -2338,7 +2339,7 @@
       "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.2.0"
+        "babel-helper-evaluate-path": "0.2.0"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
@@ -2347,10 +2348,10 @@
       "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.2.0",
-        "babel-helper-mark-eval-scopes": "^0.2.0",
-        "babel-helper-remove-or-void": "^0.2.0",
-        "lodash.some": "^4.6.0"
+        "babel-helper-evaluate-path": "0.2.0",
+        "babel-helper-mark-eval-scopes": "0.2.0",
+        "babel-helper-remove-or-void": "0.2.0",
+        "lodash.some": "4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
@@ -2359,7 +2360,7 @@
       "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "^0.2.0"
+        "babel-helper-is-void-0": "0.2.0"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
@@ -2368,7 +2369,7 @@
       "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "^0.2.0"
+        "babel-helper-flip-expressions": "0.2.0"
       }
     },
     "babel-plugin-minify-infinity": {
@@ -2383,7 +2384,7 @@
       "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "^0.2.0"
+        "babel-helper-mark-eval-scopes": "0.2.0"
       }
     },
     "babel-plugin-minify-numeric-literals": {
@@ -2404,9 +2405,9 @@
       "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "^0.2.0",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.2.0"
+        "babel-helper-flip-expressions": "0.2.0",
+        "babel-helper-is-nodes-equiv": "0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "0.2.0"
       }
     },
     "babel-plugin-minify-type-constructors": {
@@ -2415,7 +2416,7 @@
       "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "^0.2.0"
+        "babel-helper-is-void-0": "0.2.0"
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
@@ -2448,7 +2449,7 @@
       "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "babel-plugin-transform-regexp-constructors": {
@@ -2475,7 +2476,7 @@
       "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "^0.2.0"
+        "babel-helper-evaluate-path": "0.2.0"
       }
     },
     "babel-plugin-transform-simplify-comparison-operators": {
@@ -2496,9 +2497,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -2515,29 +2516,29 @@
       "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
       "dev": true,
       "requires": {
-        "babel-plugin-minify-builtins": "^0.2.0",
-        "babel-plugin-minify-constant-folding": "^0.2.0",
-        "babel-plugin-minify-dead-code-elimination": "^0.2.0",
-        "babel-plugin-minify-flip-comparisons": "^0.2.0",
-        "babel-plugin-minify-guarded-expressions": "^0.2.0",
-        "babel-plugin-minify-infinity": "^0.2.0",
-        "babel-plugin-minify-mangle-names": "^0.2.0",
-        "babel-plugin-minify-numeric-literals": "^0.2.0",
-        "babel-plugin-minify-replace": "^0.2.0",
-        "babel-plugin-minify-simplify": "^0.2.0",
-        "babel-plugin-minify-type-constructors": "^0.2.0",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.2.0",
-        "babel-plugin-transform-member-expression-literals": "^6.8.5",
-        "babel-plugin-transform-merge-sibling-variables": "^6.8.6",
-        "babel-plugin-transform-minify-booleans": "^6.8.3",
-        "babel-plugin-transform-property-literals": "^6.8.5",
-        "babel-plugin-transform-regexp-constructors": "^0.2.0",
-        "babel-plugin-transform-remove-console": "^6.8.5",
-        "babel-plugin-transform-remove-debugger": "^6.8.5",
-        "babel-plugin-transform-remove-undefined": "^0.2.0",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.8.5",
-        "babel-plugin-transform-undefined-to-void": "^6.8.3",
-        "lodash.isplainobject": "^4.0.6"
+        "babel-plugin-minify-builtins": "0.2.0",
+        "babel-plugin-minify-constant-folding": "0.2.0",
+        "babel-plugin-minify-dead-code-elimination": "0.2.0",
+        "babel-plugin-minify-flip-comparisons": "0.2.0",
+        "babel-plugin-minify-guarded-expressions": "0.2.0",
+        "babel-plugin-minify-infinity": "0.2.0",
+        "babel-plugin-minify-mangle-names": "0.2.0",
+        "babel-plugin-minify-numeric-literals": "0.2.0",
+        "babel-plugin-minify-replace": "0.2.0",
+        "babel-plugin-minify-simplify": "0.2.0",
+        "babel-plugin-minify-type-constructors": "0.2.0",
+        "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
+        "babel-plugin-transform-member-expression-literals": "6.9.4",
+        "babel-plugin-transform-merge-sibling-variables": "6.9.4",
+        "babel-plugin-transform-minify-booleans": "6.9.4",
+        "babel-plugin-transform-property-literals": "6.9.4",
+        "babel-plugin-transform-regexp-constructors": "0.2.0",
+        "babel-plugin-transform-remove-console": "6.9.4",
+        "babel-plugin-transform-remove-debugger": "6.9.4",
+        "babel-plugin-transform-remove-undefined": "0.2.0",
+        "babel-plugin-transform-simplify-comparison-operators": "6.9.4",
+        "babel-plugin-transform-undefined-to-void": "6.9.4",
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "babel-register": {
@@ -2546,13 +2547,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -2561,8 +2562,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -2571,11 +2572,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -2592,15 +2593,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -2632,10 +2633,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -2658,15 +2659,15 @@
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
-        "arr-filter": "^1.1.1",
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "array-each": "^1.0.0",
-        "array-initial": "^1.0.0",
-        "array-last": "^1.1.1",
-        "async-done": "^1.2.2",
-        "async-settle": "^1.0.0",
-        "now-and-later": "^2.0.0"
+        "arr-filter": "1.1.2",
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "array-each": "1.0.1",
+        "array-initial": "1.1.0",
+        "array-last": "1.3.0",
+        "async-done": "1.3.1",
+        "async-settle": "1.0.0",
+        "now-and-later": "2.0.0"
       }
     },
     "balanced-match": {
@@ -2681,13 +2682,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2696,7 +2697,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -2705,7 +2706,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2714,7 +2715,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2723,9 +2724,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2748,13 +2749,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2769,7 +2770,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "camelcase": {
@@ -2784,9 +2785,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2801,8 +2802,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -2811,7 +2812,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -2820,7 +2821,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2831,7 +2832,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2841,16 +2842,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2859,7 +2860,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2870,8 +2871,8 @@
       "integrity": "sha512-b+zF28HRpaKhdvLGqirkvn8XO+WEpLxAWg+dqa3OAoriVMS2UucVc1xis4Et9vMnQGLSipWks8bDeCeUvuZ0EQ==",
       "dev": true,
       "requires": {
-        "@types/ua-parser-js": "^0.7.31",
-        "ua-parser-js": "^0.7.15"
+        "@types/ua-parser-js": "0.7.32",
+        "ua-parser-js": "0.7.18"
       }
     },
     "browser-stdout": {
@@ -2887,9 +2888,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -2904,15 +2905,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "caller-path": {
@@ -2921,7 +2922,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -2936,8 +2937,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -2952,8 +2953,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2970,7 +2971,7 @@
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "dev": true,
       "requires": {
-        "@types/node": "^4.0.30"
+        "@types/node": "4.2.23"
       },
       "dependencies": {
         "@types/node": {
@@ -2993,9 +2994,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chalk": {
@@ -3004,11 +3005,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chardet": {
@@ -3023,19 +3024,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.4",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0",
+        "upath": "1.1.0"
       }
     },
     "ci-info": {
@@ -3056,10 +3057,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -3068,7 +3069,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -3079,7 +3080,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -3102,7 +3103,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -3118,9 +3119,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
     "cliui": {
@@ -3129,15 +3130,15 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-buffer": {
@@ -3158,9 +3159,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -3181,9 +3182,9 @@
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
-        "arr-map": "^2.0.2",
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "arr-map": "2.0.2",
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "collection-visit": {
@@ -3192,8 +3193,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -3229,11 +3230,11 @@
       "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "dev": true,
       "requires": {
-        "argv-tools": "^0.1.1",
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^2.6.1"
+        "argv-tools": "0.1.1",
+        "array-back": "2.0.0",
+        "find-replace": "2.0.1",
+        "lodash.camelcase": "4.3.0",
+        "typical": "2.6.1"
       }
     },
     "command-line-usage": {
@@ -3242,10 +3243,10 @@
       "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "chalk": "^2.4.1",
-        "table-layout": "^0.4.3",
-        "typical": "^2.6.1"
+        "array-back": "2.0.0",
+        "chalk": "2.4.1",
+        "table-layout": "0.4.4",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3254,7 +3255,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -3263,9 +3264,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -3274,7 +3275,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3303,10 +3304,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -3315,12 +3316,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "convert-source-map": {
@@ -3341,8 +3342,8 @@
       "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
       "dev": true,
       "requires": {
-        "each-props": "^1.3.0",
-        "is-plain-object": "^2.0.1"
+        "each-props": "1.3.2",
+        "is-plain-object": "2.0.4"
       }
     },
     "core-js": {
@@ -3363,7 +3364,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -3372,9 +3373,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -3389,11 +3390,11 @@
       "integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
       "dev": true,
       "requires": {
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^5.0.5",
-        "dom5": "^3.0.0",
-        "parse5": "^4.0.0",
-        "shady-css-parser": "^0.1.0"
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "dom5": "3.0.1",
+        "parse5": "4.0.0",
+        "shady-css-parser": "0.1.0"
       }
     },
     "cssbeautify": {
@@ -3408,7 +3409,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cycle": {
@@ -3423,7 +3424,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.45"
       }
     },
     "debug": {
@@ -3482,7 +3483,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^5.0.2"
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3505,8 +3506,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -3515,8 +3516,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3525,7 +3526,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3534,7 +3535,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3543,9 +3544,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -3556,12 +3557,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "delegate": {
@@ -3583,7 +3584,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "diff": {
@@ -3598,7 +3599,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-serializer": {
@@ -3607,8 +3608,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3625,7 +3626,7 @@
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true,
       "requires": {
-        "urijs": "^1.16.1"
+        "urijs": "1.19.1"
       }
     },
     "dom5": {
@@ -3634,9 +3635,9 @@
       "integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
       "dev": true,
       "requires": {
-        "@types/parse5": "^2.2.34",
-        "clone": "^2.1.0",
-        "parse5": "^4.0.0"
+        "@types/parse5": "2.2.34",
+        "clone": "2.1.2",
+        "parse5": "4.0.0"
       }
     },
     "domelementtype": {
@@ -3651,7 +3652,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -3660,8 +3661,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3670,7 +3671,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer": {
@@ -3685,7 +3686,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexer3": {
@@ -3700,10 +3701,10 @@
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "each-props": {
@@ -3712,8 +3713,8 @@
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
       "dev": true,
       "requires": {
-        "is-plain-object": "^2.0.1",
-        "object.defaults": "^1.1.0"
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "emitter-component": {
@@ -3728,7 +3729,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "entities": {
@@ -3743,7 +3744,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -3752,9 +3753,9 @@
       "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -3763,9 +3764,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-promise": {
@@ -3780,8 +3781,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45"
       }
     },
     "es6-weak-map": {
@@ -3790,10 +3791,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -3808,11 +3809,11 @@
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       }
     },
     "eslint": {
@@ -3821,44 +3822,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.3",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.7.0",
+        "ignore": "3.3.10",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
         "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3873,7 +3874,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -3882,9 +3883,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "strip-ansi": {
@@ -3893,7 +3894,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -3902,7 +3903,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3913,7 +3914,7 @@
       "integrity": "sha512-yULqYldzhYXTwZEaJXM30HhfgJdtTzuVH3LeoANybESHZ5+2ztLD72BsB2wR124/kk/PvQqZofDFSdNIk+kykw==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.8.2"
+        "htmlparser2": "3.9.2"
       }
     },
     "eslint-scope": {
@@ -3922,8 +3923,8 @@
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-visitor-keys": {
@@ -3932,14 +3933,20 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.0.74",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.74.tgz",
+      "integrity": "sha512-+eTnBYtB1TC2dDZ0HGSRz98hiT4vbF33/OUvnsTHSAcXwhtNLuZHUE3Vc0viRS+OFXXpRAKQBupBNKvd9YOyxw==",
+      "dev": true
+    },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.7.1",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -3954,7 +3961,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3963,7 +3970,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -3984,13 +3991,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -3999,13 +4006,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -4023,7 +4030,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -4032,7 +4039,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -4043,7 +4050,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -4052,11 +4059,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.1.0",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -4065,7 +4072,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -4083,7 +4090,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4094,7 +4101,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "extend": {
@@ -4109,8 +4116,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4119,7 +4126,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4130,9 +4137,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -4141,14 +4148,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -4157,7 +4164,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -4166,7 +4173,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -4175,7 +4182,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4184,7 +4191,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4193,9 +4200,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -4212,9 +4219,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -4241,7 +4248,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4250,8 +4257,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -4266,10 +4273,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4278,7 +4285,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -4289,8 +4296,8 @@
       "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "test-value": "^3.0.0"
+        "array-back": "2.0.0",
+        "test-value": "3.0.0"
       }
     },
     "find-up": {
@@ -4299,8 +4306,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -4309,10 +4316,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "is-glob": {
@@ -4321,7 +4328,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -4332,11 +4339,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -4357,10 +4364,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       },
       "dependencies": {
         "del": {
@@ -4369,13 +4376,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "globby": {
@@ -4384,12 +4391,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -4406,8 +4413,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "for-in": {
@@ -4422,7 +4429,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -4443,7 +4450,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "fragment-cache": {
@@ -4452,7 +4459,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -4461,9 +4468,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs-mkdirp-stream": {
@@ -4472,8 +4479,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
+        "graceful-fs": "4.1.11",
+        "through2": "2.0.3"
       }
     },
     "fs.realpath": {
@@ -4489,8 +4496,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4516,8 +4523,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -4530,7 +4537,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4594,7 +4601,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -4609,14 +4616,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -4625,12 +4632,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -4645,7 +4652,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -4654,7 +4661,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -4663,8 +4670,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -4683,7 +4690,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -4697,7 +4704,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -4710,8 +4717,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -4720,7 +4727,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -4743,9 +4750,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4754,16 +4761,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -4772,8 +4779,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -4788,8 +4795,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -4798,10 +4805,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -4820,7 +4827,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4841,8 +4848,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4863,10 +4870,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4883,13 +4890,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -4898,7 +4905,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4941,9 +4948,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4952,7 +4959,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -4960,7 +4967,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -4975,13 +4982,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -4996,7 +5003,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5053,12 +5060,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -5067,8 +5074,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -5077,7 +5084,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -5092,7 +5099,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -5103,8 +5110,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
         "is-glob": {
@@ -5113,7 +5120,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -5124,16 +5131,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
-        "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.2",
+        "glob": "7.1.2",
+        "glob-parent": "3.1.0",
+        "is-negated-glob": "1.0.0",
+        "ordered-read-streams": "1.0.1",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.6",
+        "remove-trailing-separator": "1.1.0",
+        "to-absolute-glob": "2.0.2",
+        "unique-stream": "2.2.1"
       }
     },
     "glob-watcher": {
@@ -5142,10 +5149,10 @@
       "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
       "dev": true,
       "requires": {
-        "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
-        "just-debounce": "^1.0.0",
-        "object.defaults": "^1.1.0"
+        "async-done": "1.3.1",
+        "chokidar": "2.0.4",
+        "just-debounce": "1.0.0",
+        "object.defaults": "1.1.0"
       }
     },
     "global-dirs": {
@@ -5154,7 +5161,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -5163,9 +5170,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -5174,11 +5181,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -5193,11 +5200,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -5214,7 +5221,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "good-listener": {
@@ -5224,7 +5231,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "google-closure-compiler": {
@@ -5233,9 +5240,9 @@
       "integrity": "sha1-sJf/t1DGXKB6LaRp12xVHTuOIaM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "vinyl": "^2.0.1",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "chalk": "1.1.3",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "got": {
@@ -5244,17 +5251,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -5281,10 +5288,10 @@
       "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
       "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.0",
-        "gulp-cli": "^2.0.0",
-        "undertaker": "^1.0.0",
-        "vinyl-fs": "^3.0.0"
+        "glob-watcher": "5.0.1",
+        "gulp-cli": "2.0.1",
+        "undertaker": "1.2.0",
+        "vinyl-fs": "3.0.3"
       },
       "dependencies": {
         "gulp-cli": {
@@ -5293,24 +5300,24 @@
           "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "archy": "^1.0.0",
-            "array-sort": "^1.0.0",
-            "color-support": "^1.1.3",
-            "concat-stream": "^1.6.0",
-            "copy-props": "^2.0.1",
-            "fancy-log": "^1.3.2",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
-            "isobject": "^3.0.1",
-            "liftoff": "^2.5.0",
-            "matchdep": "^2.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "replace-homedir": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
-            "yargs": "^7.1.0"
+            "ansi-colors": "1.1.0",
+            "archy": "1.0.0",
+            "array-sort": "1.0.0",
+            "color-support": "1.1.3",
+            "concat-stream": "1.6.2",
+            "copy-props": "2.0.4",
+            "fancy-log": "1.3.2",
+            "gulplog": "1.0.0",
+            "interpret": "1.1.0",
+            "isobject": "3.0.1",
+            "liftoff": "2.5.0",
+            "matchdep": "2.0.0",
+            "mute-stdout": "1.0.0",
+            "pretty-hrtime": "1.0.3",
+            "replace-homedir": "1.0.0",
+            "semver-greatest-satisfied-range": "1.1.0",
+            "v8flags": "3.1.1",
+            "yargs": "7.1.0"
           }
         }
       }
@@ -5321,12 +5328,12 @@
       "integrity": "sha512-tm15R3rt4gO59WXCuqrwf4QXJM9VIJC+0J2NPYSC6xZn+cZRD5y5RPGAiHaDxCJq7Rz5BDljlrk3cEjWADF+wQ==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.23.1",
-        "object-assign": "^4.0.1",
-        "plugin-error": "^1.0.1",
+        "babel-core": "6.26.3",
+        "object-assign": "4.1.1",
+        "plugin-error": "1.0.1",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "replace-ext": {
@@ -5343,9 +5350,9 @@
       "integrity": "sha512-fcFUQzFsN6dJ6KZlG+qPOEkqfcevRUXgztkYCvhNvJeSvOicC8ucutN4qR/ID8LmNZx9YPIkBzazTNnVvbh8wg==",
       "dev": true,
       "requires": {
-        "eslint": "^4.0.0",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.0"
+        "eslint": "4.19.1",
+        "fancy-log": "1.3.2",
+        "plugin-error": "1.0.1"
       }
     },
     "gulp-if": {
@@ -5354,9 +5361,9 @@
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
-        "gulp-match": "^1.0.3",
-        "ternary-stream": "^2.0.1",
-        "through2": "^2.0.1"
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-match": {
@@ -5365,7 +5372,7 @@
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.3"
+        "minimatch": "3.0.4"
       }
     },
     "gulp-replace": {
@@ -5375,8 +5382,8 @@
       "dev": true,
       "requires": {
         "istextorbinary": "1.0.2",
-        "readable-stream": "^2.0.1",
-        "replacestream": "^4.0.0"
+        "readable-stream": "2.3.6",
+        "replacestream": "4.0.3"
       }
     },
     "gulp-size": {
@@ -5385,13 +5392,13 @@
       "integrity": "sha1-yxrI5rqD3t5SQwxH/QOTJPAD/4I=",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "fancy-log": "^1.3.2",
-        "gzip-size": "^4.1.0",
-        "plugin-error": "^0.1.2",
-        "pretty-bytes": "^4.0.2",
-        "stream-counter": "^1.0.0",
-        "through2": "^2.0.0"
+        "chalk": "2.4.1",
+        "fancy-log": "1.3.2",
+        "gzip-size": "4.1.0",
+        "plugin-error": "0.1.2",
+        "pretty-bytes": "4.0.2",
+        "stream-counter": "1.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5400,7 +5407,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "arr-diff": {
@@ -5409,8 +5416,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -5431,9 +5438,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "extend-shallow": {
@@ -5442,7 +5449,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -5457,11 +5464,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         },
         "supports-color": {
@@ -5470,7 +5477,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -5481,11 +5488,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "clone": {
@@ -5512,8 +5519,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -5525,10 +5532,10 @@
       "integrity": "sha512-SnyChu0+DbCK7QWN0UStPKEG8igkv0feLfx25jLAbrEULTHmvUPhx1BF3vYz6SsA32Azxp5UoU6jNI4Q8PzBPQ==",
       "dev": true,
       "requires": {
-        "plugin-error": "^0.1.2",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.0",
-        "vulcanize": "^1.9.1"
+        "plugin-error": "0.1.2",
+        "safe-buffer": "5.1.2",
+        "through2": "2.0.3",
+        "vulcanize": "1.16.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -5537,8 +5544,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -5559,7 +5566,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -5574,11 +5581,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         }
       }
@@ -5589,7 +5596,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "gzip-size": {
@@ -5598,8 +5605,8 @@
       "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
       "dev": true,
       "requires": {
-        "duplexer": "^0.1.1",
-        "pify": "^3.0.0"
+        "duplexer": "0.1.1",
+        "pify": "3.0.0"
       }
     },
     "has-ansi": {
@@ -5608,7 +5615,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -5629,9 +5636,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -5640,8 +5647,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5650,7 +5657,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5667,8 +5674,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -5677,7 +5684,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -5692,13 +5699,13 @@
       "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.1.x",
-        "commander": "2.16.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.16.0",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.4.7"
       }
     },
     "htmlparser2": {
@@ -5707,12 +5714,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "hydrolysis": {
@@ -5721,14 +5728,14 @@
       "integrity": "sha1-pPsUo3oeA7DbUtiqpXxoInKhTYQ=",
       "dev": true,
       "requires": {
-        "acorn": "^3.2.0",
-        "babel-polyfill": "^6.2.0",
-        "doctrine": "^0.7.0",
+        "acorn": "3.3.0",
+        "babel-polyfill": "6.26.0",
+        "doctrine": "0.7.2",
         "dom5": "1.1.0",
-        "escodegen": "^1.7.0",
-        "espree": "^3.1.3",
-        "estraverse": "^3.1.0",
-        "path-is-absolute": "^1.0.0"
+        "escodegen": "1.11.0",
+        "espree": "3.5.4",
+        "estraverse": "3.1.0",
+        "path-is-absolute": "1.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -5743,7 +5750,7 @@
           "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
           "dev": true,
           "requires": {
-            "esutils": "^1.1.6",
+            "esutils": "1.1.6",
             "isarray": "0.0.1"
           }
         },
@@ -5753,7 +5760,7 @@
           "integrity": "sha1-Ogx3AMCDq0xNJpOKeLDwxtzDd5Q=",
           "dev": true,
           "requires": {
-            "parse5": "^1.4.1"
+            "parse5": "1.5.1"
           }
         },
         "estraverse": {
@@ -5788,7 +5795,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -5821,7 +5828,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -5830,8 +5837,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -5852,20 +5859,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5880,7 +5887,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -5889,9 +5896,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5906,8 +5913,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -5916,7 +5923,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -5925,7 +5932,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -5942,7 +5949,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -5957,8 +5964,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -5967,7 +5974,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5976,7 +5983,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5993,7 +6000,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -6008,7 +6015,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -6017,7 +6024,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -6026,7 +6033,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6035,7 +6042,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6046,9 +6053,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6071,7 +6078,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -6092,7 +6099,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -6101,7 +6108,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -6110,7 +6117,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-installed-globally": {
@@ -6119,8 +6126,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-negated-glob": {
@@ -6141,7 +6148,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6150,7 +6157,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6173,7 +6180,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -6182,7 +6189,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -6191,7 +6198,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -6224,7 +6231,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -6251,7 +6258,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -6302,8 +6309,8 @@
       "integrity": "sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=",
       "dev": true,
       "requires": {
-        "binaryextensions": "~1.0.0",
-        "textextensions": "~1.0.0"
+        "binaryextensions": "1.0.1",
+        "textextensions": "1.0.2"
       }
     },
     "js-tokens": {
@@ -6318,8 +6325,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       },
       "dependencies": {
         "esprima": {
@@ -6348,7 +6355,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -6375,7 +6382,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -6408,8 +6415,8 @@
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
-        "default-resolution": "^2.0.0",
-        "es6-weak-map": "^2.0.1"
+        "default-resolution": "2.0.0",
+        "es6-weak-map": "2.0.2"
       }
     },
     "latest-version": {
@@ -6418,7 +6425,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazypipe": {
@@ -6427,7 +6434,7 @@
       "integrity": "sha1-FHGu9rN6NA1Rw030Rpnc7wZMGUA=",
       "dev": true,
       "requires": {
-        "stream-combiner": "*"
+        "stream-combiner": "0.2.2"
       }
     },
     "lazystream": {
@@ -6436,7 +6443,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcid": {
@@ -6445,7 +6452,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lead": {
@@ -6454,7 +6461,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "^1.0.2"
+        "flush-write-stream": "1.0.3"
       }
     },
     "levn": {
@@ -6463,8 +6470,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -6473,14 +6480,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.2",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.8.1"
       }
     },
     "load-json-file": {
@@ -6489,11 +6496,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6516,8 +6523,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basecopy": {
@@ -6562,9 +6569,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
       }
     },
     "lodash.debounce": {
@@ -6609,9 +6616,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.padend": {
@@ -6638,8 +6645,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -6648,7 +6655,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lolex": {
@@ -6663,7 +6670,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -6672,8 +6679,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -6694,8 +6701,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "magic-string": {
@@ -6704,7 +6711,7 @@
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "make-dir": {
@@ -6713,7 +6720,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-iterator": {
@@ -6722,7 +6729,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       }
     },
     "map-cache": {
@@ -6743,7 +6750,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "marked": {
@@ -6758,9 +6765,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "^2.0.0",
-        "micromatch": "^3.0.4",
-        "resolve": "^1.4.0",
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.10",
+        "resolve": "1.8.1",
         "stack-trace": "0.0.10"
       }
     },
@@ -6770,7 +6777,7 @@
       "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "math-random": {
@@ -6785,16 +6792,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -6811,7 +6818,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "micromatch": {
@@ -6820,19 +6827,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mimic-fn": {
@@ -6847,7 +6854,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimatch-all": {
@@ -6856,7 +6863,7 @@
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "3.0.4"
       }
     },
     "minimist": {
@@ -6871,8 +6878,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6881,7 +6888,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6921,7 +6928,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         },
         "debug": {
@@ -6939,12 +6946,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -6959,7 +6966,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6976,8 +6983,8 @@
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "dev": true,
       "requires": {
-        "duplexer2": "^0.1.2",
-        "object-assign": "^4.1.0"
+        "duplexer2": "0.1.4",
+        "object-assign": "4.1.1"
       }
     },
     "mute-stdout": {
@@ -6998,9 +7005,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nan": {
@@ -7016,17 +7023,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natural-compare": {
@@ -7047,7 +7054,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "nopt": {
@@ -7056,7 +7063,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -7065,10 +7072,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -7077,7 +7084,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "now-and-later": {
@@ -7086,7 +7093,7 @@
       "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
       "dev": true,
       "requires": {
-        "once": "^1.3.2"
+        "once": "1.4.0"
       }
     },
     "npm-run-path": {
@@ -7095,7 +7102,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -7116,9 +7123,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -7127,7 +7134,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -7136,7 +7143,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7153,7 +7160,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -7162,10 +7169,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       }
     },
     "object.defaults": {
@@ -7174,10 +7181,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "object.map": {
@@ -7186,8 +7193,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "object.omit": {
@@ -7196,8 +7203,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       },
       "dependencies": {
         "for-own": {
@@ -7206,7 +7213,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -7217,7 +7224,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "object.reduce": {
@@ -7226,8 +7233,8 @@
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       }
     },
     "once": {
@@ -7236,7 +7243,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -7245,7 +7252,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -7254,12 +7261,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ordered-read-streams": {
@@ -7268,7 +7275,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "os-homedir": {
@@ -7283,7 +7290,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -7310,10 +7317,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "param-case": {
@@ -7322,7 +7329,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-filepath": {
@@ -7331,9 +7338,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -7342,10 +7349,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -7360,7 +7367,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -7371,7 +7378,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-passwd": {
@@ -7404,7 +7411,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -7426,9 +7433,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-posix": {
@@ -7443,7 +7450,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -7475,9 +7482,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -7506,7 +7513,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plugin-error": {
@@ -7515,10 +7522,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
       }
     },
     "pluralize": {
@@ -7533,9 +7540,9 @@
       "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
       "dev": true,
       "requires": {
-        "@types/node": "^4.2.3",
-        "@types/winston": "^2.2.0",
-        "winston": "^2.2.0"
+        "@types/node": "4.2.23",
+        "@types/winston": "2.3.9",
+        "winston": "2.4.3"
       },
       "dependencies": {
         "@types/node": {
@@ -7552,29 +7559,29 @@
       "integrity": "sha512-yD5FYQ8thX/2vHTaEgTtCs/NSG3ko4VlEb0IjM/PFsu03lHNHnpadC1NGwKyvI9vOjcFhnw4mDEVW0lbxLo8Eg==",
       "dev": true,
       "requires": {
-        "@types/chai-subset": "^1.3.0",
-        "@types/chalk": "^0.4.30",
-        "@types/clone": "^0.1.30",
-        "@types/cssbeautify": "^0.3.1",
-        "@types/doctrine": "^0.0.1",
-        "@types/escodegen": "^0.0.2",
-        "@types/estraverse": "^0.0.6",
-        "@types/estree": "^0.0.37",
-        "@types/node": "^6.0.0",
-        "@types/parse5": "^2.2.34",
-        "chalk": "^1.1.3",
-        "clone": "^2.0.0",
-        "cssbeautify": "^0.3.1",
-        "doctrine": "^2.0.0",
-        "dom5": "^2.1.0",
-        "escodegen": "^1.7.0",
-        "espree": "^3.1.7",
-        "estraverse": "^4.2.0",
-        "jsonschema": "^1.1.0",
-        "parse5": "^2.2.1",
-        "shady-css-parser": "^0.1.0",
-        "stable": "^0.1.6",
-        "strip-indent": "^2.0.0"
+        "@types/chai-subset": "1.3.1",
+        "@types/chalk": "0.4.31",
+        "@types/clone": "0.1.30",
+        "@types/cssbeautify": "0.3.1",
+        "@types/doctrine": "0.0.1",
+        "@types/escodegen": "0.0.2",
+        "@types/estraverse": "0.0.6",
+        "@types/estree": "0.0.37",
+        "@types/node": "6.0.116",
+        "@types/parse5": "2.2.34",
+        "chalk": "1.1.3",
+        "clone": "2.1.2",
+        "cssbeautify": "0.3.1",
+        "doctrine": "2.1.0",
+        "dom5": "2.3.0",
+        "escodegen": "1.11.0",
+        "espree": "3.5.4",
+        "estraverse": "4.2.0",
+        "jsonschema": "1.2.4",
+        "parse5": "2.2.3",
+        "shady-css-parser": "0.1.0",
+        "stable": "0.1.8",
+        "strip-indent": "2.0.0"
       },
       "dependencies": {
         "dom5": {
@@ -7583,11 +7590,11 @@
           "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
           "dev": true,
           "requires": {
-            "@types/clone": "^0.1.29",
-            "@types/node": "^6.0.0",
-            "@types/parse5": "^2.2.32",
-            "clone": "^2.1.0",
-            "parse5": "^2.2.2"
+            "@types/clone": "0.1.30",
+            "@types/node": "6.0.116",
+            "@types/parse5": "2.2.34",
+            "clone": "2.1.2",
+            "parse5": "2.2.3"
           }
         },
         "parse5": {
@@ -7604,78 +7611,78 @@
       "integrity": "sha512-YSppvctpcO2do3XHXNo2WnD4mxpzTpjgLlByPXE0Jfz9N+Ez6EGmge7Xwd6NsFH9ch6IMyV1P9H238I/C/KZRw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0-beta.46",
-        "@babel/plugin-external-helpers": "^7.0.0-beta.46",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.46",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-async-generators": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-import-meta": "^7.0.0-beta.46",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0-beta.46",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-beta.46",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoped-functions": "^7.0.0-beta.46",
-        "@babel/plugin-transform-block-scoping": "^7.0.0-beta.46",
-        "@babel/plugin-transform-classes": "=7.0.0-beta.35",
-        "@babel/plugin-transform-computed-properties": "^7.0.0-beta.46",
-        "@babel/plugin-transform-destructuring": "^7.0.0-beta.46",
-        "@babel/plugin-transform-duplicate-keys": "^7.0.0-beta.46",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-for-of": "^7.0.0-beta.46",
-        "@babel/plugin-transform-function-name": "^7.0.0-beta.46",
-        "@babel/plugin-transform-instanceof": "^7.0.0-beta.46",
-        "@babel/plugin-transform-literals": "^7.0.0-beta.46",
-        "@babel/plugin-transform-modules-amd": "^7.0.0-beta.46",
-        "@babel/plugin-transform-object-super": "^7.0.0-beta.46",
-        "@babel/plugin-transform-parameters": "^7.0.0-beta.46",
-        "@babel/plugin-transform-regenerator": "^7.0.0-beta.46",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-beta.46",
-        "@babel/plugin-transform-spread": "^7.0.0-beta.46",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0-beta.46",
-        "@babel/plugin-transform-template-literals": "^7.0.0-beta.46",
-        "@babel/plugin-transform-typeof-symbol": "^7.0.0-beta.46",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-beta.46",
-        "@babel/traverse": "^7.0.0-beta.46",
-        "@polymer/esm-amd-loader": "^1.0.0",
-        "@types/babel-types": "^6.25.1",
-        "@types/babylon": "^6.16.2",
+        "@babel/core": "7.0.0-rc.1",
+        "@babel/plugin-external-helpers": "7.0.0-rc.1",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.1",
+        "@babel/plugin-syntax-dynamic-import": "7.0.0-rc.1",
+        "@babel/plugin-syntax-import-meta": "7.0.0-rc.1",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-rc.1",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-rc.1",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.1",
+        "@babel/plugin-transform-block-scoping": "7.0.0-rc.1",
+        "@babel/plugin-transform-classes": "7.0.0-beta.35",
+        "@babel/plugin-transform-computed-properties": "7.0.0-rc.1",
+        "@babel/plugin-transform-destructuring": "7.0.0-rc.1",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-rc.1",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.1",
+        "@babel/plugin-transform-for-of": "7.0.0-rc.1",
+        "@babel/plugin-transform-function-name": "7.0.0-rc.1",
+        "@babel/plugin-transform-instanceof": "7.0.0-rc.1",
+        "@babel/plugin-transform-literals": "7.0.0-rc.1",
+        "@babel/plugin-transform-modules-amd": "7.0.0-rc.1",
+        "@babel/plugin-transform-object-super": "7.0.0-rc.1",
+        "@babel/plugin-transform-parameters": "7.0.0-rc.1",
+        "@babel/plugin-transform-regenerator": "7.0.0-rc.1",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-rc.1",
+        "@babel/plugin-transform-spread": "7.0.0-rc.1",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-rc.1",
+        "@babel/plugin-transform-template-literals": "7.0.0-rc.1",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-rc.1",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@polymer/esm-amd-loader": "1.0.2",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.3",
         "@types/gulp-if": "0.0.33",
-        "@types/html-minifier": "^3.5.1",
-        "@types/is-windows": "^0.2.0",
+        "@types/html-minifier": "3.5.2",
+        "@types/is-windows": "0.2.0",
         "@types/mz": "0.0.31",
-        "@types/node": "^9.6.4",
-        "@types/parse5": "^2.2.34",
+        "@types/node": "9.6.26",
+        "@types/parse5": "2.2.34",
         "@types/resolve": "0.0.7",
-        "@types/uuid": "^3.4.3",
-        "@types/vinyl": "^2.0.0",
-        "@types/vinyl-fs": "^2.4.8",
-        "babel-plugin-minify-guarded-expressions": "=0.4.1",
-        "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
-        "babylon": "^7.0.0-beta.42",
-        "css-slam": "^2.1.2",
-        "dom5": "^3.0.0",
-        "gulp-if": "^2.0.2",
-        "html-minifier": "^3.5.10",
-        "matcher": "^1.1.0",
-        "multipipe": "^1.0.2",
-        "mz": "^2.6.0",
-        "parse5": "^4.0.0",
-        "plylog": "^0.5.0",
-        "polymer-analyzer": "^3.0.0",
-        "polymer-bundler": "^4.0.0",
-        "polymer-project-config": "^4.0.0",
-        "regenerator-runtime": "^0.11.1",
+        "@types/uuid": "3.4.3",
+        "@types/vinyl": "2.0.2",
+        "@types/vinyl-fs": "2.4.9",
+        "babel-plugin-minify-guarded-expressions": "0.4.1",
+        "babel-preset-minify": "0.4.0-alpha.caaefb4c",
+        "babylon": "7.0.0-beta.47",
+        "css-slam": "2.1.2",
+        "dom5": "3.0.1",
+        "gulp-if": "2.0.2",
+        "html-minifier": "3.5.19",
+        "matcher": "1.1.1",
+        "multipipe": "1.0.2",
+        "mz": "2.7.0",
+        "parse5": "4.0.0",
+        "plylog": "0.5.0",
+        "polymer-analyzer": "3.1.0",
+        "polymer-bundler": "4.0.2",
+        "polymer-project-config": "4.0.2",
+        "regenerator-runtime": "0.11.1",
         "stream": "0.0.2",
-        "sw-precache": "^5.1.1",
-        "uuid": "^3.2.1",
-        "vinyl": "^1.2.0",
-        "vinyl-fs": "^2.4.4"
+        "sw-precache": "5.2.1",
+        "uuid": "3.3.2",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz",
-          "integrity": "sha512-o5K0mt8x735EaqS7F2x+5AG0b1Mt3V9jgV5SeW8SD6RNhE++dvwqLf2R2e4c8FmhNLaogz2oXrsiXnqnsBSSIQ==",
+          "version": "9.6.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.26.tgz",
+          "integrity": "sha512-3LKKscYUZdZreOuvnly8oWsCA1TOWtmkV3mbcUnV34f+nqDWJic+4SGjRi1C/sPHnZcSs/x209O+Dgy8aWHt2A==",
           "dev": true
         },
         "@types/resolve": {
@@ -7684,7 +7691,7 @@
           "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "9.6.26"
           }
         },
         "arr-diff": {
@@ -7693,7 +7700,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -7744,7 +7751,7 @@
           "integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-minify-constant-folding": {
@@ -7753,7 +7760,7 @@
           "integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-minify-dead-code-elimination": {
@@ -7762,10 +7769,10 @@
           "integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3",
-            "babel-helper-mark-eval-scopes": "^0.4.3",
-            "babel-helper-remove-or-void": "^0.4.3",
-            "lodash.some": "^4.6.0"
+            "babel-helper-evaluate-path": "0.4.3",
+            "babel-helper-mark-eval-scopes": "0.4.3",
+            "babel-helper-remove-or-void": "0.4.3",
+            "lodash.some": "4.6.0"
           }
         },
         "babel-plugin-minify-flip-comparisons": {
@@ -7774,7 +7781,7 @@
           "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
           "dev": true,
           "requires": {
-            "babel-helper-is-void-0": "^0.4.3"
+            "babel-helper-is-void-0": "0.4.3"
           }
         },
         "babel-plugin-minify-guarded-expressions": {
@@ -7783,7 +7790,7 @@
           "integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
           "dev": true,
           "requires": {
-            "babel-helper-flip-expressions": "^0.4.1"
+            "babel-helper-flip-expressions": "0.4.3"
           }
         },
         "babel-plugin-minify-infinity": {
@@ -7798,7 +7805,7 @@
           "integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
           "dev": true,
           "requires": {
-            "babel-helper-mark-eval-scopes": "^0.4.3"
+            "babel-helper-mark-eval-scopes": "0.4.3"
           }
         },
         "babel-plugin-minify-numeric-literals": {
@@ -7819,9 +7826,9 @@
           "integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
           "dev": true,
           "requires": {
-            "babel-helper-flip-expressions": "^0.4.3",
-            "babel-helper-is-nodes-equiv": "^0.0.1",
-            "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+            "babel-helper-flip-expressions": "0.4.3",
+            "babel-helper-is-nodes-equiv": "0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "0.4.3"
           }
         },
         "babel-plugin-minify-type-constructors": {
@@ -7830,7 +7837,7 @@
           "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
           "dev": true,
           "requires": {
-            "babel-helper-is-void-0": "^0.4.3"
+            "babel-helper-is-void-0": "0.4.3"
           }
         },
         "babel-plugin-transform-inline-consecutive-adds": {
@@ -7863,7 +7870,7 @@
           "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         },
         "babel-plugin-transform-regexp-constructors": {
@@ -7890,7 +7897,7 @@
           "integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-transform-simplify-comparison-operators": {
@@ -7911,29 +7918,29 @@
           "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
           "dev": true,
           "requires": {
-            "babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
-            "lodash.isplainobject": "^4.0.6"
+            "babel-plugin-minify-builtins": "0.4.3",
+            "babel-plugin-minify-constant-folding": "0.4.3",
+            "babel-plugin-minify-dead-code-elimination": "0.4.3",
+            "babel-plugin-minify-flip-comparisons": "0.4.3",
+            "babel-plugin-minify-guarded-expressions": "0.4.1",
+            "babel-plugin-minify-infinity": "0.4.3",
+            "babel-plugin-minify-mangle-names": "0.4.3",
+            "babel-plugin-minify-numeric-literals": "0.4.3",
+            "babel-plugin-minify-replace": "0.4.3",
+            "babel-plugin-minify-simplify": "0.4.3",
+            "babel-plugin-minify-type-constructors": "0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "0.4.3",
+            "babel-plugin-transform-member-expression-literals": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-merge-sibling-variables": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-minify-booleans": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-property-literals": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-regexp-constructors": "0.4.3",
+            "babel-plugin-transform-remove-console": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-remove-debugger": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-remove-undefined": "0.4.3",
+            "babel-plugin-transform-simplify-comparison-operators": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-undefined-to-void": "6.10.0-alpha.f95869d4",
+            "lodash.isplainobject": "4.0.6"
           }
         },
         "braces": {
@@ -7942,9 +7949,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "clone-stats": {
@@ -7959,7 +7966,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extend-shallow": {
@@ -7968,7 +7975,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "extglob": {
@@ -7977,7 +7984,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "glob": {
@@ -7986,11 +7993,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-stream": {
@@ -7999,14 +8006,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.2",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -8015,10 +8022,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "through2": {
@@ -8027,8 +8034,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -8045,7 +8052,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-valid-glob": {
@@ -8066,7 +8073,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8075,19 +8082,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "ordered-read-streams": {
@@ -8096,8 +8103,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.6"
           }
         },
         "polymer-analyzer": {
@@ -8106,44 +8113,44 @@
           "integrity": "sha512-TW+SE+dofxSU6+7vJeH//Znjtu1brYE+J4w6M8W+BwoC3FHtBonxp4zCQFf+RnhQGcKIrfHVAxgujzccXer19Q==",
           "dev": true,
           "requires": {
-            "@babel/generator": "^7.0.0-beta.42",
-            "@babel/traverse": "^7.0.0-beta.42",
-            "@babel/types": "^7.0.0-beta.42",
-            "@types/babel-generator": "^6.25.1",
-            "@types/babel-traverse": "^6.25.2",
-            "@types/babel-types": "^6.25.1",
-            "@types/babylon": "^6.16.2",
-            "@types/chai-subset": "^1.3.0",
-            "@types/chalk": "^0.4.30",
-            "@types/clone": "^0.1.30",
-            "@types/cssbeautify": "^0.3.1",
-            "@types/doctrine": "^0.0.1",
-            "@types/is-windows": "^0.2.0",
-            "@types/minimatch": "^3.0.1",
-            "@types/node": "^9.6.4",
-            "@types/parse5": "^2.2.34",
-            "@types/path-is-inside": "^1.0.0",
+            "@babel/generator": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
+            "@types/chai-subset": "1.3.1",
+            "@types/chalk": "0.4.31",
+            "@types/clone": "0.1.30",
+            "@types/cssbeautify": "0.3.1",
+            "@types/doctrine": "0.0.1",
+            "@types/is-windows": "0.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/node": "9.6.26",
+            "@types/parse5": "2.2.34",
+            "@types/path-is-inside": "1.0.0",
             "@types/resolve": "0.0.6",
-            "@types/whatwg-url": "^6.4.0",
-            "babylon": "^7.0.0-beta.42",
-            "cancel-token": "^0.1.1",
-            "chalk": "^1.1.3",
-            "clone": "^2.0.0",
-            "cssbeautify": "^0.3.1",
-            "doctrine": "^2.0.2",
-            "dom5": "^3.0.0",
+            "@types/whatwg-url": "6.4.0",
+            "babylon": "7.0.0-beta.47",
+            "cancel-token": "0.1.1",
+            "chalk": "1.1.3",
+            "clone": "2.1.2",
+            "cssbeautify": "0.3.1",
+            "doctrine": "2.1.0",
+            "dom5": "3.0.1",
             "indent": "0.0.2",
-            "is-windows": "^1.0.2",
-            "jsonschema": "^1.1.0",
-            "minimatch": "^3.0.4",
-            "parse5": "^4.0.0",
-            "path-is-inside": "^1.0.2",
-            "resolve": "^1.5.0",
-            "shady-css-parser": "^0.1.0",
-            "stable": "^0.1.6",
-            "strip-indent": "^2.0.0",
-            "vscode-uri": "^1.0.1",
-            "whatwg-url": "^6.4.0"
+            "is-windows": "1.0.2",
+            "jsonschema": "1.2.4",
+            "minimatch": "3.0.4",
+            "parse5": "4.0.0",
+            "path-is-inside": "1.0.2",
+            "resolve": "1.8.1",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.5",
+            "whatwg-url": "6.5.0"
           },
           "dependencies": {
             "@types/resolve": {
@@ -8152,7 +8159,7 @@
               "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
               "dev": true,
               "requires": {
-                "@types/node": "*"
+                "@types/node": "9.6.26"
               }
             }
           }
@@ -8175,7 +8182,7 @@
           "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1"
+            "extend-shallow": "2.0.1"
           }
         },
         "vinyl": {
@@ -8184,8 +8191,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           },
           "dependencies": {
@@ -8203,23 +8210,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.6.0",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.6",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -8230,31 +8237,31 @@
       "integrity": "sha512-eH+MNSVb/bCqchxYE1gVtdLP9eq1pLsr9NdcHhiJGEgSoZOYq7lGm2M/L7DHGJqa1/OqC7ZC9Sz3eQKAB8FaJQ==",
       "dev": true,
       "requires": {
-        "@types/acorn": "^4.0.3",
-        "@types/babel-generator": "^6.25.1",
-        "@types/babel-traverse": "^6.25.3",
-        "acorn-import-meta": "^0.2.1",
-        "babel-generator": "^6.26.1",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "clone": "^2.1.0",
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^5.0.5",
-        "dom5": "^3.0.0",
-        "espree": "^3.5.2",
-        "magic-string": "^0.22.4",
-        "mkdirp": "^0.5.1",
-        "parse5": "^4.0.0",
-        "polymer-analyzer": "^3.0.1",
-        "rollup": "^0.58.2",
-        "source-map": "^0.5.6",
-        "vscode-uri": "^1.0.1"
+        "@types/acorn": "4.0.3",
+        "@types/babel-generator": "6.25.2",
+        "@types/babel-traverse": "6.25.4",
+        "acorn-import-meta": "0.2.1",
+        "babel-generator": "6.26.1",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "clone": "2.1.2",
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "dom5": "3.0.1",
+        "espree": "3.5.4",
+        "magic-string": "0.22.5",
+        "mkdirp": "0.5.1",
+        "parse5": "4.0.0",
+        "polymer-analyzer": "3.1.0",
+        "rollup": "0.58.2",
+        "source-map": "0.5.7",
+        "vscode-uri": "1.0.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz",
-          "integrity": "sha512-o5K0mt8x735EaqS7F2x+5AG0b1Mt3V9jgV5SeW8SD6RNhE++dvwqLf2R2e4c8FmhNLaogz2oXrsiXnqnsBSSIQ==",
+          "version": "9.6.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.26.tgz",
+          "integrity": "sha512-3LKKscYUZdZreOuvnly8oWsCA1TOWtmkV3mbcUnV34f+nqDWJic+4SGjRi1C/sPHnZcSs/x209O+Dgy8aWHt2A==",
           "dev": true
         },
         "polymer-analyzer": {
@@ -8263,44 +8270,44 @@
           "integrity": "sha512-TW+SE+dofxSU6+7vJeH//Znjtu1brYE+J4w6M8W+BwoC3FHtBonxp4zCQFf+RnhQGcKIrfHVAxgujzccXer19Q==",
           "dev": true,
           "requires": {
-            "@babel/generator": "^7.0.0-beta.42",
-            "@babel/traverse": "^7.0.0-beta.42",
-            "@babel/types": "^7.0.0-beta.42",
-            "@types/babel-generator": "^6.25.1",
-            "@types/babel-traverse": "^6.25.2",
-            "@types/babel-types": "^6.25.1",
-            "@types/babylon": "^6.16.2",
-            "@types/chai-subset": "^1.3.0",
-            "@types/chalk": "^0.4.30",
-            "@types/clone": "^0.1.30",
-            "@types/cssbeautify": "^0.3.1",
-            "@types/doctrine": "^0.0.1",
-            "@types/is-windows": "^0.2.0",
-            "@types/minimatch": "^3.0.1",
-            "@types/node": "^9.6.4",
-            "@types/parse5": "^2.2.34",
-            "@types/path-is-inside": "^1.0.0",
+            "@babel/generator": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
+            "@types/chai-subset": "1.3.1",
+            "@types/chalk": "0.4.31",
+            "@types/clone": "0.1.30",
+            "@types/cssbeautify": "0.3.1",
+            "@types/doctrine": "0.0.1",
+            "@types/is-windows": "0.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/node": "9.6.26",
+            "@types/parse5": "2.2.34",
+            "@types/path-is-inside": "1.0.0",
             "@types/resolve": "0.0.6",
-            "@types/whatwg-url": "^6.4.0",
-            "babylon": "^7.0.0-beta.42",
-            "cancel-token": "^0.1.1",
-            "chalk": "^1.1.3",
-            "clone": "^2.0.0",
-            "cssbeautify": "^0.3.1",
-            "doctrine": "^2.0.2",
-            "dom5": "^3.0.0",
+            "@types/whatwg-url": "6.4.0",
+            "babylon": "7.0.0-beta.47",
+            "cancel-token": "0.1.1",
+            "chalk": "1.1.3",
+            "clone": "2.1.2",
+            "cssbeautify": "0.3.1",
+            "doctrine": "2.1.0",
+            "dom5": "3.0.1",
             "indent": "0.0.2",
-            "is-windows": "^1.0.2",
-            "jsonschema": "^1.1.0",
-            "minimatch": "^3.0.4",
-            "parse5": "^4.0.0",
-            "path-is-inside": "^1.0.2",
-            "resolve": "^1.5.0",
-            "shady-css-parser": "^0.1.0",
-            "stable": "^0.1.6",
-            "strip-indent": "^2.0.0",
-            "vscode-uri": "^1.0.1",
-            "whatwg-url": "^6.4.0"
+            "is-windows": "1.0.2",
+            "jsonschema": "1.2.4",
+            "minimatch": "3.0.4",
+            "parse5": "4.0.0",
+            "path-is-inside": "1.0.2",
+            "resolve": "1.8.1",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.5",
+            "whatwg-url": "6.5.0"
           }
         },
         "source-map": {
@@ -8317,57 +8324,57 @@
       "integrity": "sha512-Bn4CXlTIWZNTCjvy6vJZlq0IyFQ/a4gi0Me3x3LDkM2anwks/NWELWsEfp9ZEUZJ4rJ9+VJO1QGEM11XBweo6w==",
       "dev": true,
       "requires": {
-        "@types/chalk": "^0.4.31",
-        "@types/del": "^3.0.0",
-        "@types/findup-sync": "^0.3.29",
-        "@types/globby": "^6.1.0",
+        "@types/chalk": "0.4.31",
+        "@types/del": "3.0.1",
+        "@types/findup-sync": "0.3.29",
+        "@types/globby": "6.1.0",
         "@types/inquirer": "0.0.32",
-        "@types/merge-stream": "^1.0.28",
-        "@types/mz": "^0.0.31",
+        "@types/merge-stream": "1.1.1",
+        "@types/mz": "0.0.31",
         "@types/request": "2.0.3",
         "@types/resolve": "0.0.4",
-        "@types/rimraf": "^0.0.28",
-        "@types/semver": "^5.3.30",
-        "@types/temp": "^0.8.28",
-        "@types/update-notifier": "^1.0.0",
-        "@types/vinyl": "^2.0.0",
+        "@types/rimraf": "0.0.28",
+        "@types/semver": "5.5.0",
+        "@types/temp": "0.8.32",
+        "@types/update-notifier": "1.0.3",
+        "@types/vinyl": "2.0.2",
         "@types/vinyl-fs": "0.0.28",
-        "@types/yeoman-generator": "^2.0.3",
+        "@types/yeoman-generator": "2.0.3",
         "bower": "1.8.2",
-        "bower-json": "^0.8.1",
-        "bower-logger": "^0.2.2",
-        "chalk": "^1.1.3",
-        "chokidar": "^1.7.0",
-        "command-line-args": "^5.0.2",
-        "command-line-commands": "^2.0.1",
-        "command-line-usage": "^5.0.5",
-        "del": "^3.0.0",
-        "findup-sync": "^0.4.2",
-        "github": "^7.2.1",
-        "globby": "^8.0.1",
-        "gunzip-maybe": "^1.3.1",
-        "inquirer": "^1.0.2",
-        "merge-stream": "^1.0.1",
-        "mz": "^2.6.0",
-        "plylog": "^0.5.0",
-        "polymer-analyzer": "^3.0.1",
-        "polymer-build": "^3.0.3",
-        "polymer-bundler": "^4.0.1",
-        "polymer-linter": "^3.0.0",
-        "polymer-project-config": "^4.0.1",
-        "polyserve": "^0.27.11",
-        "request": "^2.72.0",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar-fs": "^1.12.0",
-        "temp": "^0.8.3",
-        "update-notifier": "^1.0.0",
-        "validate-element-name": "^2.1.1",
-        "vinyl": "^1.1.1",
-        "vinyl-fs": "^2.4.3",
-        "web-component-tester": "^6.7.1",
-        "yeoman-environment": "^1.5.2",
-        "yeoman-generator": "^2.0.1"
+        "bower-json": "0.8.1",
+        "bower-logger": "0.2.2",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "command-line-args": "5.0.2",
+        "command-line-commands": "2.0.1",
+        "command-line-usage": "5.0.5",
+        "del": "3.0.0",
+        "findup-sync": "0.4.3",
+        "github": "7.3.2",
+        "globby": "8.0.1",
+        "gunzip-maybe": "1.4.1",
+        "inquirer": "1.2.3",
+        "merge-stream": "1.0.1",
+        "mz": "2.7.0",
+        "plylog": "0.5.0",
+        "polymer-analyzer": "3.0.2",
+        "polymer-build": "3.0.4",
+        "polymer-bundler": "4.0.2",
+        "polymer-linter": "3.0.1",
+        "polymer-project-config": "4.0.2",
+        "polyserve": "0.27.12",
+        "request": "2.87.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.3",
+        "temp": "0.8.3",
+        "update-notifier": "1.0.3",
+        "validate-element-name": "2.1.1",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4",
+        "web-component-tester": "6.7.1",
+        "yeoman-environment": "1.6.6",
+        "yeoman-generator": "2.0.5"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -8392,14 +8399,14 @@
             "@babel/template": "7.0.0-beta.51",
             "@babel/traverse": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "convert-source-map": "^1.1.0",
-            "debug": "^3.1.0",
-            "json5": "^0.5.0",
-            "lodash": "^4.17.5",
-            "micromatch": "^3.1.10",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
+            "convert-source-map": "1.5.1",
+            "debug": "3.1.0",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "micromatch": "3.1.10",
+            "resolve": "1.8.1",
+            "semver": "5.5.0",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "arr-diff": {
@@ -8420,16 +8427,16 @@
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -8438,7 +8445,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -8458,13 +8465,13 @@
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "debug": {
@@ -8482,7 +8489,7 @@
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^0.1.0"
+                    "is-descriptor": "0.1.6"
                   }
                 },
                 "extend-shallow": {
@@ -8491,7 +8498,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -8500,7 +8507,7 @@
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -8509,7 +8516,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -8520,7 +8527,7 @@
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -8529,7 +8536,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -8540,9 +8547,9 @@
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
                   }
                 },
                 "kind-of": {
@@ -8559,14 +8566,14 @@
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -8575,7 +8582,7 @@
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^1.0.0"
+                    "is-descriptor": "1.0.2"
                   }
                 },
                 "extend-shallow": {
@@ -8584,7 +8591,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -8595,10 +8602,10 @@
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -8607,7 +8614,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -8618,7 +8625,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -8627,7 +8634,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -8636,9 +8643,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-number": {
@@ -8647,7 +8654,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -8656,7 +8663,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -8679,19 +8686,19 @@
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               }
             }
           }
@@ -8703,10 +8710,10 @@
           "dev": true,
           "requires": {
             "@babel/types": "7.0.0-beta.51",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.5",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "jsesc": "2.5.1",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -8747,7 +8754,7 @@
           "requires": {
             "@babel/helper-function-name": "7.0.0-beta.35",
             "@babel/types": "7.0.0-beta.35",
-            "lodash": "^4.2.0"
+            "lodash": "4.17.10"
           },
           "dependencies": {
             "@babel/code-frame": {
@@ -8756,9 +8763,9 @@
               "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
               }
             },
             "@babel/helper-function-name": {
@@ -8790,7 +8797,7 @@
                 "@babel/code-frame": "7.0.0-beta.35",
                 "@babel/types": "7.0.0-beta.35",
                 "babylon": "7.0.0-beta.35",
-                "lodash": "^4.2.0"
+                "lodash": "4.17.10"
               }
             },
             "@babel/types": {
@@ -8799,9 +8806,9 @@
               "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
               "dev": true,
               "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "2.0.0"
               }
             },
             "ansi-styles": {
@@ -8810,7 +8817,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "babylon": {
@@ -8825,9 +8832,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -8836,7 +8843,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -8896,7 +8903,7 @@
           "dev": true,
           "requires": {
             "@babel/types": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/helper-module-transforms": {
@@ -8910,7 +8917,7 @@
             "@babel/helper-split-export-declaration": "7.0.0-beta.51",
             "@babel/template": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -8928,9 +8935,9 @@
               "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
               "dev": true,
               "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "2.0.0"
               }
             }
           }
@@ -8947,7 +8954,7 @@
           "integrity": "sha1-mXIqPAxwRZavsSMoSwqIihoAPYI=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -8981,9 +8988,9 @@
               "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
               }
             },
             "@babel/helper-function-name": {
@@ -9015,7 +9022,7 @@
                 "@babel/code-frame": "7.0.0-beta.35",
                 "@babel/types": "7.0.0-beta.35",
                 "babylon": "7.0.0-beta.35",
-                "lodash": "^4.2.0"
+                "lodash": "4.17.10"
               }
             },
             "@babel/traverse": {
@@ -9028,10 +9035,10 @@
                 "@babel/helper-function-name": "7.0.0-beta.35",
                 "@babel/types": "7.0.0-beta.35",
                 "babylon": "7.0.0-beta.35",
-                "debug": "^3.0.1",
-                "globals": "^10.0.0",
-                "invariant": "^2.2.0",
-                "lodash": "^4.2.0"
+                "debug": "3.1.0",
+                "globals": "10.4.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.10"
               }
             },
             "@babel/types": {
@@ -9040,9 +9047,9 @@
               "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
               "dev": true,
               "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "2.0.0"
               }
             },
             "ansi-styles": {
@@ -9051,7 +9058,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "babylon": {
@@ -9066,9 +9073,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "debug": {
@@ -9092,7 +9099,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -9105,7 +9112,7 @@
           "requires": {
             "@babel/template": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -9146,9 +9153,9 @@
           "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           },
           "dependencies": {
             "ansi-styles": {
@@ -9157,7 +9164,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "chalk": {
@@ -9166,9 +9173,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -9177,7 +9184,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -9290,7 +9297,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/plugin-transform-classes": {
@@ -9312,9 +9319,9 @@
               "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
               }
             },
             "@babel/helper-annotate-as-pure": {
@@ -9355,7 +9362,7 @@
                 "@babel/code-frame": "7.0.0-beta.35",
                 "@babel/types": "7.0.0-beta.35",
                 "babylon": "7.0.0-beta.35",
-                "lodash": "^4.2.0"
+                "lodash": "4.17.10"
               }
             },
             "@babel/types": {
@@ -9364,9 +9371,9 @@
               "integrity": "sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==",
               "dev": true,
               "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.10",
+                "to-fast-properties": "2.0.0"
               }
             },
             "ansi-styles": {
@@ -9375,7 +9382,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "babylon": {
@@ -9390,9 +9397,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -9401,7 +9408,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -9540,7 +9547,7 @@
           "integrity": "sha1-U28NWZ0nU9ygor6KZeLCRKe1YSs=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "^0.12.4"
+            "regenerator-transform": "0.12.4"
           }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -9598,7 +9605,7 @@
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.51",
             "@babel/helper-regex": "7.0.0-beta.51",
-            "regexpu-core": "^4.1.3"
+            "regexpu-core": "4.2.0"
           }
         },
         "@babel/template": {
@@ -9610,7 +9617,7 @@
             "@babel/code-frame": "7.0.0-beta.51",
             "@babel/parser": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/traverse": {
@@ -9625,10 +9632,10 @@
             "@babel/helper-split-export-declaration": "7.0.0-beta.51",
             "@babel/parser": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.17.5"
+            "debug": "3.1.0",
+            "globals": "11.7.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           },
           "dependencies": {
             "debug": {
@@ -9648,9 +9655,9 @@
           "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.5",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -9659,8 +9666,8 @@
           "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
           "dev": true,
           "requires": {
-            "call-me-maybe": "^1.0.1",
-            "glob-to-regexp": "^0.3.0"
+            "call-me-maybe": "1.0.1",
+            "glob-to-regexp": "0.3.0"
           }
         },
         "@nodelib/fs.stat": {
@@ -9693,7 +9700,7 @@
           "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
           "dev": true,
           "requires": {
-            "@types/estree": "*"
+            "@types/estree": "0.0.39"
           }
         },
         "@types/babel-generator": {
@@ -9702,7 +9709,7 @@
           "integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
           "dev": true,
           "requires": {
-            "@types/babel-types": "*"
+            "@types/babel-types": "6.25.2"
           }
         },
         "@types/babel-traverse": {
@@ -9711,7 +9718,7 @@
           "integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
           "dev": true,
           "requires": {
-            "@types/babel-types": "*"
+            "@types/babel-types": "6.25.2"
           }
         },
         "@types/babel-types": {
@@ -9726,7 +9733,7 @@
           "integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
           "dev": true,
           "requires": {
-            "@types/babel-types": "*"
+            "@types/babel-types": "6.25.2"
           }
         },
         "@types/bluebird": {
@@ -9741,8 +9748,8 @@
           "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
           "dev": true,
           "requires": {
-            "@types/connect": "*",
-            "@types/node": "*"
+            "@types/connect": "3.4.32",
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -9765,7 +9772,7 @@
           "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
           "dev": true,
           "requires": {
-            "@types/chai": "*"
+            "@types/chai": "4.1.4"
           }
         },
         "@types/chalk": {
@@ -9792,7 +9799,7 @@
           "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
           "dev": true,
           "requires": {
-            "@types/express": "*"
+            "@types/express": "4.16.0"
           }
         },
         "@types/connect": {
@@ -9801,7 +9808,7 @@
           "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -9830,7 +9837,7 @@
           "integrity": "sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==",
           "dev": true,
           "requires": {
-            "@types/glob": "*"
+            "@types/glob": "5.0.35"
           }
         },
         "@types/doctrine": {
@@ -9863,9 +9870,9 @@
           "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
           "dev": true,
           "requires": {
-            "@types/body-parser": "*",
-            "@types/express-serve-static-core": "*",
-            "@types/serve-static": "*"
+            "@types/body-parser": "1.17.0",
+            "@types/express-serve-static-core": "4.16.0",
+            "@types/serve-static": "1.13.2"
           }
         },
         "@types/express-serve-static-core": {
@@ -9874,9 +9881,9 @@
           "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
           "dev": true,
           "requires": {
-            "@types/events": "*",
-            "@types/node": "*",
-            "@types/range-parser": "*"
+            "@types/events": "1.2.0",
+            "@types/node": "10.5.0",
+            "@types/range-parser": "1.2.2"
           },
           "dependencies": {
             "@types/node": {
@@ -9899,7 +9906,7 @@
           "integrity": "sha1-7AyAWX5e0VcoIgfnYspyVMrVdjI=",
           "dev": true,
           "requires": {
-            "@types/minimatch": "*"
+            "@types/minimatch": "3.0.3"
           }
         },
         "@types/form-data": {
@@ -9908,7 +9915,7 @@
           "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -9932,9 +9939,9 @@
           "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
           "dev": true,
           "requires": {
-            "@types/events": "*",
-            "@types/minimatch": "*",
-            "@types/node": "*"
+            "@types/events": "1.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -9951,8 +9958,8 @@
           "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
           "dev": true,
           "requires": {
-            "@types/glob": "*",
-            "@types/node": "*"
+            "@types/glob": "5.0.35",
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -9969,7 +9976,7 @@
           "integrity": "sha512-j3XSDNoK4LO5T+ZviQD6PqfEjm07QFEacOTbJR3hnLWuWX0ZMLJl9oRPgj1PyrfGbXhfHFkksC9QZ9HFltJyrw==",
           "dev": true,
           "requires": {
-            "@types/glob": "*"
+            "@types/glob": "5.0.35"
           }
         },
         "@types/gulp-if": {
@@ -9978,8 +9985,8 @@
           "integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
           "dev": true,
           "requires": {
-            "@types/node": "*",
-            "@types/vinyl": "*"
+            "@types/node": "10.5.0",
+            "@types/vinyl": "2.0.2"
           },
           "dependencies": {
             "@types/node": {
@@ -9996,9 +10003,9 @@
           "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
           "dev": true,
           "requires": {
-            "@types/clean-css": "*",
-            "@types/relateurl": "*",
-            "@types/uglify-js": "*"
+            "@types/clean-css": "3.4.30",
+            "@types/relateurl": "0.2.28",
+            "@types/uglify-js": "3.0.2"
           }
         },
         "@types/inquirer": {
@@ -10007,8 +10014,8 @@
           "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
           "dev": true,
           "requires": {
-            "@types/rx": "*",
-            "@types/through": "*"
+            "@types/rx": "4.1.1",
+            "@types/through": "0.0.29"
           }
         },
         "@types/is-windows": {
@@ -10030,7 +10037,7 @@
           "integrity": "sha512-3MMu/pT4gZR0V8DBqpSM4mcv1IPpHV7PNsGrA+306R5TXEOPem60OFn37wD+L20t6oE32OebIBLestUoNAEsuA==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10059,7 +10066,7 @@
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10076,7 +10083,7 @@
           "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10093,7 +10100,7 @@
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10134,8 +10141,8 @@
           "integrity": "sha512-cIvnyFRARxwE4OHpCyYue7H+SxaKFPpeleRCHJicft8QhyTNbVYsMwjvEzEPqG06D2LGHZ+sN5lXc8+bTu6D8A==",
           "dev": true,
           "requires": {
-            "@types/form-data": "*",
-            "@types/node": "*"
+            "@types/form-data": "2.2.1",
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10152,7 +10159,7 @@
           "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10175,18 +10182,18 @@
           "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
           "dev": true,
           "requires": {
-            "@types/rx-core": "*",
-            "@types/rx-core-binding": "*",
-            "@types/rx-lite": "*",
-            "@types/rx-lite-aggregates": "*",
-            "@types/rx-lite-async": "*",
-            "@types/rx-lite-backpressure": "*",
-            "@types/rx-lite-coincidence": "*",
-            "@types/rx-lite-experimental": "*",
-            "@types/rx-lite-joinpatterns": "*",
-            "@types/rx-lite-testing": "*",
-            "@types/rx-lite-time": "*",
-            "@types/rx-lite-virtualtime": "*"
+            "@types/rx-core": "4.0.3",
+            "@types/rx-core-binding": "4.0.4",
+            "@types/rx-lite": "4.0.5",
+            "@types/rx-lite-aggregates": "4.0.3",
+            "@types/rx-lite-async": "4.0.2",
+            "@types/rx-lite-backpressure": "4.0.3",
+            "@types/rx-lite-coincidence": "4.0.3",
+            "@types/rx-lite-experimental": "4.0.1",
+            "@types/rx-lite-joinpatterns": "4.0.1",
+            "@types/rx-lite-testing": "4.0.1",
+            "@types/rx-lite-time": "4.0.3",
+            "@types/rx-lite-virtualtime": "4.0.3"
           }
         },
         "@types/rx-core": {
@@ -10201,7 +10208,7 @@
           "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
           "dev": true,
           "requires": {
-            "@types/rx-core": "*"
+            "@types/rx-core": "4.0.3"
           }
         },
         "@types/rx-lite": {
@@ -10210,8 +10217,8 @@
           "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
           "dev": true,
           "requires": {
-            "@types/rx-core": "*",
-            "@types/rx-core-binding": "*"
+            "@types/rx-core": "4.0.3",
+            "@types/rx-core-binding": "4.0.4"
           }
         },
         "@types/rx-lite-aggregates": {
@@ -10220,7 +10227,7 @@
           "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-async": {
@@ -10229,7 +10236,7 @@
           "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-backpressure": {
@@ -10238,7 +10245,7 @@
           "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-coincidence": {
@@ -10247,7 +10254,7 @@
           "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-experimental": {
@@ -10256,7 +10263,7 @@
           "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-joinpatterns": {
@@ -10265,7 +10272,7 @@
           "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-testing": {
@@ -10274,7 +10281,7 @@
           "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
           "dev": true,
           "requires": {
-            "@types/rx-lite-virtualtime": "*"
+            "@types/rx-lite-virtualtime": "4.0.3"
           }
         },
         "@types/rx-lite-time": {
@@ -10283,7 +10290,7 @@
           "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/rx-lite-virtualtime": {
@@ -10292,7 +10299,7 @@
           "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
           "dev": true,
           "requires": {
-            "@types/rx-lite": "*"
+            "@types/rx-lite": "4.0.5"
           }
         },
         "@types/semver": {
@@ -10307,8 +10314,8 @@
           "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
           "dev": true,
           "requires": {
-            "@types/express-serve-static-core": "*",
-            "@types/mime": "*"
+            "@types/express-serve-static-core": "4.16.0",
+            "@types/mime": "2.0.0"
           }
         },
         "@types/spdy": {
@@ -10317,7 +10324,7 @@
           "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10334,7 +10341,7 @@
           "integrity": "sha512-gyIhOlWPqI8vtYTlRb61HKV7x+3wjpJIQi8mTaweVtEMvhIV6Xajo8FVcNJWeJOBuedRCzK2Uy+uhj/rJmR9oQ==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10351,7 +10358,7 @@
           "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10374,7 +10381,7 @@
           "integrity": "sha512-o8hU2+4xsyGC27Vujoklvxl88Ew5zmJuTBYMX1Uro2rYUt4HEFJKL6fuq8aGykvS+ssIsIzerWWP2DRxonownQ==",
           "dev": true,
           "requires": {
-            "source-map": "^0.6.1"
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -10397,7 +10404,7 @@
           "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10414,7 +10421,7 @@
           "integrity": "sha512-2iYpNuOl98SrLPBZfEN9Mh2JCJ2EI9HU35SfgBEb51DcmaHkhp8cKMblYeBqMQiwXMgAD3W60DbQ4i/UdLiXhw==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10431,9 +10438,9 @@
           "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
           "dev": true,
           "requires": {
-            "@types/glob-stream": "*",
-            "@types/node": "*",
-            "@types/vinyl": "*"
+            "@types/glob-stream": "6.1.0",
+            "@types/node": "10.5.0",
+            "@types/vinyl": "2.0.2"
           },
           "dependencies": {
             "@types/node": {
@@ -10450,7 +10457,7 @@
           "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10474,7 +10481,7 @@
           "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -10491,8 +10498,8 @@
           "integrity": "sha512-vch2UFd6k7DdfWEv/alRwZIRXQoxZNUDpfLOK24+005dzE1HVnwSWfETF3WxJnWlsOcH87wU4uzldAE/7F/6Lw==",
           "dev": true,
           "requires": {
-            "@types/events": "*",
-            "@types/inquirer": "*"
+            "@types/events": "1.2.0",
+            "@types/inquirer": "0.0.32"
           }
         },
         "@webcomponents/webcomponentsjs": {
@@ -10507,7 +10514,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -10529,7 +10536,7 @@
           "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
           "dev": true,
           "requires": {
-            "acorn": "^5.4.1"
+            "acorn": "5.7.1"
           }
         },
         "acorn-jsx": {
@@ -10538,7 +10545,7 @@
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
-            "acorn": "^3.0.4"
+            "acorn": "3.3.0"
           },
           "dependencies": {
             "acorn": {
@@ -10568,8 +10575,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
+            "extend": "3.0.1",
+            "semver": "5.0.3"
           },
           "dependencies": {
             "semver": {
@@ -10586,10 +10593,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-align": {
@@ -10598,7 +10605,7 @@
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "string-width": "2.1.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10619,8 +10626,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
               }
             },
             "strip-ansi": {
@@ -10629,7 +10636,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -10664,8 +10671,8 @@
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "dev": true,
           "requires": {
-            "micromatch": "^2.1.5",
-            "normalize-path": "^2.0.0"
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
           }
         },
         "append-field": {
@@ -10680,14 +10687,14 @@
           "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
           "dev": true,
           "requires": {
-            "archiver-utils": "^1.3.0",
-            "async": "^2.0.0",
-            "buffer-crc32": "^0.2.1",
-            "glob": "^7.0.0",
-            "lodash": "^4.8.0",
-            "readable-stream": "^2.0.0",
-            "tar-stream": "^1.5.0",
-            "zip-stream": "^1.2.0"
+            "archiver-utils": "1.3.0",
+            "async": "2.6.1",
+            "buffer-crc32": "0.2.13",
+            "glob": "7.1.2",
+            "lodash": "4.17.10",
+            "readable-stream": "2.3.6",
+            "tar-stream": "1.6.1",
+            "zip-stream": "1.2.0"
           },
           "dependencies": {
             "async": {
@@ -10696,7 +10703,7 @@
               "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "dev": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               }
             }
           }
@@ -10707,12 +10714,12 @@
           "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "graceful-fs": "^4.1.0",
-            "lazystream": "^1.0.0",
-            "lodash": "^4.8.0",
-            "normalize-path": "^2.0.0",
-            "readable-stream": "^2.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lazystream": "1.0.0",
+            "lodash": "4.17.10",
+            "normalize-path": "2.1.1",
+            "readable-stream": "2.3.6"
           }
         },
         "argv-tools": {
@@ -10721,8 +10728,8 @@
           "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0",
-            "find-replace": "^2.0.1"
+            "array-back": "2.0.0",
+            "find-replace": "2.0.1"
           }
         },
         "arr-diff": {
@@ -10731,7 +10738,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "arr-flatten": {
@@ -10752,7 +10759,7 @@
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "dev": true,
           "requires": {
-            "typical": "^2.6.1"
+            "typical": "2.6.1"
           }
         },
         "array-differ": {
@@ -10779,7 +10786,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "^1.0.1"
+            "array-uniq": "1.0.3"
           }
         },
         "array-uniq": {
@@ -10878,9 +10885,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "babel-generator": {
@@ -10889,14 +10896,14 @@
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           },
           "dependencies": {
             "jsesc": {
@@ -10955,7 +10962,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-minify-builtins": {
@@ -10964,7 +10971,7 @@
           "integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-minify-constant-folding": {
@@ -10973,7 +10980,7 @@
           "integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-minify-dead-code-elimination": {
@@ -10982,10 +10989,10 @@
           "integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3",
-            "babel-helper-mark-eval-scopes": "^0.4.3",
-            "babel-helper-remove-or-void": "^0.4.3",
-            "lodash.some": "^4.6.0"
+            "babel-helper-evaluate-path": "0.4.3",
+            "babel-helper-mark-eval-scopes": "0.4.3",
+            "babel-helper-remove-or-void": "0.4.3",
+            "lodash.some": "4.6.0"
           }
         },
         "babel-plugin-minify-flip-comparisons": {
@@ -10994,7 +11001,7 @@
           "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
           "dev": true,
           "requires": {
-            "babel-helper-is-void-0": "^0.4.3"
+            "babel-helper-is-void-0": "0.4.3"
           }
         },
         "babel-plugin-minify-guarded-expressions": {
@@ -11003,7 +11010,7 @@
           "integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
           "dev": true,
           "requires": {
-            "babel-helper-flip-expressions": "^0.4.1"
+            "babel-helper-flip-expressions": "0.4.3"
           }
         },
         "babel-plugin-minify-infinity": {
@@ -11018,7 +11025,7 @@
           "integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
           "dev": true,
           "requires": {
-            "babel-helper-mark-eval-scopes": "^0.4.3"
+            "babel-helper-mark-eval-scopes": "0.4.3"
           }
         },
         "babel-plugin-minify-numeric-literals": {
@@ -11039,9 +11046,9 @@
           "integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
           "dev": true,
           "requires": {
-            "babel-helper-flip-expressions": "^0.4.3",
-            "babel-helper-is-nodes-equiv": "^0.0.1",
-            "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+            "babel-helper-flip-expressions": "0.4.3",
+            "babel-helper-is-nodes-equiv": "0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "0.4.3"
           }
         },
         "babel-plugin-minify-type-constructors": {
@@ -11050,7 +11057,7 @@
           "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
           "dev": true,
           "requires": {
-            "babel-helper-is-void-0": "^0.4.3"
+            "babel-helper-is-void-0": "0.4.3"
           }
         },
         "babel-plugin-transform-inline-consecutive-adds": {
@@ -11083,7 +11090,7 @@
           "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         },
         "babel-plugin-transform-regexp-constructors": {
@@ -11110,7 +11117,7 @@
           "integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
           "dev": true,
           "requires": {
-            "babel-helper-evaluate-path": "^0.4.3"
+            "babel-helper-evaluate-path": "0.4.3"
           }
         },
         "babel-plugin-transform-simplify-comparison-operators": {
@@ -11131,29 +11138,29 @@
           "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
           "dev": true,
           "requires": {
-            "babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
-            "babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
-            "babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
-            "lodash.isplainobject": "^4.0.6"
+            "babel-plugin-minify-builtins": "0.4.3",
+            "babel-plugin-minify-constant-folding": "0.4.3",
+            "babel-plugin-minify-dead-code-elimination": "0.4.3",
+            "babel-plugin-minify-flip-comparisons": "0.4.3",
+            "babel-plugin-minify-guarded-expressions": "0.4.1",
+            "babel-plugin-minify-infinity": "0.4.3",
+            "babel-plugin-minify-mangle-names": "0.4.3",
+            "babel-plugin-minify-numeric-literals": "0.4.3",
+            "babel-plugin-minify-replace": "0.4.3",
+            "babel-plugin-minify-simplify": "0.4.3",
+            "babel-plugin-minify-type-constructors": "0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "0.4.3",
+            "babel-plugin-transform-member-expression-literals": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-merge-sibling-variables": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-minify-booleans": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-property-literals": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-regexp-constructors": "0.4.3",
+            "babel-plugin-transform-remove-console": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-remove-debugger": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-remove-undefined": "0.4.3",
+            "babel-plugin-transform-simplify-comparison-operators": "6.10.0-alpha.f95869d4",
+            "babel-plugin-transform-undefined-to-void": "6.10.0-alpha.f95869d4",
+            "lodash.isplainobject": "4.0.6"
           }
         },
         "babel-runtime": {
@@ -11162,8 +11169,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.7",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "babel-traverse": {
@@ -11172,15 +11179,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           },
           "dependencies": {
             "babylon": {
@@ -11203,10 +11210,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
           },
           "dependencies": {
             "to-fast-properties": {
@@ -11241,13 +11248,13 @@
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -11256,7 +11263,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -11265,7 +11272,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -11274,7 +11281,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -11283,9 +11290,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -11328,7 +11335,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "better-assert": {
@@ -11358,8 +11365,8 @@
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
           }
         },
         "blob": {
@@ -11375,15 +11382,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "boom": {
@@ -11392,7 +11399,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "bower": {
@@ -11407,11 +11414,11 @@
           "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.3",
-            "mout": "^1.0.0",
-            "optimist": "^0.6.1",
-            "osenv": "^0.1.3",
-            "untildify": "^2.1.0"
+            "graceful-fs": "4.1.11",
+            "mout": "1.1.0",
+            "optimist": "0.6.1",
+            "osenv": "0.1.5",
+            "untildify": "2.1.0"
           }
         },
         "bower-json": {
@@ -11420,10 +11427,10 @@
           "integrity": "sha1-lsFHIyQa5kZqnFLhbKoyYjqIOEM=",
           "dev": true,
           "requires": {
-            "deep-extend": "^0.4.0",
-            "ext-name": "^3.0.0",
-            "graceful-fs": "^4.1.3",
-            "intersect": "^1.0.1"
+            "deep-extend": "0.4.2",
+            "ext-name": "3.0.0",
+            "graceful-fs": "4.1.11",
+            "intersect": "1.0.1"
           }
         },
         "bower-logger": {
@@ -11438,13 +11445,13 @@
           "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -11459,7 +11466,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "camelcase": {
@@ -11474,9 +11481,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "is-fullwidth-code-point": {
@@ -11491,8 +11498,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
               }
             },
             "strip-ansi": {
@@ -11501,7 +11508,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "supports-color": {
@@ -11510,7 +11517,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11521,7 +11528,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -11531,9 +11538,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "browser-capabilities": {
@@ -11542,8 +11549,8 @@
           "integrity": "sha512-b+zF28HRpaKhdvLGqirkvn8XO+WEpLxAWg+dqa3OAoriVMS2UucVc1xis4Et9vMnQGLSipWks8bDeCeUvuZ0EQ==",
           "dev": true,
           "requires": {
-            "@types/ua-parser-js": "^0.7.31",
-            "ua-parser-js": "^0.7.15"
+            "@types/ua-parser-js": "0.7.32",
+            "ua-parser-js": "0.7.18"
           }
         },
         "browserify-zlib": {
@@ -11552,7 +11559,7 @@
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "dev": true,
           "requires": {
-            "pako": "~0.2.0"
+            "pako": "0.2.9"
           }
         },
         "browserstack": {
@@ -11562,7 +11569,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "https-proxy-agent": "^2.2.1"
+            "https-proxy-agent": "2.2.1"
           },
           "dependencies": {
             "agent-base": {
@@ -11572,7 +11579,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "es6-promisify": "^5.0.0"
+                "es6-promisify": "5.0.0"
               }
             },
             "debug": {
@@ -11592,8 +11599,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "agent-base": "^4.1.0",
-                "debug": "^3.1.0"
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
               }
             }
           }
@@ -11604,8 +11611,8 @@
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
           "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-fill": "^1.0.0"
+            "buffer-alloc-unsafe": "1.1.0",
+            "buffer-fill": "1.0.0"
           }
         },
         "buffer-alloc-unsafe": {
@@ -11645,7 +11652,7 @@
           "dev": true,
           "requires": {
             "dicer": "0.2.5",
-            "readable-stream": "1.1.x"
+            "readable-stream": "1.1.14"
           },
           "dependencies": {
             "isarray": {
@@ -11660,10 +11667,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -11686,15 +11693,15 @@
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -11723,8 +11730,8 @@
           "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0",
-            "upper-case": "^1.1.1"
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
           }
         },
         "camelcase": {
@@ -11739,8 +11746,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "cancel-token": {
@@ -11749,7 +11756,7 @@
           "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
           "dev": true,
           "requires": {
-            "@types/node": "^4.0.30"
+            "@types/node": "4.2.23"
           },
           "dependencies": {
             "@types/node": {
@@ -11778,11 +11785,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "chardet": {
@@ -11809,15 +11816,15 @@
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "dev": true,
           "requires": {
-            "anymatch": "^1.3.0",
-            "async-each": "^1.0.0",
-            "fsevents": "^1.0.0",
-            "glob-parent": "^2.0.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^2.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0"
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.2.4",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
           }
         },
         "chownr": {
@@ -11838,10 +11845,10 @@
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
           },
           "dependencies": {
             "define-property": {
@@ -11850,7 +11857,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "isobject": {
@@ -11867,7 +11874,7 @@
           "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.x"
+            "source-map": "0.5.7"
           }
         },
         "cleankill": {
@@ -11888,7 +11895,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "cli-table": {
@@ -11930,9 +11937,9 @@
           "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "process-nextick-args": "^2.0.0",
-            "readable-stream": "^2.3.5"
+            "inherits": "2.0.3",
+            "process-nextick-args": "2.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "co": {
@@ -11953,8 +11960,8 @@
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
           }
         },
         "color-convert": {
@@ -11984,7 +11991,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "command-line-args": {
@@ -11993,11 +12000,11 @@
           "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
           "dev": true,
           "requires": {
-            "argv-tools": "^0.1.1",
-            "array-back": "^2.0.0",
-            "find-replace": "^2.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "typical": "^2.6.1"
+            "argv-tools": "0.1.1",
+            "array-back": "2.0.0",
+            "find-replace": "2.0.1",
+            "lodash.camelcase": "4.3.0",
+            "typical": "2.6.1"
           }
         },
         "command-line-commands": {
@@ -12006,7 +12013,7 @@
           "integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0"
+            "array-back": "2.0.0"
           }
         },
         "command-line-usage": {
@@ -12015,10 +12022,10 @@
           "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0",
-            "chalk": "^2.4.1",
-            "table-layout": "^0.4.3",
-            "typical": "^2.6.1"
+            "array-back": "2.0.0",
+            "chalk": "2.4.1",
+            "table-layout": "0.4.4",
+            "typical": "2.6.1"
           },
           "dependencies": {
             "ansi-styles": {
@@ -12027,7 +12034,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "chalk": {
@@ -12036,9 +12043,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -12047,7 +12054,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12088,10 +12095,10 @@
           "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "^0.2.1",
-            "crc32-stream": "^2.0.0",
-            "normalize-path": "^2.0.0",
-            "readable-stream": "^2.0.0"
+            "buffer-crc32": "0.2.13",
+            "crc32-stream": "2.0.0",
+            "normalize-path": "2.1.1",
+            "readable-stream": "2.3.6"
           }
         },
         "compressible": {
@@ -12100,7 +12107,7 @@
           "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
           "dev": true,
           "requires": {
-            "mime-db": ">= 1.34.0 < 2"
+            "mime-db": "1.34.0"
           }
         },
         "compression": {
@@ -12109,13 +12116,13 @@
           "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
           "dev": true,
           "requires": {
-            "accepts": "~1.3.4",
+            "accepts": "1.3.5",
             "bytes": "3.0.0",
-            "compressible": "~2.0.13",
+            "compressible": "2.0.14",
             "debug": "2.6.9",
-            "on-headers": "~1.0.1",
+            "on-headers": "1.0.1",
             "safe-buffer": "5.1.1",
-            "vary": "~1.1.2"
+            "vary": "1.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -12138,10 +12145,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "configstore": {
@@ -12150,12 +12157,12 @@
           "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "content-disposition": {
@@ -12218,8 +12225,8 @@
           "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
           "dev": true,
           "requires": {
-            "crc": "^3.4.4",
-            "readable-stream": "^2.0.0"
+            "crc": "3.5.0",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "crc": {
@@ -12236,7 +12243,7 @@
           "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
-            "capture-stack-trace": "^1.0.0"
+            "capture-stack-trace": "1.0.0"
           }
         },
         "cross-spawn": {
@@ -12245,9 +12252,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "crypt": {
@@ -12262,7 +12269,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.x.x"
+            "boom": "5.2.0"
           },
           "dependencies": {
             "boom": {
@@ -12271,7 +12278,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
               }
             }
           }
@@ -12288,11 +12295,11 @@
           "integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
           "dev": true,
           "requires": {
-            "command-line-args": "^5.0.2",
-            "command-line-usage": "^5.0.5",
-            "dom5": "^3.0.0",
-            "parse5": "^4.0.0",
-            "shady-css-parser": "^0.1.0"
+            "command-line-args": "5.0.2",
+            "command-line-usage": "5.0.5",
+            "dom5": "3.0.1",
+            "parse5": "4.0.0",
+            "shady-css-parser": "0.1.0"
           }
         },
         "css-what": {
@@ -12313,7 +12320,7 @@
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "dev": true,
           "requires": {
-            "array-find-index": "^1.0.1"
+            "array-find-index": "1.0.2"
           }
         },
         "cycle": {
@@ -12334,7 +12341,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "dateformat": {
@@ -12370,7 +12377,7 @@
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
           "requires": {
-            "mimic-response": "^1.0.0"
+            "mimic-response": "1.0.0"
           }
         },
         "deep-eql": {
@@ -12379,7 +12386,7 @@
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "dev": true,
           "requires": {
-            "type-detect": "^4.0.0"
+            "type-detect": "4.0.8"
           }
         },
         "deep-extend": {
@@ -12394,8 +12401,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -12404,7 +12411,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -12413,7 +12420,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -12422,9 +12429,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -12447,12 +12454,12 @@
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "dev": true,
           "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "6.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "p-map": "1.2.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2"
           },
           "dependencies": {
             "globby": {
@@ -12461,11 +12468,11 @@
               "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
               "dev": true,
               "requires": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
               },
               "dependencies": {
                 "pify": {
@@ -12514,7 +12521,7 @@
           "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
           "dev": true,
           "requires": {
-            "fs-exists-sync": "^0.1.0"
+            "fs-exists-sync": "0.1.0"
           }
         },
         "detect-indent": {
@@ -12523,7 +12530,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "detect-node": {
@@ -12538,7 +12545,7 @@
           "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.x",
+            "readable-stream": "1.1.14",
             "streamsearch": "0.1.2"
           },
           "dependencies": {
@@ -12554,10 +12561,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -12580,8 +12587,8 @@
           "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "path-type": "^3.0.0"
+            "arrify": "1.0.1",
+            "path-type": "3.0.0"
           },
           "dependencies": {
             "path-type": {
@@ -12590,7 +12597,7 @@
               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "dev": true,
               "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
               }
             },
             "pify": {
@@ -12607,7 +12614,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2"
+            "esutils": "2.0.2"
           }
         },
         "dom-urls": {
@@ -12616,7 +12623,7 @@
           "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
           "dev": true,
           "requires": {
-            "urijs": "^1.16.1"
+            "urijs": "1.19.1"
           }
         },
         "dom5": {
@@ -12625,9 +12632,9 @@
           "integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
           "dev": true,
           "requires": {
-            "@types/parse5": "^2.2.34",
-            "clone": "^2.1.0",
-            "parse5": "^4.0.0"
+            "@types/parse5": "2.2.34",
+            "clone": "2.1.1",
+            "parse5": "4.0.0"
           }
         },
         "dot-prop": {
@@ -12636,7 +12643,7 @@
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "duplexer2": {
@@ -12645,7 +12652,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.6"
           }
         },
         "duplexer3": {
@@ -12660,10 +12667,10 @@
           "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -12673,7 +12680,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "editions": {
@@ -12712,7 +12719,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "ends-with": {
@@ -12727,12 +12734,12 @@
           "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
           "dev": true,
           "requires": {
-            "accepts": "~1.3.4",
+            "accepts": "1.3.5",
             "base64id": "1.0.0",
             "cookie": "0.3.1",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.1.0",
-            "ws": "~3.3.1"
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
+            "ws": "3.3.3"
           },
           "dependencies": {
             "debug": {
@@ -12754,14 +12761,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.1.1",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
             "yeast": "0.1.2"
           },
           "dependencies": {
@@ -12783,10 +12790,10 @@
           "dev": true,
           "requires": {
             "after": "0.8.2",
-            "arraybuffer.slice": "~0.0.7",
+            "arraybuffer.slice": "0.0.7",
             "base64-arraybuffer": "0.1.5",
             "blob": "0.0.4",
-            "has-binary2": "~1.0.2"
+            "has-binary2": "1.0.3"
           }
         },
         "error": {
@@ -12795,8 +12802,8 @@
           "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
           "dev": true,
           "requires": {
-            "string-template": "~0.2.1",
-            "xtend": "~4.0.0"
+            "string-template": "0.2.1",
+            "xtend": "4.0.1"
           }
         },
         "error-ex": {
@@ -12805,7 +12812,7 @@
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
-            "is-arrayish": "^0.2.1"
+            "is-arrayish": "0.2.1"
           }
         },
         "es6-promise": {
@@ -12821,7 +12828,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "es6-promise": "^4.0.3"
+            "es6-promise": "4.2.4"
           }
         },
         "escape-html": {
@@ -12842,8 +12849,8 @@
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
+            "acorn": "5.7.1",
+            "acorn-jsx": "3.0.1"
           }
         },
         "esutils": {
@@ -12870,13 +12877,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "exit-hook": {
@@ -12891,7 +12898,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "expand-range": {
@@ -12900,7 +12907,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "^2.1.0"
+            "fill-range": "2.2.4"
           }
         },
         "expand-tilde": {
@@ -12909,7 +12916,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.1"
+            "os-homedir": "1.0.2"
           }
         },
         "express": {
@@ -12918,36 +12925,36 @@
           "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
           "dev": true,
           "requires": {
-            "accepts": "~1.3.5",
+            "accepts": "1.3.5",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "finalhandler": "1.1.1",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "~1.1.2",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "~2.0.3",
+            "proxy-addr": "2.0.3",
             "qs": "6.5.1",
-            "range-parser": "~1.2.0",
+            "range-parser": "1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.2",
             "serve-static": "1.13.2",
             "setprototypeof": "1.1.0",
-            "statuses": "~1.4.0",
-            "type-is": "~1.6.16",
+            "statuses": "1.4.0",
+            "type-is": "1.6.16",
             "utils-merge": "1.0.1",
-            "vary": "~1.1.2"
+            "vary": "1.1.2"
           },
           "dependencies": {
             "path-to-regexp": {
@@ -12970,7 +12977,7 @@
           "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
           "dev": true,
           "requires": {
-            "mime-db": "^1.28.0"
+            "mime-db": "1.34.0"
           }
         },
         "ext-name": {
@@ -12979,10 +12986,10 @@
           "integrity": "sha1-B+RBhzfLH1E8MsbqSNi4yOBHGrs=",
           "dev": true,
           "requires": {
-            "ends-with": "^0.2.0",
-            "ext-list": "^2.0.0",
-            "meow": "^3.1.0",
-            "sort-keys-length": "^1.0.0"
+            "ends-with": "0.2.0",
+            "ext-list": "2.2.2",
+            "meow": "3.7.0",
+            "sort-keys-length": "1.0.1"
           }
         },
         "extend": {
@@ -12997,8 +13004,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -13007,7 +13014,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -13018,9 +13025,9 @@
           "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "spawn-sync": "^1.0.15",
-            "tmp": "^0.0.29"
+            "extend": "3.0.1",
+            "spawn-sync": "1.0.15",
+            "tmp": "0.0.29"
           },
           "dependencies": {
             "tmp": {
@@ -13029,7 +13036,7 @@
               "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
               "dev": true,
               "requires": {
-                "os-tmpdir": "~1.0.1"
+                "os-tmpdir": "1.0.2"
               }
             }
           }
@@ -13040,7 +13047,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "extsprintf": {
@@ -13067,12 +13074,12 @@
           "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
           "dev": true,
           "requires": {
-            "@mrmlnc/readdir-enhanced": "^2.2.1",
-            "@nodelib/fs.stat": "^1.0.1",
-            "glob-parent": "^3.1.0",
-            "is-glob": "^4.0.0",
-            "merge2": "^1.2.1",
-            "micromatch": "^3.1.10"
+            "@mrmlnc/readdir-enhanced": "2.2.1",
+            "@nodelib/fs.stat": "1.1.0",
+            "glob-parent": "3.1.0",
+            "is-glob": "4.0.0",
+            "merge2": "1.2.2",
+            "micromatch": "3.1.10"
           },
           "dependencies": {
             "arr-diff": {
@@ -13093,16 +13100,16 @@
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -13111,7 +13118,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -13122,13 +13129,13 @@
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -13137,7 +13144,7 @@
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^0.1.0"
+                    "is-descriptor": "0.1.6"
                   }
                 },
                 "extend-shallow": {
@@ -13146,7 +13153,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -13155,7 +13162,7 @@
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -13164,7 +13171,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -13175,7 +13182,7 @@
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -13184,7 +13191,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -13195,9 +13202,9 @@
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
                   }
                 },
                 "kind-of": {
@@ -13214,14 +13221,14 @@
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -13230,7 +13237,7 @@
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^1.0.0"
+                    "is-descriptor": "1.0.2"
                   }
                 },
                 "extend-shallow": {
@@ -13239,7 +13246,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -13250,10 +13257,10 @@
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -13262,7 +13269,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -13273,8 +13280,8 @@
               "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
               "dev": true,
               "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
               },
               "dependencies": {
                 "is-glob": {
@@ -13283,7 +13290,7 @@
                   "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                   "dev": true,
                   "requires": {
-                    "is-extglob": "^2.1.0"
+                    "is-extglob": "2.1.1"
                   }
                 }
               }
@@ -13294,7 +13301,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -13303,7 +13310,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -13312,9 +13319,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-extglob": {
@@ -13329,7 +13336,7 @@
               "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "2.1.1"
               }
             },
             "is-number": {
@@ -13338,7 +13345,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -13347,7 +13354,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -13370,19 +13377,19 @@
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               }
             }
           }
@@ -13406,7 +13413,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pend": "~1.2.0"
+            "pend": "1.2.0"
           }
         },
         "figures": {
@@ -13415,8 +13422,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "filename-regex": {
@@ -13431,11 +13438,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.0.0",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "filled-array": {
@@ -13451,12 +13458,12 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "statuses": "~1.4.0",
-            "unpipe": "~1.0.0"
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
+            "unpipe": "1.0.0"
           }
         },
         "find-port": {
@@ -13465,7 +13472,7 @@
           "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
           "dev": true,
           "requires": {
-            "async": "~0.2.9"
+            "async": "0.2.10"
           },
           "dependencies": {
             "async": {
@@ -13482,8 +13489,8 @@
           "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0",
-            "test-value": "^3.0.0"
+            "array-back": "2.0.0",
+            "test-value": "3.0.0"
           }
         },
         "find-up": {
@@ -13492,8 +13499,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "findup-sync": {
@@ -13502,10 +13509,10 @@
           "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
           "dev": true,
           "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
+            "detect-file": "0.1.0",
+            "is-glob": "2.0.1",
+            "micromatch": "2.3.11",
+            "resolve-dir": "0.1.1"
           }
         },
         "first-chunk-stream": {
@@ -13520,8 +13527,8 @@
           "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
-            "stream-consume": "^0.1.0"
+            "debug": "2.6.9",
+            "stream-consume": "0.1.1"
           }
         },
         "for-in": {
@@ -13536,7 +13543,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "forever-agent": {
@@ -13557,9 +13564,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.18"
           }
         },
         "formatio": {
@@ -13568,7 +13575,7 @@
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "dev": true,
           "requires": {
-            "samsam": "1.x"
+            "samsam": "1.3.0"
           }
         },
         "forwarded": {
@@ -13583,7 +13590,7 @@
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
-            "map-cache": "^0.2.2"
+            "map-cache": "0.2.2"
           }
         },
         "freeport": {
@@ -13624,8 +13631,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "^2.9.2",
-            "node-pre-gyp": "^0.10.0"
+            "nan": "2.10.0",
+            "node-pre-gyp": "0.10.0"
           },
           "dependencies": {
             "abbrev": {
@@ -13655,8 +13662,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
               }
             },
             "balanced-match": {
@@ -13671,7 +13678,7 @@
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -13745,7 +13752,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "fs.realpath": {
@@ -13762,14 +13769,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               }
             },
             "glob": {
@@ -13779,12 +13786,12 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "has-unicode": {
@@ -13801,7 +13808,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "^2.1.0"
+                "safer-buffer": "2.1.2"
               }
             },
             "ignore-walk": {
@@ -13811,7 +13818,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -13821,8 +13828,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
@@ -13844,7 +13851,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "isarray": {
@@ -13860,7 +13867,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               }
             },
             "minimist": {
@@ -13875,8 +13882,8 @@
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.0"
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
               }
             },
             "minizlib": {
@@ -13886,7 +13893,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "mkdirp": {
@@ -13912,9 +13919,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "^2.1.2",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.21",
+                "sax": "1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -13924,16 +13931,16 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.0",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.1.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
+                "detect-libc": "1.0.3",
+                "mkdirp": "0.5.1",
+                "needle": "2.2.0",
+                "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
+                "npmlog": "4.1.2",
+                "rc": "1.2.7",
+                "rimraf": "2.6.2",
+                "semver": "5.5.0",
+                "tar": "4.4.1"
               }
             },
             "nopt": {
@@ -13943,8 +13950,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               }
             },
             "npm-bundled": {
@@ -13961,8 +13968,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               }
             },
             "npmlog": {
@@ -13972,10 +13979,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               }
             },
             "number-is-nan": {
@@ -13997,7 +14004,7 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "os-homedir": {
@@ -14021,8 +14028,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               }
             },
             "path-is-absolute": {
@@ -14046,10 +14053,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "deep-extend": "^0.5.1",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.5.1",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -14068,13 +14075,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "rimraf": {
@@ -14084,7 +14091,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -14134,9 +14141,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             },
             "string_decoder": {
@@ -14146,7 +14153,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "strip-ansi": {
@@ -14155,7 +14162,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               }
             },
             "strip-json-comments": {
@@ -14172,13 +14179,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.2.4",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.2"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
               }
             },
             "util-deprecate": {
@@ -14195,7 +14202,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "^1.0.2"
+                "string-width": "1.0.2"
               }
             },
             "wrappy": {
@@ -14242,7 +14249,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "gh-got": {
@@ -14251,8 +14258,8 @@
           "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
           "dev": true,
           "requires": {
-            "got": "^7.0.0",
-            "is-plain-obj": "^1.1.0"
+            "got": "7.1.0",
+            "is-plain-obj": "1.1.0"
           },
           "dependencies": {
             "got": {
@@ -14261,20 +14268,20 @@
               "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
               "dev": true,
               "requires": {
-                "decompress-response": "^3.2.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "isurl": "^1.0.0-alpha5",
-                "lowercase-keys": "^1.0.0",
-                "p-cancelable": "^0.3.0",
-                "p-timeout": "^1.1.1",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "url-parse-lax": "^1.0.0",
-                "url-to-options": "^1.0.1"
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-plain-obj": "1.1.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.1",
+                "p-cancelable": "0.3.0",
+                "p-timeout": "1.2.1",
+                "safe-buffer": "5.1.2",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "1.0.0",
+                "url-to-options": "1.0.1"
               }
             }
           }
@@ -14286,9 +14293,9 @@
           "dev": true,
           "requires": {
             "follow-redirects": "0.0.7",
-            "https-proxy-agent": "^1.0.0",
-            "mime": "^1.2.11",
-            "netrc": "^0.1.4"
+            "https-proxy-agent": "1.0.0",
+            "mime": "1.6.0",
+            "netrc": "0.1.4"
           }
         },
         "github-username": {
@@ -14297,7 +14304,7 @@
           "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
           "dev": true,
           "requires": {
-            "gh-got": "^6.0.0"
+            "gh-got": "6.0.0"
           }
         },
         "glob": {
@@ -14306,12 +14313,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-base": {
@@ -14320,8 +14327,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "glob-parent": {
@@ -14330,7 +14337,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "glob-stream": {
@@ -14339,14 +14346,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "glob": {
@@ -14355,11 +14362,11 @@
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "dev": true,
               "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "glob-parent": {
@@ -14368,8 +14375,8 @@
               "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
               "dev": true,
               "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
               }
             },
             "is-extglob": {
@@ -14384,7 +14391,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             },
             "isarray": {
@@ -14399,10 +14406,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -14417,8 +14424,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -14435,7 +14442,7 @@
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
-            "ini": "^1.3.4"
+            "ini": "1.3.5"
           }
         },
         "global-modules": {
@@ -14444,8 +14451,8 @@
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "dev": true,
           "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
           }
         },
         "global-prefix": {
@@ -14454,10 +14461,10 @@
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.1"
           }
         },
         "globals": {
@@ -14472,13 +14479,13 @@
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "fast-glob": "2.2.2",
+            "glob": "7.1.2",
+            "ignore": "3.3.10",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           },
           "dependencies": {
             "pify": {
@@ -14495,17 +14502,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -14520,7 +14527,7 @@
           "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.2"
+            "lodash": "4.17.10"
           }
         },
         "gulp-if": {
@@ -14529,9 +14536,9 @@
           "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
           "dev": true,
           "requires": {
-            "gulp-match": "^1.0.3",
-            "ternary-stream": "^2.0.1",
-            "through2": "^2.0.1"
+            "gulp-match": "1.0.3",
+            "ternary-stream": "2.0.1",
+            "through2": "2.0.3"
           }
         },
         "gulp-match": {
@@ -14540,7 +14547,7 @@
           "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.3"
+            "minimatch": "3.0.4"
           }
         },
         "gulp-sourcemaps": {
@@ -14549,11 +14556,11 @@
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
           "dev": true,
           "requires": {
-            "convert-source-map": "^1.1.1",
-            "graceful-fs": "^4.1.2",
-            "strip-bom": "^2.0.0",
-            "through2": "^2.0.0",
-            "vinyl": "^1.0.0"
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
           }
         },
         "gunzip-maybe": {
@@ -14562,12 +14569,12 @@
           "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
           "dev": true,
           "requires": {
-            "browserify-zlib": "^0.1.4",
-            "is-deflate": "^1.0.0",
-            "is-gzip": "^1.0.0",
-            "peek-stream": "^1.1.0",
-            "pumpify": "^1.3.3",
-            "through2": "^2.0.3"
+            "browserify-zlib": "0.1.4",
+            "is-deflate": "1.0.0",
+            "is-gzip": "1.0.0",
+            "peek-stream": "1.1.3",
+            "pumpify": "1.5.1",
+            "through2": "2.0.3"
           }
         },
         "handle-thing": {
@@ -14588,8 +14595,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "has-ansi": {
@@ -14598,7 +14605,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-binary2": {
@@ -14648,7 +14655,7 @@
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "dev": true,
           "requires": {
-            "has-symbol-support-x": "^1.4.1"
+            "has-symbol-support-x": "1.4.2"
           }
         },
         "has-value": {
@@ -14657,9 +14664,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -14676,8 +14683,8 @@
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -14686,7 +14693,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14695,7 +14702,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -14706,7 +14713,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -14717,10 +14724,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "he": {
@@ -14741,7 +14748,7 @@
           "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
           "dev": true,
           "requires": {
-            "parse-passwd": "^1.0.0"
+            "parse-passwd": "1.0.0"
           }
         },
         "hosted-git-info": {
@@ -14756,10 +14763,10 @@
           "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "obuf": "^1.0.0",
-            "readable-stream": "^2.0.1",
-            "wbuf": "^1.1.0"
+            "inherits": "2.0.3",
+            "obuf": "1.1.2",
+            "readable-stream": "2.3.6",
+            "wbuf": "1.7.3"
           }
         },
         "html-minifier": {
@@ -14768,13 +14775,13 @@
           "integrity": "sha512-O+StuKL0UWfwX5Zv4rFxd60DPcT5DVjGq1AlnP6VQ8wzudft/W4hx5Wl98aSYNwFBHY6XWJreRw/BehX4l+diQ==",
           "dev": true,
           "requires": {
-            "camel-case": "3.0.x",
-            "clean-css": "4.1.x",
-            "commander": "2.15.x",
-            "he": "1.1.x",
-            "param-case": "2.1.x",
-            "relateurl": "0.2.x",
-            "uglify-js": "3.4.x"
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.11",
+            "commander": "2.15.1",
+            "he": "1.1.1",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.4.2"
           }
         },
         "http-deceiver": {
@@ -14789,10 +14796,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.4.0"
           }
         },
         "http-proxy": {
@@ -14801,9 +14808,9 @@
           "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
           "dev": true,
           "requires": {
-            "eventemitter3": "^3.0.0",
-            "follow-redirects": "^1.0.0",
-            "requires-port": "^1.0.0"
+            "eventemitter3": "3.1.0",
+            "follow-redirects": "1.5.0",
+            "requires-port": "1.0.0"
           },
           "dependencies": {
             "debug": {
@@ -14821,7 +14828,7 @@
               "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
               "dev": true,
               "requires": {
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
               }
             }
           }
@@ -14832,10 +14839,10 @@
           "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
           "dev": true,
           "requires": {
-            "http-proxy": "^1.16.2",
-            "is-glob": "^3.1.0",
-            "lodash": "^4.17.2",
-            "micromatch": "^2.3.11"
+            "http-proxy": "1.17.0",
+            "is-glob": "3.1.0",
+            "lodash": "4.17.10",
+            "micromatch": "2.3.11"
           },
           "dependencies": {
             "is-extglob": {
@@ -14850,7 +14857,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -14861,9 +14868,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "https-proxy-agent": {
@@ -14872,9 +14879,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
           }
         },
         "iconv-lite": {
@@ -14913,7 +14920,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "indexof": {
@@ -14928,8 +14935,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -14950,20 +14957,20 @@
           "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "external-editor": "^1.1.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "external-editor": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "4.17.10",
             "mute-stream": "0.0.6",
-            "pinkie-promise": "^2.0.0",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
+            "pinkie-promise": "2.0.1",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
           }
         },
         "interpret": {
@@ -14984,7 +14991,7 @@
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.3.1"
           }
         },
         "ipaddr.js": {
@@ -14999,7 +15006,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -15014,7 +15021,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "^1.0.0"
+            "binary-extensions": "1.11.0"
           }
         },
         "is-buffer": {
@@ -15029,7 +15036,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-ci": {
@@ -15038,7 +15045,7 @@
           "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
           "dev": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "1.1.3"
           }
         },
         "is-data-descriptor": {
@@ -15047,7 +15054,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-deflate": {
@@ -15062,9 +15069,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -15087,7 +15094,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "^2.0.0"
+            "is-primitive": "2.0.0"
           }
         },
         "is-extendable": {
@@ -15108,7 +15115,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -15117,7 +15124,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-glob": {
@@ -15126,7 +15133,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-gzip": {
@@ -15141,8 +15148,8 @@
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
           }
         },
         "is-npm": {
@@ -15157,7 +15164,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-obj": {
@@ -15184,7 +15191,7 @@
           "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
           "dev": true,
           "requires": {
-            "is-path-inside": "^1.0.0"
+            "is-path-inside": "1.0.1"
           }
         },
         "is-path-inside": {
@@ -15193,7 +15200,7 @@
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
-            "path-is-inside": "^1.0.1"
+            "path-is-inside": "1.0.2"
           }
         },
         "is-plain-obj": {
@@ -15208,7 +15215,7 @@
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -15261,7 +15268,7 @@
           "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
           "dev": true,
           "requires": {
-            "scoped-regex": "^1.0.0"
+            "scoped-regex": "1.0.0"
           }
         },
         "is-stream": {
@@ -15333,9 +15340,9 @@
           "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
           "dev": true,
           "requires": {
-            "binaryextensions": "2",
-            "editions": "^1.3.3",
-            "textextensions": "2"
+            "binaryextensions": "2.1.1",
+            "editions": "1.3.4",
+            "textextensions": "2.2.0"
           }
         },
         "isurl": {
@@ -15344,8 +15351,8 @@
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "dev": true,
           "requires": {
-            "has-to-string-tag-x": "^1.2.0",
-            "is-object": "^1.0.1"
+            "has-to-string-tag-x": "1.4.1",
+            "is-object": "1.0.1"
           }
         },
         "js-tokens": {
@@ -15391,7 +15398,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -15436,7 +15443,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "latest-version": {
@@ -15445,7 +15452,7 @@
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "package-json": "4.0.1"
           }
         },
         "launchpad": {
@@ -15455,12 +15462,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "^2.0.1",
-            "browserstack": "^1.2.0",
-            "debug": "^2.2.0",
-            "plist": "^2.0.1",
-            "q": "^1.4.1",
-            "underscore": "^1.8.3"
+            "async": "2.6.1",
+            "browserstack": "1.5.1",
+            "debug": "2.6.9",
+            "plist": "2.1.0",
+            "q": "1.5.1",
+            "underscore": "1.9.1"
           },
           "dependencies": {
             "async": {
@@ -15470,7 +15477,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               }
             },
             "underscore": {
@@ -15494,7 +15501,7 @@
           "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.5"
+            "readable-stream": "2.3.6"
           }
         },
         "load-json-file": {
@@ -15503,11 +15510,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "locate-path": {
@@ -15516,8 +15523,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -15588,8 +15595,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -15598,7 +15605,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "log-symbols": {
@@ -15607,7 +15614,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "lolex": {
@@ -15622,7 +15629,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0"
+            "js-tokens": "3.0.2"
           }
         },
         "loud-rejection": {
@@ -15631,8 +15638,8 @@
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "dev": true,
           "requires": {
-            "currently-unhandled": "^0.4.1",
-            "signal-exit": "^3.0.0"
+            "currently-unhandled": "0.4.1",
+            "signal-exit": "3.0.2"
           }
         },
         "lower-case": {
@@ -15653,8 +15660,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "magic-string": {
@@ -15663,7 +15670,7 @@
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
           "dev": true,
           "requires": {
-            "vlq": "^0.2.2"
+            "vlq": "0.2.3"
           }
         },
         "make-dir": {
@@ -15672,7 +15679,7 @@
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -15701,7 +15708,7 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
-            "object-visit": "^1.0.0"
+            "object-visit": "1.0.1"
           }
         },
         "matcher": {
@@ -15710,7 +15717,7 @@
           "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.4"
+            "escape-string-regexp": "1.0.5"
           }
         },
         "math-random": {
@@ -15725,9 +15732,9 @@
           "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
           "dev": true,
           "requires": {
-            "charenc": "~0.0.1",
-            "crypt": "~0.0.1",
-            "is-buffer": "~1.1.1"
+            "charenc": "0.0.2",
+            "crypt": "0.0.2",
+            "is-buffer": "1.1.6"
           }
         },
         "media-typer": {
@@ -15742,9 +15749,9 @@
           "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
           "dev": true,
           "requires": {
-            "through2": "^2.0.0",
-            "vinyl": "^1.1.0",
-            "vinyl-file": "^2.0.0"
+            "through2": "2.0.3",
+            "vinyl": "1.2.0",
+            "vinyl-file": "2.0.0"
           }
         },
         "mem-fs-editor": {
@@ -15753,17 +15760,17 @@
           "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "deep-extend": "^0.5.1",
-            "ejs": "^2.5.9",
-            "glob": "^7.0.3",
-            "globby": "^8.0.0",
-            "isbinaryfile": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "multimatch": "^2.0.0",
-            "rimraf": "^2.2.8",
-            "through2": "^2.0.0",
-            "vinyl": "^2.0.1"
+            "commondir": "1.0.1",
+            "deep-extend": "0.5.1",
+            "ejs": "2.6.1",
+            "glob": "7.1.2",
+            "globby": "8.0.1",
+            "isbinaryfile": "3.0.2",
+            "mkdirp": "0.5.1",
+            "multimatch": "2.1.0",
+            "rimraf": "2.6.2",
+            "through2": "2.0.3",
+            "vinyl": "2.2.0"
           },
           "dependencies": {
             "clone-stats": {
@@ -15790,12 +15797,12 @@
               "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
               "dev": true,
               "requires": {
-                "clone": "^2.1.1",
-                "clone-buffer": "^1.0.0",
-                "clone-stats": "^1.0.0",
-                "cloneable-readable": "^1.0.0",
-                "remove-trailing-separator": "^1.0.1",
-                "replace-ext": "^1.0.0"
+                "clone": "2.1.1",
+                "clone-buffer": "1.0.0",
+                "clone-stats": "1.0.0",
+                "cloneable-readable": "1.1.2",
+                "remove-trailing-separator": "1.1.0",
+                "replace-ext": "1.0.0"
               }
             }
           }
@@ -15806,16 +15813,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "merge-descriptors": {
@@ -15830,7 +15837,7 @@
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.1"
+            "readable-stream": "2.3.6"
           }
         },
         "merge2": {
@@ -15851,19 +15858,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "mime": {
@@ -15884,7 +15891,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.33.0"
           },
           "dependencies": {
             "mime-db": {
@@ -15919,7 +15926,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimatch-all": {
@@ -15928,7 +15935,7 @@
           "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.2"
+            "minimatch": "3.0.4"
           }
         },
         "minimist": {
@@ -15943,8 +15950,8 @@
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -15953,7 +15960,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -15993,14 +16000,14 @@
           "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
           "dev": true,
           "requires": {
-            "append-field": "^0.1.0",
-            "busboy": "^0.2.11",
-            "concat-stream": "^1.5.2",
-            "mkdirp": "^0.5.1",
-            "object-assign": "^3.0.0",
-            "on-finished": "^2.3.0",
-            "type-is": "^1.6.4",
-            "xtend": "^4.0.0"
+            "append-field": "0.1.0",
+            "busboy": "0.2.14",
+            "concat-stream": "1.6.2",
+            "mkdirp": "0.5.1",
+            "object-assign": "3.0.0",
+            "on-finished": "2.3.0",
+            "type-is": "1.6.16",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "object-assign": {
@@ -16017,10 +16024,10 @@
           "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
           "dev": true,
           "requires": {
-            "array-differ": "^1.0.0",
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "minimatch": "^3.0.0"
+            "array-differ": "1.0.0",
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "minimatch": "3.0.4"
           }
         },
         "multipipe": {
@@ -16029,8 +16036,8 @@
           "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
           "dev": true,
           "requires": {
-            "duplexer2": "^0.1.2",
-            "object-assign": "^4.1.0"
+            "duplexer2": "0.1.4",
+            "object-assign": "4.1.1"
           }
         },
         "mute-stream": {
@@ -16045,9 +16052,9 @@
           "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
           "dev": true,
           "requires": {
-            "any-promise": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "thenify-all": "^1.0.0"
+            "any-promise": "1.3.0",
+            "object-assign": "4.1.1",
+            "thenify-all": "1.6.0"
           }
         },
         "nan": {
@@ -16063,17 +16070,17 @@
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "arr-diff": {
@@ -16132,7 +16139,7 @@
           "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
           "dev": true,
           "requires": {
-            "lower-case": "^1.1.1"
+            "lower-case": "1.1.4"
           }
         },
         "node-status-codes": {
@@ -16147,8 +16154,8 @@
           "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
           "dev": true,
           "requires": {
-            "chalk": "~0.4.0",
-            "underscore": "~1.6.0"
+            "chalk": "0.4.0",
+            "underscore": "1.6.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -16163,9 +16170,9 @@
               "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
               "dev": true,
               "requires": {
-                "ansi-styles": "~1.0.0",
-                "has-color": "~0.1.0",
-                "strip-ansi": "~0.1.0"
+                "ansi-styles": "1.0.0",
+                "has-color": "0.1.7",
+                "strip-ansi": "0.1.1"
               }
             },
             "strip-ansi": {
@@ -16182,10 +16189,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.1",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "normalize-path": {
@@ -16194,7 +16201,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         },
         "npm-run-path": {
@@ -16203,7 +16210,7 @@
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
@@ -16236,9 +16243,9 @@
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "define-property": {
@@ -16247,7 +16254,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -16258,7 +16265,7 @@
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.0"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -16275,8 +16282,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
           }
         },
         "object.pick": {
@@ -16285,7 +16292,7 @@
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -16323,7 +16330,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "onetime": {
@@ -16338,7 +16345,7 @@
           "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1"
+            "object-assign": "4.1.1"
           }
         },
         "optimist": {
@@ -16347,8 +16354,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
           },
           "dependencies": {
             "minimist": {
@@ -16365,8 +16372,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.6"
           }
         },
         "os-homedir": {
@@ -16393,8 +16400,8 @@
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "p-cancelable": {
@@ -16415,7 +16422,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -16424,7 +16431,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-map": {
@@ -16439,7 +16446,7 @@
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
           "requires": {
-            "p-finally": "^1.0.0"
+            "p-finally": "1.0.0"
           }
         },
         "p-try": {
@@ -16454,10 +16461,10 @@
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pako": {
@@ -16472,7 +16479,7 @@
           "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0"
+            "no-case": "2.3.2"
           }
         },
         "parse-glob": {
@@ -16481,10 +16488,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "parse-json": {
@@ -16493,7 +16500,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "parse-passwd": {
@@ -16514,7 +16521,7 @@
           "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
           "dev": true,
           "requires": {
-            "better-assert": "~1.0.0"
+            "better-assert": "1.0.2"
           }
         },
         "parseuri": {
@@ -16523,7 +16530,7 @@
           "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
           "dev": true,
           "requires": {
-            "better-assert": "~1.0.0"
+            "better-assert": "1.0.2"
           }
         },
         "parseurl": {
@@ -16550,7 +16557,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
@@ -16600,9 +16607,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pathval": {
@@ -16617,9 +16624,9 @@
           "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "duplexify": "^3.5.0",
-            "through2": "^2.0.3"
+            "buffer-from": "1.1.0",
+            "duplexify": "3.6.0",
+            "through2": "2.0.3"
           }
         },
         "pem": {
@@ -16628,10 +16635,10 @@
           "integrity": "sha512-mm8gLf4ZCaY6Qdm8J4bBdHs6SO4px71FspxgC2jJ0vXf3PYNZnGhU9zITCxpzFHpLPHsHU3xRBbuXNxEWuWziQ==",
           "dev": true,
           "requires": {
-            "md5": "^2.2.1",
-            "os-tmpdir": "^1.0.1",
-            "safe-buffer": "^5.1.1",
-            "which": "^1.2.4"
+            "md5": "2.2.1",
+            "os-tmpdir": "1.0.2",
+            "safe-buffer": "5.1.2",
+            "which": "1.3.1"
           }
         },
         "pend": {
@@ -16665,7 +16672,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "plist": {
@@ -16677,7 +16684,7 @@
           "requires": {
             "base64-js": "1.2.0",
             "xmlbuilder": "8.2.2",
-            "xmldom": "0.1.x"
+            "xmldom": "0.1.27"
           }
         },
         "plylog": {
@@ -16686,9 +16693,9 @@
           "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
           "dev": true,
           "requires": {
-            "@types/node": "^4.2.3",
-            "@types/winston": "^2.2.0",
-            "winston": "^2.2.0"
+            "@types/node": "4.2.23",
+            "@types/winston": "2.3.9",
+            "winston": "2.4.3"
           },
           "dependencies": {
             "@types/node": {
@@ -16705,44 +16712,44 @@
           "integrity": "sha512-a8g+60VagUqmzWttG+/7BBGJiQLdLTIpFzhHp8UVcAitq/Z3ZywWaEGP5C9VEtALRCruVYue+dAsGvxHhNBdJw==",
           "dev": true,
           "requires": {
-            "@babel/generator": "^7.0.0-beta.42",
-            "@babel/traverse": "^7.0.0-beta.42",
-            "@babel/types": "^7.0.0-beta.42",
-            "@types/babel-generator": "^6.25.1",
-            "@types/babel-traverse": "^6.25.2",
-            "@types/babel-types": "^6.25.1",
-            "@types/babylon": "^6.16.2",
-            "@types/chai-subset": "^1.3.0",
-            "@types/chalk": "^0.4.30",
-            "@types/clone": "^0.1.30",
-            "@types/cssbeautify": "^0.3.1",
-            "@types/doctrine": "^0.0.1",
-            "@types/is-windows": "^0.2.0",
-            "@types/minimatch": "^3.0.1",
-            "@types/node": "^9.6.4",
-            "@types/parse5": "^2.2.34",
-            "@types/path-is-inside": "^1.0.0",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/traverse": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
+            "@types/chai-subset": "1.3.1",
+            "@types/chalk": "0.4.31",
+            "@types/clone": "0.1.30",
+            "@types/cssbeautify": "0.3.1",
+            "@types/doctrine": "0.0.1",
+            "@types/is-windows": "0.2.0",
+            "@types/minimatch": "3.0.3",
+            "@types/node": "9.6.22",
+            "@types/parse5": "2.2.34",
+            "@types/path-is-inside": "1.0.0",
             "@types/resolve": "0.0.6",
-            "@types/whatwg-url": "^6.4.0",
-            "babylon": "^7.0.0-beta.42",
-            "cancel-token": "^0.1.1",
-            "chalk": "^1.1.3",
-            "clone": "^2.0.0",
-            "cssbeautify": "^0.3.1",
-            "doctrine": "^2.0.2",
-            "dom5": "^3.0.0",
+            "@types/whatwg-url": "6.4.0",
+            "babylon": "7.0.0-beta.47",
+            "cancel-token": "0.1.1",
+            "chalk": "1.1.3",
+            "clone": "2.1.1",
+            "cssbeautify": "0.3.1",
+            "doctrine": "2.1.0",
+            "dom5": "3.0.1",
             "indent": "0.0.2",
-            "is-windows": "^1.0.2",
-            "jsonschema": "^1.1.0",
-            "minimatch": "^3.0.4",
-            "parse5": "^4.0.0",
-            "path-is-inside": "^1.0.2",
-            "resolve": "^1.5.0",
-            "shady-css-parser": "^0.1.0",
-            "stable": "^0.1.6",
-            "strip-indent": "^2.0.0",
-            "vscode-uri": "^1.0.1",
-            "whatwg-url": "^6.4.0"
+            "is-windows": "1.0.2",
+            "jsonschema": "1.2.4",
+            "minimatch": "3.0.4",
+            "parse5": "4.0.0",
+            "path-is-inside": "1.0.2",
+            "resolve": "1.8.1",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "vscode-uri": "1.0.5",
+            "whatwg-url": "6.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -16757,7 +16764,7 @@
               "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
               "dev": true,
               "requires": {
-                "@types/node": "*"
+                "@types/node": "9.6.22"
               }
             },
             "is-windows": {
@@ -16780,72 +16787,72 @@
           "integrity": "sha512-YSppvctpcO2do3XHXNo2WnD4mxpzTpjgLlByPXE0Jfz9N+Ez6EGmge7Xwd6NsFH9ch6IMyV1P9H238I/C/KZRw==",
           "dev": true,
           "requires": {
-            "@babel/core": "^7.0.0-beta.46",
-            "@babel/plugin-external-helpers": "^7.0.0-beta.46",
-            "@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.46",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
-            "@babel/plugin-syntax-async-generators": "^7.0.0-beta.46",
-            "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta.46",
-            "@babel/plugin-syntax-import-meta": "^7.0.0-beta.46",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0-beta.46",
-            "@babel/plugin-transform-arrow-functions": "^7.0.0-beta.46",
-            "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.46",
-            "@babel/plugin-transform-block-scoped-functions": "^7.0.0-beta.46",
-            "@babel/plugin-transform-block-scoping": "^7.0.0-beta.46",
-            "@babel/plugin-transform-classes": "=7.0.0-beta.35",
-            "@babel/plugin-transform-computed-properties": "^7.0.0-beta.46",
-            "@babel/plugin-transform-destructuring": "^7.0.0-beta.46",
-            "@babel/plugin-transform-duplicate-keys": "^7.0.0-beta.46",
-            "@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta.46",
-            "@babel/plugin-transform-for-of": "^7.0.0-beta.46",
-            "@babel/plugin-transform-function-name": "^7.0.0-beta.46",
-            "@babel/plugin-transform-instanceof": "^7.0.0-beta.46",
-            "@babel/plugin-transform-literals": "^7.0.0-beta.46",
-            "@babel/plugin-transform-modules-amd": "^7.0.0-beta.46",
-            "@babel/plugin-transform-object-super": "^7.0.0-beta.46",
-            "@babel/plugin-transform-parameters": "^7.0.0-beta.46",
-            "@babel/plugin-transform-regenerator": "^7.0.0-beta.46",
-            "@babel/plugin-transform-shorthand-properties": "^7.0.0-beta.46",
-            "@babel/plugin-transform-spread": "^7.0.0-beta.46",
-            "@babel/plugin-transform-sticky-regex": "^7.0.0-beta.46",
-            "@babel/plugin-transform-template-literals": "^7.0.0-beta.46",
-            "@babel/plugin-transform-typeof-symbol": "^7.0.0-beta.46",
-            "@babel/plugin-transform-unicode-regex": "^7.0.0-beta.46",
-            "@babel/traverse": "^7.0.0-beta.46",
-            "@polymer/esm-amd-loader": "^1.0.0",
-            "@types/babel-types": "^6.25.1",
-            "@types/babylon": "^6.16.2",
+            "@babel/core": "7.0.0-beta.51",
+            "@babel/plugin-external-helpers": "7.0.0-beta.51",
+            "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.51",
+            "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.51",
+            "@babel/plugin-syntax-async-generators": "7.0.0-beta.51",
+            "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.51",
+            "@babel/plugin-syntax-import-meta": "7.0.0-beta.51",
+            "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.51",
+            "@babel/plugin-transform-arrow-functions": "7.0.0-beta.51",
+            "@babel/plugin-transform-async-to-generator": "7.0.0-beta.51",
+            "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.51",
+            "@babel/plugin-transform-block-scoping": "7.0.0-beta.51",
+            "@babel/plugin-transform-classes": "7.0.0-beta.35",
+            "@babel/plugin-transform-computed-properties": "7.0.0-beta.51",
+            "@babel/plugin-transform-destructuring": "7.0.0-beta.51",
+            "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.51",
+            "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.51",
+            "@babel/plugin-transform-for-of": "7.0.0-beta.51",
+            "@babel/plugin-transform-function-name": "7.0.0-beta.51",
+            "@babel/plugin-transform-instanceof": "7.0.0-beta.51",
+            "@babel/plugin-transform-literals": "7.0.0-beta.51",
+            "@babel/plugin-transform-modules-amd": "7.0.0-beta.51",
+            "@babel/plugin-transform-object-super": "7.0.0-beta.51",
+            "@babel/plugin-transform-parameters": "7.0.0-beta.51",
+            "@babel/plugin-transform-regenerator": "7.0.0-beta.51",
+            "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.51",
+            "@babel/plugin-transform-spread": "7.0.0-beta.51",
+            "@babel/plugin-transform-sticky-regex": "7.0.0-beta.51",
+            "@babel/plugin-transform-template-literals": "7.0.0-beta.51",
+            "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.51",
+            "@babel/plugin-transform-unicode-regex": "7.0.0-beta.51",
+            "@babel/traverse": "7.0.0-beta.51",
+            "@polymer/esm-amd-loader": "1.0.2",
+            "@types/babel-types": "6.25.2",
+            "@types/babylon": "6.16.3",
             "@types/gulp-if": "0.0.33",
-            "@types/html-minifier": "^3.5.1",
-            "@types/is-windows": "^0.2.0",
+            "@types/html-minifier": "3.5.2",
+            "@types/is-windows": "0.2.0",
             "@types/mz": "0.0.31",
-            "@types/node": "^9.6.4",
-            "@types/parse5": "^2.2.34",
+            "@types/node": "9.6.22",
+            "@types/parse5": "2.2.34",
             "@types/resolve": "0.0.7",
-            "@types/uuid": "^3.4.3",
-            "@types/vinyl": "^2.0.0",
-            "@types/vinyl-fs": "^2.4.8",
-            "babel-plugin-minify-guarded-expressions": "=0.4.1",
-            "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
-            "babylon": "^7.0.0-beta.42",
-            "css-slam": "^2.1.2",
-            "dom5": "^3.0.0",
-            "gulp-if": "^2.0.2",
-            "html-minifier": "^3.5.10",
-            "matcher": "^1.1.0",
-            "multipipe": "^1.0.2",
-            "mz": "^2.6.0",
-            "parse5": "^4.0.0",
-            "plylog": "^0.5.0",
-            "polymer-analyzer": "^3.0.0",
-            "polymer-bundler": "^4.0.0",
-            "polymer-project-config": "^4.0.0",
-            "regenerator-runtime": "^0.11.1",
+            "@types/uuid": "3.4.3",
+            "@types/vinyl": "2.0.2",
+            "@types/vinyl-fs": "2.4.8",
+            "babel-plugin-minify-guarded-expressions": "0.4.1",
+            "babel-preset-minify": "0.4.0-alpha.caaefb4c",
+            "babylon": "7.0.0-beta.47",
+            "css-slam": "2.1.2",
+            "dom5": "3.0.1",
+            "gulp-if": "2.0.2",
+            "html-minifier": "3.5.17",
+            "matcher": "1.1.1",
+            "multipipe": "1.0.2",
+            "mz": "2.7.0",
+            "parse5": "4.0.0",
+            "plylog": "0.5.0",
+            "polymer-analyzer": "3.0.2",
+            "polymer-bundler": "4.0.2",
+            "polymer-project-config": "4.0.2",
+            "regenerator-runtime": "0.11.1",
             "stream": "0.0.2",
-            "sw-precache": "^5.1.1",
-            "uuid": "^3.2.1",
-            "vinyl": "^1.2.0",
-            "vinyl-fs": "^2.4.4"
+            "sw-precache": "5.2.1",
+            "uuid": "3.3.2",
+            "vinyl": "1.2.0",
+            "vinyl-fs": "2.4.4"
           },
           "dependencies": {
             "@types/node": {
@@ -16860,7 +16867,7 @@
               "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
               "dev": true,
               "requires": {
-                "@types/node": "*"
+                "@types/node": "9.6.22"
               }
             },
             "@types/vinyl-fs": {
@@ -16869,9 +16876,9 @@
               "integrity": "sha512-yE2pN9OOrxJVeO7IZLHAHrh5R4Q0osbn5WQRuQU6GdXoK7dNFrMK3K7YhATkzf3z0yQBkol3+gafs7Rp0s7dDg==",
               "dev": true,
               "requires": {
-                "@types/glob-stream": "*",
-                "@types/node": "*",
-                "@types/vinyl": "*"
+                "@types/glob-stream": "6.1.0",
+                "@types/node": "9.6.22",
+                "@types/vinyl": "2.0.2"
               }
             }
           }
@@ -16882,25 +16889,25 @@
           "integrity": "sha512-eH+MNSVb/bCqchxYE1gVtdLP9eq1pLsr9NdcHhiJGEgSoZOYq7lGm2M/L7DHGJqa1/OqC7ZC9Sz3eQKAB8FaJQ==",
           "dev": true,
           "requires": {
-            "@types/acorn": "^4.0.3",
-            "@types/babel-generator": "^6.25.1",
-            "@types/babel-traverse": "^6.25.3",
-            "acorn-import-meta": "^0.2.1",
-            "babel-generator": "^6.26.1",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "clone": "^2.1.0",
-            "command-line-args": "^5.0.2",
-            "command-line-usage": "^5.0.5",
-            "dom5": "^3.0.0",
-            "espree": "^3.5.2",
-            "magic-string": "^0.22.4",
-            "mkdirp": "^0.5.1",
-            "parse5": "^4.0.0",
-            "polymer-analyzer": "^3.0.1",
-            "rollup": "^0.58.2",
-            "source-map": "^0.5.6",
-            "vscode-uri": "^1.0.1"
+            "@types/acorn": "4.0.3",
+            "@types/babel-generator": "6.25.2",
+            "@types/babel-traverse": "6.25.4",
+            "acorn-import-meta": "0.2.1",
+            "babel-generator": "6.26.1",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "clone": "2.1.1",
+            "command-line-args": "5.0.2",
+            "command-line-usage": "5.0.5",
+            "dom5": "3.0.1",
+            "espree": "3.5.4",
+            "magic-string": "0.22.5",
+            "mkdirp": "0.5.1",
+            "parse5": "4.0.0",
+            "polymer-analyzer": "3.0.2",
+            "rollup": "0.58.2",
+            "source-map": "0.5.7",
+            "vscode-uri": "1.0.5"
           }
         },
         "polymer-linter": {
@@ -16910,19 +16917,19 @@
           "dev": true,
           "requires": {
             "@types/fast-levenshtein": "0.0.1",
-            "@types/parse5": "^2.2.34",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "cancel-token": "^0.1.1",
-            "css-what": "^2.1.0",
-            "dom5": "^3.0.0",
-            "fast-levenshtein": "^2.0.6",
-            "parse5": "^4.0.0",
-            "polymer-analyzer": "^3.0.0",
-            "shady-css-parser": "^0.1.0",
-            "stable": "^0.1.6",
-            "strip-indent": "^2.0.0",
-            "validate-element-name": "^2.1.1"
+            "@types/parse5": "2.2.34",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "cancel-token": "0.1.1",
+            "css-what": "2.1.0",
+            "dom5": "3.0.1",
+            "fast-levenshtein": "2.0.6",
+            "parse5": "4.0.0",
+            "polymer-analyzer": "3.0.2",
+            "shady-css-parser": "0.1.0",
+            "stable": "0.1.8",
+            "strip-indent": "2.0.0",
+            "validate-element-name": "2.1.1"
           },
           "dependencies": {
             "strip-indent": {
@@ -16939,11 +16946,11 @@
           "integrity": "sha512-nnxLkbpYYPIVBYooeercovQIWqq4coHzQ5PwK2+NxNpVWUJ5tW3OCDt46dqw3CtJNe4r/qIOkPgBJdVwXAAEmw==",
           "dev": true,
           "requires": {
-            "@types/node": "^9.6.4",
-            "browser-capabilities": "^1.0.0",
-            "jsonschema": "^1.1.1",
-            "minimatch-all": "^1.1.0",
-            "plylog": "^0.5.0"
+            "@types/node": "9.6.22",
+            "browser-capabilities": "1.1.1",
+            "jsonschema": "1.2.4",
+            "minimatch-all": "1.1.0",
+            "plylog": "0.5.0"
           },
           "dependencies": {
             "@types/node": {
@@ -16960,40 +16967,40 @@
           "integrity": "sha512-P4lb0fNqkSSRHrKTp9/bUnTjZOmnNnLWJ5zMBiWjkkJe3vzNcRpdL0vMQO6RxZ8MUvBI2Iv9mqGPVPY+Dk+Z1w==",
           "dev": true,
           "requires": {
-            "@types/compression": "^0.0.33",
-            "@types/content-type": "^1.1.0",
+            "@types/compression": "0.0.33",
+            "@types/content-type": "1.1.2",
             "@types/escape-html": "0.0.20",
-            "@types/express": "^4.0.36",
-            "@types/mime": "^2.0.0",
+            "@types/express": "4.16.0",
+            "@types/mime": "2.0.0",
             "@types/mz": "0.0.29",
-            "@types/node": "^9.6.4",
-            "@types/opn": "^3.0.28",
-            "@types/parse5": "^2.2.34",
-            "@types/pem": "^1.8.1",
+            "@types/node": "9.6.22",
+            "@types/opn": "3.0.28",
+            "@types/parse5": "2.2.34",
+            "@types/pem": "1.9.3",
             "@types/resolve": "0.0.6",
-            "@types/serve-static": "^1.7.31",
-            "@types/spdy": "^3.4.1",
-            "bower-config": "^1.4.1",
-            "browser-capabilities": "^1.0.0",
-            "command-line-args": "^5.0.2",
-            "command-line-usage": "^5.0.5",
-            "compression": "^1.6.2",
-            "content-type": "^1.0.2",
-            "escape-html": "^1.0.3",
-            "express": "^4.8.5",
-            "find-port": "^1.0.1",
-            "http-proxy-middleware": "^0.17.2",
-            "lru-cache": "^4.0.2",
-            "mime": "^2.3.1",
-            "mz": "^2.4.0",
-            "opn": "^3.0.2",
-            "pem": "^1.8.3",
-            "polymer-build": "^3.0.3",
-            "polymer-project-config": "^4.0.0",
-            "requirejs": "^2.3.4",
-            "resolve": "^1.5.0",
-            "send": "^0.16.2",
-            "spdy": "^3.3.3"
+            "@types/serve-static": "1.13.2",
+            "@types/spdy": "3.4.4",
+            "bower-config": "1.4.1",
+            "browser-capabilities": "1.1.1",
+            "command-line-args": "5.0.2",
+            "command-line-usage": "5.0.5",
+            "compression": "1.7.2",
+            "content-type": "1.0.4",
+            "escape-html": "1.0.3",
+            "express": "4.16.3",
+            "find-port": "1.0.1",
+            "http-proxy-middleware": "0.17.4",
+            "lru-cache": "4.1.3",
+            "mime": "2.3.1",
+            "mz": "2.7.0",
+            "opn": "3.0.3",
+            "pem": "1.12.5",
+            "polymer-build": "3.0.4",
+            "polymer-project-config": "4.0.2",
+            "requirejs": "2.3.5",
+            "resolve": "1.8.1",
+            "send": "0.16.2",
+            "spdy": "3.4.7"
           },
           "dependencies": {
             "@types/mz": {
@@ -17002,8 +17009,8 @@
               "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
               "dev": true,
               "requires": {
-                "@types/bluebird": "*",
-                "@types/node": "*"
+                "@types/bluebird": "3.5.21",
+                "@types/node": "9.6.22"
               }
             },
             "@types/node": {
@@ -17018,7 +17025,7 @@
               "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
               "dev": true,
               "requires": {
-                "@types/node": "*"
+                "@types/node": "9.6.22"
               }
             },
             "mime": {
@@ -17078,7 +17085,7 @@
           "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
           "dev": true,
           "requires": {
-            "forwarded": "~0.1.2",
+            "forwarded": "0.1.2",
             "ipaddr.js": "1.6.0"
           }
         },
@@ -17094,8 +17101,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "pumpify": {
@@ -17104,9 +17111,9 @@
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
           }
         },
         "punycode": {
@@ -17134,9 +17141,9 @@
           "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
           "dev": true,
           "requires": {
-            "is-number": "^4.0.0",
-            "kind-of": "^6.0.0",
-            "math-random": "^1.0.1"
+            "is-number": "4.0.0",
+            "kind-of": "6.0.2",
+            "math-random": "1.0.1"
           },
           "dependencies": {
             "is-number": {
@@ -17186,7 +17193,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.4.0"
               }
             },
             "setprototypeof": {
@@ -17203,10 +17210,10 @@
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "deep-extend": {
@@ -17223,8 +17230,8 @@
           "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0",
-            "readable-stream": "^2.0.0"
+            "pinkie-promise": "2.0.1",
+            "readable-stream": "2.3.6"
           }
         },
         "read-chunk": {
@@ -17233,8 +17240,8 @@
           "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0",
-            "safe-buffer": "^5.1.1"
+            "pify": "3.0.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "pify": {
@@ -17251,9 +17258,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -17262,8 +17269,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "readable-stream": {
@@ -17272,13 +17279,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdirp": {
@@ -17287,10 +17294,10 @@
           "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "readable-stream": "^2.0.2",
-            "set-immediate-shim": "^1.0.1"
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "readable-stream": "2.3.6",
+            "set-immediate-shim": "1.0.1"
           }
         },
         "rechoir": {
@@ -17299,7 +17306,7 @@
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "dev": true,
           "requires": {
-            "resolve": "^1.1.6"
+            "resolve": "1.8.1"
           }
         },
         "redent": {
@@ -17308,8 +17315,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "reduce-flatten": {
@@ -17330,7 +17337,7 @@
           "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
           "dev": true,
           "requires": {
-            "regenerate": "^1.4.0"
+            "regenerate": "1.4.0"
           }
         },
         "regenerator-runtime": {
@@ -17345,7 +17352,7 @@
           "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
           "dev": true,
           "requires": {
-            "private": "^0.1.6"
+            "private": "0.1.8"
           }
         },
         "regex-cache": {
@@ -17354,7 +17361,7 @@
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "^0.1.3"
+            "is-equal-shallow": "0.1.3"
           }
         },
         "regex-not": {
@@ -17363,8 +17370,8 @@
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "regexpu-core": {
@@ -17373,12 +17380,12 @@
           "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
           "dev": true,
           "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^7.0.0",
-            "regjsgen": "^0.4.0",
-            "regjsparser": "^0.3.0",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.0.2"
+            "regenerate": "1.4.0",
+            "regenerate-unicode-properties": "7.0.0",
+            "regjsgen": "0.4.0",
+            "regjsparser": "0.3.0",
+            "unicode-match-property-ecmascript": "1.0.4",
+            "unicode-match-property-value-ecmascript": "1.0.2"
           }
         },
         "registry-auth-token": {
@@ -17387,8 +17394,8 @@
           "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
           "dev": true,
           "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
+            "rc": "1.2.8",
+            "safe-buffer": "5.1.2"
           }
         },
         "registry-url": {
@@ -17397,7 +17404,7 @@
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
-            "rc": "^1.0.1"
+            "rc": "1.2.8"
           }
         },
         "regjsgen": {
@@ -17412,7 +17419,7 @@
           "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           },
           "dependencies": {
             "jsesc": {
@@ -17453,7 +17460,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "replace-ext": {
@@ -17468,26 +17475,26 @@
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "requirejs": {
@@ -17508,7 +17515,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.5"
           }
         },
         "resolve-dir": {
@@ -17517,8 +17524,8 @@
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
           }
         },
         "resolve-url": {
@@ -17533,8 +17540,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "ret": {
@@ -17549,7 +17556,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "rollup": {
@@ -17559,7 +17566,7 @@
           "dev": true,
           "requires": {
             "@types/estree": "0.0.38",
-            "@types/node": "*"
+            "@types/node": "10.5.0"
           },
           "dependencies": {
             "@types/estree": {
@@ -17582,7 +17589,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "^2.1.0"
+            "is-promise": "2.1.0"
           }
         },
         "rx": {
@@ -17612,7 +17619,7 @@
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
-            "ret": "~0.1.10"
+            "ret": "0.1.15"
           }
         },
         "safer-buffer": {
@@ -17634,11 +17641,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "adm-zip": "~0.4.3",
-            "async": "^2.1.2",
-            "https-proxy-agent": "^2.2.1",
-            "lodash": "^4.16.6",
-            "rimraf": "^2.5.4"
+            "adm-zip": "0.4.11",
+            "async": "2.6.1",
+            "https-proxy-agent": "2.2.1",
+            "lodash": "4.17.10",
+            "rimraf": "2.6.2"
           },
           "dependencies": {
             "agent-base": {
@@ -17648,7 +17655,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "es6-promisify": "^5.0.0"
+                "es6-promisify": "5.0.0"
               }
             },
             "async": {
@@ -17658,7 +17665,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               }
             },
             "debug": {
@@ -17678,8 +17685,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "agent-base": "^4.1.0",
-                "debug": "^3.1.0"
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
               }
             }
           }
@@ -17703,19 +17710,19 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "^2.1.4",
-            "commander": "^2.9.0",
-            "cross-spawn": "^6.0.0",
-            "debug": "^3.0.0",
-            "lodash": "^4.17.4",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
+            "async": "2.6.1",
+            "commander": "2.15.1",
+            "cross-spawn": "6.0.5",
+            "debug": "3.1.0",
+            "lodash": "4.17.10",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
             "progress": "2.0.0",
             "request": "2.87.0",
             "tar-stream": "1.6.1",
-            "urijs": "^1.18.4",
-            "which": "^1.2.12",
-            "yauzl": "^2.5.0"
+            "urijs": "1.19.1",
+            "which": "1.3.1",
+            "yauzl": "2.9.2"
           },
           "dependencies": {
             "async": {
@@ -17725,7 +17732,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               }
             },
             "cross-spawn": {
@@ -17735,11 +17742,11 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
               }
             },
             "debug": {
@@ -17766,7 +17773,7 @@
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
-            "semver": "^5.0.3"
+            "semver": "5.5.0"
           }
         },
         "send": {
@@ -17776,18 +17783,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.4.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           },
           "dependencies": {
             "mime": {
@@ -17804,9 +17811,9 @@
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
           "requires": {
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
             "send": "0.16.2"
           }
         },
@@ -17834,10 +17841,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -17846,7 +17853,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -17869,7 +17876,7 @@
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -17884,9 +17891,9 @@
           "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.2",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
           }
         },
         "signal-exit": {
@@ -17919,14 +17926,14 @@
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.2",
+            "use": "3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -17935,7 +17942,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -17944,7 +17951,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -17955,9 +17962,9 @@
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -17966,7 +17973,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -17975,7 +17982,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -17984,7 +17991,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -17993,9 +18000,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -18018,7 +18025,7 @@
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^3.2.0"
+            "kind-of": "3.2.2"
           }
         },
         "sntp": {
@@ -18027,7 +18034,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "socket.io": {
@@ -18036,12 +18043,12 @@
           "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
           "dev": true,
           "requires": {
-            "debug": "~3.1.0",
-            "engine.io": "~3.2.0",
-            "has-binary2": "~1.0.2",
-            "socket.io-adapter": "~1.1.0",
+            "debug": "3.1.0",
+            "engine.io": "3.2.0",
+            "has-binary2": "1.0.3",
+            "socket.io-adapter": "1.1.1",
             "socket.io-client": "2.1.1",
-            "socket.io-parser": "~3.2.0"
+            "socket.io-parser": "3.2.0"
           },
           "dependencies": {
             "debug": {
@@ -18071,15 +18078,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
-            "engine.io-client": "~3.2.0",
-            "has-binary2": "~1.0.2",
+            "debug": "3.1.0",
+            "engine.io-client": "3.2.1",
+            "has-binary2": "1.0.3",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "~3.2.0",
+            "socket.io-parser": "3.2.0",
             "to-array": "0.1.4"
           },
           "dependencies": {
@@ -18101,7 +18108,7 @@
           "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
+            "debug": "3.1.0",
             "isarray": "2.0.1"
           },
           "dependencies": {
@@ -18128,7 +18135,7 @@
           "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         },
         "sort-keys-length": {
@@ -18137,7 +18144,7 @@
           "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
           "dev": true,
           "requires": {
-            "sort-keys": "^1.0.0"
+            "sort-keys": "1.1.2"
           }
         },
         "source-map": {
@@ -18152,11 +18159,11 @@
           "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
           "dev": true,
           "requires": {
-            "atob": "^2.1.1",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-url": {
@@ -18171,8 +18178,8 @@
           "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
           "dev": true,
           "requires": {
-            "concat-stream": "^1.4.7",
-            "os-shim": "^0.1.2"
+            "concat-stream": "1.6.2",
+            "os-shim": "0.1.3"
           }
         },
         "spdx-correct": {
@@ -18181,8 +18188,8 @@
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -18197,8 +18204,8 @@
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -18213,12 +18220,12 @@
           "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
           "dev": true,
           "requires": {
-            "debug": "^2.6.8",
-            "handle-thing": "^1.2.5",
-            "http-deceiver": "^1.2.7",
-            "safe-buffer": "^5.0.1",
-            "select-hose": "^2.0.0",
-            "spdy-transport": "^2.0.18"
+            "debug": "2.6.9",
+            "handle-thing": "1.2.5",
+            "http-deceiver": "1.2.7",
+            "safe-buffer": "5.1.2",
+            "select-hose": "2.0.0",
+            "spdy-transport": "2.1.0"
           }
         },
         "spdy-transport": {
@@ -18227,13 +18234,13 @@
           "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
           "dev": true,
           "requires": {
-            "debug": "^2.6.8",
-            "detect-node": "^2.0.3",
-            "hpack.js": "^2.1.6",
-            "obuf": "^1.1.1",
-            "readable-stream": "^2.2.9",
-            "safe-buffer": "^5.0.1",
-            "wbuf": "^1.7.2"
+            "debug": "2.6.9",
+            "detect-node": "2.0.3",
+            "hpack.js": "2.1.6",
+            "obuf": "1.1.2",
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2",
+            "wbuf": "1.7.3"
           }
         },
         "split-string": {
@@ -18242,7 +18249,7 @@
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.0"
+            "extend-shallow": "3.0.2"
           }
         },
         "sprintf-js": {
@@ -18257,15 +18264,15 @@
           "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "dev": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
           }
         },
         "stable": {
@@ -18286,8 +18293,8 @@
           "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.1",
-            "lodash": "^3.0.0"
+            "chalk": "1.1.3",
+            "lodash": "3.10.1"
           },
           "dependencies": {
             "lodash": {
@@ -18304,8 +18311,8 @@
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -18314,7 +18321,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -18331,7 +18338,7 @@
           "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
           "dev": true,
           "requires": {
-            "emitter-component": "^1.1.1"
+            "emitter-component": "1.1.1"
           }
         },
         "stream-consume": {
@@ -18364,9 +18371,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -18375,7 +18382,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "stringstream": {
@@ -18390,7 +18397,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
@@ -18399,7 +18406,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-bom-stream": {
@@ -18408,8 +18415,8 @@
           "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
           "dev": true,
           "requires": {
-            "first-chunk-stream": "^1.0.0",
-            "strip-bom": "^2.0.0"
+            "first-chunk-stream": "1.0.0",
+            "strip-bom": "2.0.0"
           }
         },
         "strip-eof": {
@@ -18424,7 +18431,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "strip-json-comments": {
@@ -18445,16 +18452,16 @@
           "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
           "dev": true,
           "requires": {
-            "dom-urls": "^1.1.0",
-            "es6-promise": "^4.0.5",
-            "glob": "^7.1.1",
-            "lodash.defaults": "^4.2.0",
-            "lodash.template": "^4.4.0",
-            "meow": "^3.7.0",
-            "mkdirp": "^0.5.1",
-            "pretty-bytes": "^4.0.2",
-            "sw-toolbox": "^3.4.0",
-            "update-notifier": "^2.3.0"
+            "dom-urls": "1.1.0",
+            "es6-promise": "4.2.4",
+            "glob": "7.1.2",
+            "lodash.defaults": "4.2.0",
+            "lodash.template": "4.4.0",
+            "meow": "3.7.0",
+            "mkdirp": "0.5.1",
+            "pretty-bytes": "4.0.2",
+            "sw-toolbox": "3.6.0",
+            "update-notifier": "2.5.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -18463,7 +18470,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "chalk": {
@@ -18472,9 +18479,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -18483,7 +18490,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             },
             "update-notifier": {
@@ -18492,16 +18499,16 @@
               "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
               "dev": true,
               "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.3.0",
+                "chalk": "2.4.1",
+                "configstore": "3.1.2",
+                "import-lazy": "2.1.0",
+                "is-ci": "1.1.0",
+                "is-installed-globally": "0.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
               }
             }
           }
@@ -18512,8 +18519,8 @@
           "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
           "dev": true,
           "requires": {
-            "path-to-regexp": "^1.0.1",
-            "serviceworker-cache-polyfill": "^4.0.0"
+            "path-to-regexp": "1.7.0",
+            "serviceworker-cache-polyfill": "4.0.0"
           }
         },
         "symbol-observable": {
@@ -18528,11 +18535,11 @@
           "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0",
-            "deep-extend": "~0.6.0",
-            "lodash.padend": "^4.6.1",
-            "typical": "^2.6.1",
-            "wordwrapjs": "^3.0.0"
+            "array-back": "2.0.0",
+            "deep-extend": "0.6.0",
+            "lodash.padend": "4.6.1",
+            "typical": "2.6.1",
+            "wordwrapjs": "3.0.0"
           },
           "dependencies": {
             "deep-extend": {
@@ -18549,10 +18556,10 @@
           "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
           "dev": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pump": "^1.0.0",
-            "tar-stream": "^1.1.2"
+            "chownr": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pump": "1.0.3",
+            "tar-stream": "1.6.1"
           },
           "dependencies": {
             "pump": {
@@ -18561,8 +18568,8 @@
               "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             }
           }
@@ -18573,13 +18580,13 @@
           "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
           "dev": true,
           "requires": {
-            "bl": "^1.0.0",
-            "buffer-alloc": "^1.1.0",
-            "end-of-stream": "^1.0.0",
-            "fs-constants": "^1.0.0",
-            "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.0",
-            "xtend": "^4.0.0"
+            "bl": "1.2.2",
+            "buffer-alloc": "1.2.0",
+            "end-of-stream": "1.4.1",
+            "fs-constants": "1.0.0",
+            "readable-stream": "2.3.6",
+            "to-buffer": "1.1.1",
+            "xtend": "4.0.1"
           }
         },
         "temp": {
@@ -18588,8 +18595,8 @@
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "^1.0.0",
-            "rimraf": "~2.2.6"
+            "os-tmpdir": "1.0.2",
+            "rimraf": "2.2.8"
           },
           "dependencies": {
             "rimraf": {
@@ -18606,7 +18613,7 @@
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0"
+            "execa": "0.7.0"
           }
         },
         "ternary-stream": {
@@ -18615,10 +18622,10 @@
           "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.5.0",
-            "fork-stream": "^0.0.4",
-            "merge-stream": "^1.0.0",
-            "through2": "^2.0.1"
+            "duplexify": "3.6.0",
+            "fork-stream": "0.0.4",
+            "merge-stream": "1.0.1",
+            "through2": "2.0.3"
           }
         },
         "test-value": {
@@ -18627,8 +18634,8 @@
           "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
           "dev": true,
           "requires": {
-            "array-back": "^2.0.0",
-            "typical": "^2.6.1"
+            "array-back": "2.0.0",
+            "typical": "2.6.1"
           }
         },
         "text-encoding": {
@@ -18655,7 +18662,7 @@
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
           "dev": true,
           "requires": {
-            "any-promise": "^1.0.0"
+            "any-promise": "1.3.0"
           }
         },
         "thenify-all": {
@@ -18664,7 +18671,7 @@
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
           "dev": true,
           "requires": {
-            "thenify": ">= 3.1.0 < 4"
+            "thenify": "3.3.0"
           }
         },
         "through": {
@@ -18679,8 +18686,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         },
         "through2-filter": {
@@ -18689,8 +18696,8 @@
           "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
           "dev": true,
           "requires": {
-            "through2": "~2.0.0",
-            "xtend": "~4.0.0"
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
           }
         },
         "timed-out": {
@@ -18705,7 +18712,7 @@
           "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1"
+            "extend-shallow": "2.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -18714,7 +18721,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -18743,7 +18750,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "to-regex": {
@@ -18752,10 +18759,10 @@
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "to-regex-range": {
@@ -18764,8 +18771,8 @@
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           },
           "dependencies": {
             "is-number": {
@@ -18774,7 +18781,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               }
             }
           }
@@ -18785,7 +18792,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           },
           "dependencies": {
             "punycode": {
@@ -18802,7 +18809,7 @@
           "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
           "dev": true,
           "requires": {
-            "punycode": "^2.1.0"
+            "punycode": "2.1.1"
           }
         },
         "trim-newlines": {
@@ -18823,7 +18830,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "tweetnacl": {
@@ -18846,7 +18853,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "~2.1.18"
+            "mime-types": "2.1.18"
           }
         },
         "typedarray": {
@@ -18873,8 +18880,8 @@
           "integrity": "sha512-/kVQDzwiE9Vy7Y63eMkMozF4jIt0C2+xHctF9YpqNWdE/NLOuMurshkpoYGUlAbeYhACPv0HJPIHJul0Ak4/uw==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -18903,8 +18910,8 @@
           "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
           "dev": true,
           "requires": {
-            "sprintf-js": "^1.0.3",
-            "util-deprecate": "^1.0.2"
+            "sprintf-js": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "unicode-canonical-property-names-ecmascript": {
@@ -18919,8 +18926,8 @@
           "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
           "dev": true,
           "requires": {
-            "unicode-canonical-property-names-ecmascript": "^1.0.4",
-            "unicode-property-aliases-ecmascript": "^1.0.4"
+            "unicode-canonical-property-names-ecmascript": "1.0.4",
+            "unicode-property-aliases-ecmascript": "1.0.4"
           }
         },
         "unicode-match-property-value-ecmascript": {
@@ -18941,10 +18948,10 @@
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -18953,7 +18960,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "set-value": {
@@ -18962,10 +18969,10 @@
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
               }
             }
           }
@@ -18976,8 +18983,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "unique-string": {
@@ -18986,7 +18993,7 @@
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
@@ -19001,8 +19008,8 @@
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "has-value": {
@@ -19011,9 +19018,9 @@
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
               },
               "dependencies": {
                 "isobject": {
@@ -19047,7 +19054,7 @@
           "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         },
         "unzip-response": {
@@ -19062,14 +19069,14 @@
           "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
           "dev": true,
           "requires": {
-            "boxen": "^0.6.0",
-            "chalk": "^1.0.0",
-            "configstore": "^2.0.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^2.0.0",
-            "lazy-req": "^1.1.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^2.0.0"
+            "boxen": "0.6.0",
+            "chalk": "1.1.3",
+            "configstore": "2.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "2.0.0",
+            "lazy-req": "1.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "2.0.0"
           },
           "dependencies": {
             "ansi-align": {
@@ -19078,7 +19085,7 @@
               "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1"
+                "string-width": "1.0.2"
               }
             },
             "boxen": {
@@ -19087,15 +19094,15 @@
               "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
               "dev": true,
               "requires": {
-                "ansi-align": "^1.1.0",
-                "camelcase": "^2.1.0",
-                "chalk": "^1.1.1",
-                "cli-boxes": "^1.0.0",
-                "filled-array": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "repeating": "^2.0.0",
-                "string-width": "^1.0.1",
-                "widest-line": "^1.0.0"
+                "ansi-align": "1.1.0",
+                "camelcase": "2.1.1",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "filled-array": "1.1.0",
+                "object-assign": "4.1.1",
+                "repeating": "2.0.1",
+                "string-width": "1.0.2",
+                "widest-line": "1.0.0"
               }
             },
             "configstore": {
@@ -19104,15 +19111,15 @@
               "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
               "dev": true,
               "requires": {
-                "dot-prop": "^3.0.0",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.1",
-                "os-tmpdir": "^1.0.0",
-                "osenv": "^0.1.0",
-                "uuid": "^2.0.1",
-                "write-file-atomic": "^1.1.2",
-                "xdg-basedir": "^2.0.0"
+                "dot-prop": "3.0.0",
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "os-tmpdir": "1.0.2",
+                "osenv": "0.1.5",
+                "uuid": "2.0.3",
+                "write-file-atomic": "1.3.4",
+                "xdg-basedir": "2.0.0"
               }
             },
             "dot-prop": {
@@ -19121,7 +19128,7 @@
               "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
               "dev": true,
               "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
               }
             },
             "got": {
@@ -19130,21 +19137,21 @@
               "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
               "dev": true,
               "requires": {
-                "create-error-class": "^3.0.1",
-                "duplexer2": "^0.1.4",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "node-status-codes": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "parse-json": "^2.1.0",
-                "pinkie-promise": "^2.0.0",
-                "read-all-stream": "^3.0.0",
-                "readable-stream": "^2.0.5",
-                "timed-out": "^3.0.0",
-                "unzip-response": "^1.0.2",
-                "url-parse-lax": "^1.0.0"
+                "create-error-class": "3.0.2",
+                "duplexer2": "0.1.4",
+                "is-redirect": "1.0.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "lowercase-keys": "1.0.1",
+                "node-status-codes": "1.0.0",
+                "object-assign": "4.1.1",
+                "parse-json": "2.2.0",
+                "pinkie-promise": "2.0.1",
+                "read-all-stream": "3.1.0",
+                "readable-stream": "2.3.6",
+                "timed-out": "3.1.3",
+                "unzip-response": "1.0.2",
+                "url-parse-lax": "1.0.0"
               }
             },
             "latest-version": {
@@ -19153,7 +19160,7 @@
               "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
               "dev": true,
               "requires": {
-                "package-json": "^2.0.0"
+                "package-json": "2.4.0"
               }
             },
             "package-json": {
@@ -19162,10 +19169,10 @@
               "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
               "dev": true,
               "requires": {
-                "got": "^5.0.0",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
+                "got": "5.7.1",
+                "registry-auth-token": "3.3.2",
+                "registry-url": "3.1.0",
+                "semver": "5.5.0"
               }
             },
             "timed-out": {
@@ -19192,7 +19199,7 @@
               "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1"
+                "string-width": "1.0.2"
               }
             },
             "write-file-atomic": {
@@ -19201,9 +19208,9 @@
               "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
               }
             },
             "xdg-basedir": {
@@ -19212,7 +19219,7 @@
               "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
               "dev": true,
               "requires": {
-                "os-homedir": "^1.0.0"
+                "os-homedir": "1.0.2"
               }
             }
           }
@@ -19241,7 +19248,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         },
         "url-to-options": {
@@ -19256,7 +19263,7 @@
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.2"
+            "kind-of": "6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19297,9 +19304,9 @@
           "integrity": "sha1-j/dffaafc+fFEFiDYhMFCLesZE4=",
           "dev": true,
           "requires": {
-            "is-potential-custom-element-name": "^1.0.0",
-            "log-symbols": "^1.0.0",
-            "meow": "^3.7.0"
+            "is-potential-custom-element-name": "1.0.0",
+            "log-symbols": "1.0.2",
+            "meow": "3.7.0"
           }
         },
         "validate-npm-package-license": {
@@ -19308,8 +19315,8 @@
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "vargs": {
@@ -19330,9 +19337,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           }
         },
         "vinyl": {
@@ -19341,8 +19348,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           },
           "dependencies": {
@@ -19360,12 +19367,12 @@
           "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.3.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^2.0.0",
-            "vinyl": "^1.1.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "2.0.0",
+            "vinyl": "1.2.0"
           },
           "dependencies": {
             "first-chunk-stream": {
@@ -19374,7 +19381,7 @@
               "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
               "dev": true,
               "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
               }
             },
             "strip-bom-stream": {
@@ -19383,8 +19390,8 @@
               "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
               "dev": true,
               "requires": {
-                "first-chunk-stream": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "2.0.0",
+                "strip-bom": "2.0.0"
               }
             }
           }
@@ -19395,23 +19402,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.6.0",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.6",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         },
         "vlq": {
@@ -19432,7 +19439,7 @@
           "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
           "dev": true,
           "requires": {
-            "minimalistic-assert": "^1.0.0"
+            "minimalistic-assert": "1.0.1"
           }
         },
         "wct-local": {
@@ -19442,17 +19449,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@types/express": "^4.0.30",
-            "@types/freeport": "^1.0.19",
-            "@types/launchpad": "^0.6.0",
-            "@types/node": "^9.3.0",
-            "@types/which": "^1.3.1",
-            "chalk": "^2.3.0",
-            "cleankill": "^2.0.0",
-            "freeport": "^1.0.4",
-            "launchpad": "^0.7.0",
-            "selenium-standalone": "^6.7.0",
-            "which": "^1.0.8"
+            "@types/express": "4.16.0",
+            "@types/freeport": "1.0.21",
+            "@types/launchpad": "0.6.0",
+            "@types/node": "9.6.22",
+            "@types/which": "1.3.1",
+            "chalk": "2.4.1",
+            "cleankill": "2.0.0",
+            "freeport": "1.0.5",
+            "launchpad": "0.7.0",
+            "selenium-standalone": "6.15.1",
+            "which": "1.3.1"
           },
           "dependencies": {
             "@types/node": {
@@ -19469,7 +19476,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "chalk": {
@@ -19479,9 +19486,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -19491,7 +19498,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19503,13 +19510,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "cleankill": "^2.0.0",
-            "lodash": "^4.17.10",
-            "request": "^2.85.0",
-            "sauce-connect-launcher": "^1.0.0",
-            "temp": "^0.8.1",
-            "uuid": "^3.2.1"
+            "chalk": "2.4.1",
+            "cleankill": "2.0.0",
+            "lodash": "4.17.10",
+            "request": "2.87.0",
+            "sauce-connect-launcher": "1.2.4",
+            "temp": "0.8.3",
+            "uuid": "3.3.2"
           },
           "dependencies": {
             "ansi-styles": {
@@ -19519,7 +19526,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "chalk": {
@@ -19529,9 +19536,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "supports-color": {
@@ -19541,7 +19548,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19555,7 +19562,7 @@
             "archiver": "2.1.1",
             "async": "2.0.1",
             "lodash": "4.17.10",
-            "mkdirp": "^0.5.1",
+            "mkdirp": "0.5.1",
             "q": "1.4.1",
             "request": "2.85.0",
             "underscore.string": "3.3.4",
@@ -19568,7 +19575,7 @@
               "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
               "dev": true,
               "requires": {
-                "lodash": "^4.8.0"
+                "lodash": "4.17.10"
               }
             },
             "q": {
@@ -19583,28 +19590,28 @@
               "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
               "dev": true,
               "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "stringstream": "~0.0.5",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.2",
+                "stringstream": "0.0.6",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
               }
             }
           }
@@ -19615,35 +19622,35 @@
           "integrity": "sha512-i/N0MYLBh9fjzI4pcKvfYiTx4JEr+Zbt2m1/ANovpvT74El55WaiFyiwCdUGhnlX1xy1URGUB2CJgl6gdTBumg==",
           "dev": true,
           "requires": {
-            "@polymer/sinonjs": "^1.14.1",
-            "@polymer/test-fixture": "^0.0.3",
-            "@webcomponents/webcomponentsjs": "^1.0.7",
-            "accessibility-developer-tools": "^2.12.0",
-            "async": "^2.4.1",
-            "body-parser": "^1.17.2",
-            "bower-config": "^1.4.0",
-            "chai": "^4.0.2",
-            "chalk": "^1.1.3",
-            "cleankill": "^2.0.0",
-            "express": "^4.15.3",
-            "findup-sync": "^2.0.0",
-            "glob": "^7.1.2",
-            "lodash": "^3.10.1",
-            "multer": "^1.3.0",
-            "nomnom": "^1.8.1",
-            "polyserve": "^0.27.11",
-            "resolve": "^1.5.0",
-            "semver": "^5.3.0",
-            "send": "^0.11.1",
-            "server-destroy": "^1.0.1",
-            "sinon": "^2.3.5",
-            "sinon-chai": "^2.10.0",
-            "socket.io": "^2.0.3",
-            "stacky": "^1.3.1",
-            "update-notifier": "^2.2.0",
-            "wct-local": "^2.1.1",
-            "wct-sauce": "^2.0.2",
-            "wd": "^1.2.0"
+            "@polymer/sinonjs": "1.17.1",
+            "@polymer/test-fixture": "0.0.3",
+            "@webcomponents/webcomponentsjs": "1.2.2",
+            "accessibility-developer-tools": "2.12.0",
+            "async": "2.6.1",
+            "body-parser": "1.18.2",
+            "bower-config": "1.4.1",
+            "chai": "4.1.2",
+            "chalk": "1.1.3",
+            "cleankill": "2.0.0",
+            "express": "4.16.3",
+            "findup-sync": "2.0.0",
+            "glob": "7.1.2",
+            "lodash": "3.10.1",
+            "multer": "1.3.1",
+            "nomnom": "1.8.1",
+            "polyserve": "0.27.12",
+            "resolve": "1.8.1",
+            "semver": "5.5.0",
+            "send": "0.11.1",
+            "server-destroy": "1.0.1",
+            "sinon": "2.4.1",
+            "sinon-chai": "2.14.0",
+            "socket.io": "2.1.1",
+            "stacky": "1.3.1",
+            "update-notifier": "2.5.0",
+            "wct-local": "2.1.1",
+            "wct-sauce": "2.0.3",
+            "wd": "1.10.1"
           },
           "dependencies": {
             "ansi-styles": {
@@ -19653,7 +19660,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "arr-diff": {
@@ -19674,7 +19681,7 @@
               "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "dev": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               },
               "dependencies": {
                 "lodash": {
@@ -19691,16 +19698,16 @@
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -19709,7 +19716,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -19720,12 +19727,12 @@
               "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
               "dev": true,
               "requires": {
-                "assertion-error": "^1.0.1",
-                "check-error": "^1.0.1",
-                "deep-eql": "^3.0.0",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.0.0",
-                "type-detect": "^4.0.0"
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
               }
             },
             "depd": {
@@ -19773,13 +19780,13 @@
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -19788,7 +19795,7 @@
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^0.1.0"
+                    "is-descriptor": "0.1.6"
                   }
                 },
                 "extend-shallow": {
@@ -19797,7 +19804,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -19806,7 +19813,7 @@
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -19815,7 +19822,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -19826,7 +19833,7 @@
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -19835,7 +19842,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -19846,9 +19853,9 @@
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
                   }
                 },
                 "kind-of": {
@@ -19865,7 +19872,7 @@
               "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
               "dev": true,
               "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
               }
             },
             "extglob": {
@@ -19874,14 +19881,14 @@
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -19890,7 +19897,7 @@
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^1.0.0"
+                    "is-descriptor": "1.0.2"
                   }
                 },
                 "extend-shallow": {
@@ -19899,7 +19906,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -19910,10 +19917,10 @@
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -19922,7 +19929,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -19933,10 +19940,10 @@
               "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
               "dev": true,
               "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
               }
             },
             "fresh": {
@@ -19951,9 +19958,9 @@
               "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
               "dev": true,
               "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
+                "global-prefix": "1.0.2",
+                "is-windows": "1.0.2",
+                "resolve-dir": "1.0.1"
               }
             },
             "global-prefix": {
@@ -19962,11 +19969,11 @@
               "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
               "dev": true,
               "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
+                "expand-tilde": "2.0.2",
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "1.0.2",
+                "which": "1.3.1"
               }
             },
             "is-accessor-descriptor": {
@@ -19975,7 +19982,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -19984,7 +19991,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -19993,9 +20000,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-extglob": {
@@ -20010,7 +20017,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             },
             "is-number": {
@@ -20019,7 +20026,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -20028,7 +20035,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -20063,19 +20070,19 @@
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               }
             },
             "mime": {
@@ -20111,8 +20118,8 @@
               "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
               "dev": true,
               "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
               }
             },
             "send": {
@@ -20121,16 +20128,16 @@
               "integrity": "sha1-G+q/1C+eJwn5kCivMHisErRwktU=",
               "dev": true,
               "requires": {
-                "debug": "~2.1.1",
-                "depd": "~1.0.0",
+                "debug": "2.1.3",
+                "depd": "1.0.1",
                 "destroy": "1.0.3",
                 "escape-html": "1.0.1",
-                "etag": "~1.5.1",
+                "etag": "1.5.1",
                 "fresh": "0.2.4",
                 "mime": "1.2.11",
                 "ms": "0.7.0",
-                "on-finished": "~2.2.0",
-                "range-parser": "~1.0.2"
+                "on-finished": "2.2.1",
+                "range-parser": "1.0.3"
               },
               "dependencies": {
                 "debug": {
@@ -20150,14 +20157,14 @@
               "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
               "dev": true,
               "requires": {
-                "diff": "^3.1.0",
+                "diff": "3.5.0",
                 "formatio": "1.2.0",
-                "lolex": "^1.6.0",
-                "native-promise-only": "^0.8.1",
-                "path-to-regexp": "^1.7.0",
-                "samsam": "^1.1.3",
+                "lolex": "1.6.0",
+                "native-promise-only": "0.8.1",
+                "path-to-regexp": "1.7.0",
+                "samsam": "1.3.0",
                 "text-encoding": "0.6.4",
-                "type-detect": "^4.0.0"
+                "type-detect": "4.0.8"
               }
             },
             "supports-color": {
@@ -20167,7 +20174,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             },
             "update-notifier": {
@@ -20177,16 +20184,16 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.3.0",
+                "chalk": "2.4.1",
+                "configstore": "3.1.2",
+                "import-lazy": "2.1.0",
+                "is-ci": "1.1.0",
+                "is-installed-globally": "0.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "chalk": {
@@ -20196,9 +20203,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "ansi-styles": "^3.2.1",
-                    "escape-string-regexp": "^1.0.5",
-                    "supports-color": "^5.3.0"
+                    "ansi-styles": "3.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "5.4.0"
                   }
                 }
               }
@@ -20217,9 +20224,9 @@
           "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
           }
         },
         "which": {
@@ -20228,7 +20235,7 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "widest-line": {
@@ -20237,7 +20244,7 @@
           "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -20258,8 +20265,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
               }
             },
             "strip-ansi": {
@@ -20268,7 +20275,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -20279,12 +20286,12 @@
           "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
           "dev": true,
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "stack-trace": "0.0.10"
           }
         },
         "wordwrap": {
@@ -20299,8 +20306,8 @@
           "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
           "dev": true,
           "requires": {
-            "reduce-flatten": "^1.0.1",
-            "typical": "^2.6.1"
+            "reduce-flatten": "1.0.1",
+            "typical": "2.6.1"
           }
         },
         "wrappy": {
@@ -20315,9 +20322,9 @@
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         },
         "ws": {
@@ -20326,9 +20333,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         },
         "xdg-basedir": {
@@ -20376,8 +20383,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.1.0"
+            "buffer-crc32": "0.2.13",
+            "fd-slicer": "1.1.0"
           }
         },
         "yeast": {
@@ -20392,18 +20399,18 @@
           "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0",
-            "debug": "^2.0.0",
-            "diff": "^2.1.2",
-            "escape-string-regexp": "^1.0.2",
-            "globby": "^4.0.0",
-            "grouped-queue": "^0.3.0",
-            "inquirer": "^1.0.2",
-            "lodash": "^4.11.1",
-            "log-symbols": "^1.0.1",
-            "mem-fs": "^1.1.0",
-            "text-table": "^0.2.0",
-            "untildify": "^2.0.0"
+            "chalk": "1.1.3",
+            "debug": "2.6.9",
+            "diff": "2.2.3",
+            "escape-string-regexp": "1.0.5",
+            "globby": "4.1.0",
+            "grouped-queue": "0.3.3",
+            "inquirer": "1.2.3",
+            "lodash": "4.17.10",
+            "log-symbols": "1.0.2",
+            "mem-fs": "1.1.3",
+            "text-table": "0.2.0",
+            "untildify": "2.1.0"
           },
           "dependencies": {
             "diff": {
@@ -20418,11 +20425,11 @@
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "globby": {
@@ -20431,12 +20438,12 @@
               "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
               "dev": true,
               "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^6.0.1",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "6.0.4",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -20447,31 +20454,31 @@
           "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
           "dev": true,
           "requires": {
-            "async": "^2.6.0",
-            "chalk": "^2.3.0",
-            "cli-table": "^0.3.1",
-            "cross-spawn": "^6.0.5",
-            "dargs": "^5.1.0",
-            "dateformat": "^3.0.3",
-            "debug": "^3.1.0",
-            "detect-conflict": "^1.0.0",
-            "error": "^7.0.2",
-            "find-up": "^2.1.0",
-            "github-username": "^4.0.0",
-            "istextorbinary": "^2.2.1",
-            "lodash": "^4.17.10",
-            "make-dir": "^1.1.0",
-            "mem-fs-editor": "^4.0.0",
-            "minimist": "^1.2.0",
-            "pretty-bytes": "^4.0.2",
-            "read-chunk": "^2.1.0",
-            "read-pkg-up": "^3.0.0",
-            "rimraf": "^2.6.2",
-            "run-async": "^2.0.0",
-            "shelljs": "^0.8.0",
-            "text-table": "^0.2.0",
-            "through2": "^2.0.0",
-            "yeoman-environment": "^2.0.5"
+            "async": "2.6.1",
+            "chalk": "2.4.1",
+            "cli-table": "0.3.1",
+            "cross-spawn": "6.0.5",
+            "dargs": "5.1.0",
+            "dateformat": "3.0.3",
+            "debug": "3.1.0",
+            "detect-conflict": "1.0.1",
+            "error": "7.0.2",
+            "find-up": "2.1.0",
+            "github-username": "4.1.0",
+            "istextorbinary": "2.2.1",
+            "lodash": "4.17.10",
+            "make-dir": "1.3.0",
+            "mem-fs-editor": "4.0.2",
+            "minimist": "1.2.0",
+            "pretty-bytes": "4.0.2",
+            "read-chunk": "2.1.0",
+            "read-pkg-up": "3.0.0",
+            "rimraf": "2.6.2",
+            "run-async": "2.3.0",
+            "shelljs": "0.8.2",
+            "text-table": "0.2.0",
+            "through2": "2.0.3",
+            "yeoman-environment": "2.3.0"
           },
           "dependencies": {
             "ansi-escapes": {
@@ -20492,7 +20499,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
               }
             },
             "async": {
@@ -20501,7 +20508,7 @@
               "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
               "dev": true,
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.10"
               }
             },
             "chalk": {
@@ -20510,9 +20517,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "cli-cursor": {
@@ -20521,7 +20528,7 @@
               "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
               "dev": true,
               "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
               }
             },
             "cross-spawn": {
@@ -20530,11 +20537,11 @@
               "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
               }
             },
             "debug": {
@@ -20552,9 +20559,9 @@
               "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
               "dev": true,
               "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.19",
+                "tmp": "0.0.33"
               }
             },
             "figures": {
@@ -20563,7 +20570,7 @@
               "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
               "dev": true,
               "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
               }
             },
             "find-up": {
@@ -20572,7 +20579,7 @@
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
               }
             },
             "inquirer": {
@@ -20581,19 +20588,19 @@
               "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
               "dev": true,
               "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.1.0",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^5.5.2",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rxjs": "5.5.11",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
               }
             },
             "is-fullwidth-code-point": {
@@ -20608,10 +20615,10 @@
               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
               }
             },
             "log-symbols": {
@@ -20620,7 +20627,7 @@
               "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
               "dev": true,
               "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "2.4.1"
               }
             },
             "mute-stream": {
@@ -20635,7 +20642,7 @@
               "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
               "dev": true,
               "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
               }
             },
             "parse-json": {
@@ -20644,8 +20651,8 @@
               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "dev": true,
               "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "1.3.2",
+                "json-parse-better-errors": "1.0.2"
               }
             },
             "path-type": {
@@ -20654,7 +20661,7 @@
               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "dev": true,
               "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
               }
             },
             "pify": {
@@ -20669,9 +20676,9 @@
               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
               "dev": true,
               "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "3.0.0"
               }
             },
             "read-pkg-up": {
@@ -20680,8 +20687,8 @@
               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
               "dev": true,
               "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "2.1.0",
+                "read-pkg": "3.0.0"
               }
             },
             "restore-cursor": {
@@ -20690,8 +20697,8 @@
               "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
               "dev": true,
               "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
               }
             },
             "string-width": {
@@ -20700,8 +20707,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
               }
             },
             "strip-ansi": {
@@ -20710,7 +20717,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "strip-bom": {
@@ -20725,7 +20732,7 @@
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             },
             "tmp": {
@@ -20734,7 +20741,7 @@
               "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
               "dev": true,
               "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
               }
             },
             "untildify": {
@@ -20749,21 +20756,21 @@
               "integrity": "sha512-PHSAkVOqYdcR+C+Uht1SGC4eVD/9OhygYFkYaI66xF8vKIeS1RNYay+umj2ZrQeJ50tF5Q/RSO6qGDz9y3Ifug==",
               "dev": true,
               "requires": {
-                "chalk": "^2.1.0",
-                "cross-spawn": "^6.0.5",
-                "debug": "^3.1.0",
-                "diff": "^3.3.1",
-                "escape-string-regexp": "^1.0.2",
-                "globby": "^8.0.1",
-                "grouped-queue": "^0.3.3",
-                "inquirer": "^5.2.0",
-                "is-scoped": "^1.0.0",
-                "lodash": "^4.17.10",
-                "log-symbols": "^2.1.0",
-                "mem-fs": "^1.1.0",
-                "strip-ansi": "^4.0.0",
-                "text-table": "^0.2.0",
-                "untildify": "^3.0.2"
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "globby": "8.0.1",
+                "grouped-queue": "0.3.3",
+                "inquirer": "5.2.0",
+                "is-scoped": "1.0.0",
+                "lodash": "4.17.10",
+                "log-symbols": "2.2.0",
+                "mem-fs": "1.1.3",
+                "strip-ansi": "4.0.0",
+                "text-table": "0.2.0",
+                "untildify": "3.0.3"
               }
             }
           }
@@ -20774,12 +20781,26 @@
           "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
           "dev": true,
           "requires": {
-            "archiver-utils": "^1.3.0",
-            "compress-commons": "^1.2.0",
-            "lodash": "^4.8.0",
-            "readable-stream": "^2.0.0"
+            "archiver-utils": "1.3.0",
+            "compress-commons": "1.2.2",
+            "lodash": "4.17.10",
+            "readable-stream": "2.3.6"
           }
         }
+      }
+    },
+    "polymer-css-build": {
+      "version": "0.3.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/polymer-css-build/-/polymer-css-build-0.3.0-alpha.7.tgz",
+      "integrity": "sha512-T3gOgGnEsCWk84aus5I5n3GAF6e7021g6MJ5mxb6nJ68pn7LuhRMIA5a1y7zwcNQLzdlkK5FMrDAZZfQUPxPyw==",
+      "dev": true,
+      "requires": {
+        "@webcomponents/shadycss": "1.4.0",
+        "command-line-args": "5.0.2",
+        "command-line-usage": "5.0.5",
+        "dom5": "3.0.1",
+        "esm": "3.0.74",
+        "polymer-analyzer": "2.7.0"
       }
     },
     "polymer-project-config": {
@@ -20788,17 +20809,17 @@
       "integrity": "sha512-nnxLkbpYYPIVBYooeercovQIWqq4coHzQ5PwK2+NxNpVWUJ5tW3OCDt46dqw3CtJNe4r/qIOkPgBJdVwXAAEmw==",
       "dev": true,
       "requires": {
-        "@types/node": "^9.6.4",
-        "browser-capabilities": "^1.0.0",
-        "jsonschema": "^1.1.1",
-        "minimatch-all": "^1.1.0",
-        "plylog": "^0.5.0"
+        "@types/node": "9.6.26",
+        "browser-capabilities": "1.1.1",
+        "jsonschema": "1.2.4",
+        "minimatch-all": "1.1.0",
+        "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz",
-          "integrity": "sha512-o5K0mt8x735EaqS7F2x+5AG0b1Mt3V9jgV5SeW8SD6RNhE++dvwqLf2R2e4c8FmhNLaogz2oXrsiXnqnsBSSIQ==",
+          "version": "9.6.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.26.tgz",
+          "integrity": "sha512-3LKKscYUZdZreOuvnly8oWsCA1TOWtmkV3mbcUnV34f+nqDWJic+4SGjRi1C/sPHnZcSs/x209O+Dgy8aWHt2A==",
           "dev": true
         }
       }
@@ -20845,7 +20866,7 @@
       "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
       "dev": true,
       "requires": {
-        "clipboard": "^2.0.0"
+        "clipboard": "2.0.1"
       }
     },
     "private": {
@@ -20878,8 +20899,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -20888,9 +20909,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.6.0",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -20900,14 +20921,14 @@
       "dev": true
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -20924,10 +20945,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -20944,9 +20965,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -20955,8 +20976,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -20965,13 +20986,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -20980,10 +21001,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "rechoir": {
@@ -20992,7 +21013,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.8.1"
       }
     },
     "redent": {
@@ -21001,8 +21022,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       },
       "dependencies": {
         "strip-indent": {
@@ -21011,7 +21032,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         }
       }
@@ -21034,7 +21055,7 @@
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -21049,7 +21070,7 @@
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -21058,7 +21079,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -21067,8 +21088,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpp": {
@@ -21083,12 +21104,12 @@
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "registry-auth-token": {
@@ -21097,8 +21118,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -21107,7 +21128,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -21122,7 +21143,7 @@
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -21145,8 +21166,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5",
-        "is-utf8": "^0.2.1"
+        "is-buffer": "1.1.6",
+        "is-utf8": "0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -21155,9 +21176,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "^3.0.0",
-        "safe-buffer": "^5.1.0",
-        "through2": "^2.0.3"
+        "remove-bom-buffer": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "through2": "2.0.3"
       }
     },
     "remove-trailing-separator": {
@@ -21184,7 +21205,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -21199,9 +21220,9 @@
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1",
-        "is-absolute": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0"
+        "homedir-polyfill": "1.0.1",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "replacestream": {
@@ -21210,9 +21231,9 @@
       "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.3",
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.2"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "require-directory": {
@@ -21233,8 +21254,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -21243,7 +21264,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-dir": {
@@ -21252,8 +21273,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -21268,7 +21289,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "^3.0.0"
+        "value-or-function": "3.0.0"
       }
     },
     "resolve-url": {
@@ -21283,8 +21304,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -21299,7 +21320,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "rollup": {
@@ -21309,7 +21330,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "*"
+        "@types/node": "6.0.116"
       },
       "dependencies": {
         "@types/estree": {
@@ -21326,7 +21347,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -21341,7 +21362,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -21356,7 +21377,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -21390,7 +21411,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "semver-greatest-satisfied-range": {
@@ -21399,7 +21420,7 @@
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "^1.5.0"
+        "sver-compat": "1.5.0"
       }
     },
     "serviceworker-cache-polyfill": {
@@ -21426,10 +21447,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -21438,7 +21459,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -21455,7 +21476,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -21479,7 +21500,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.11.0"
       }
     },
     "sinon-chai": {
@@ -21500,7 +21521,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -21517,14 +21538,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -21542,7 +21563,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -21551,7 +21572,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -21568,9 +21589,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -21579,7 +21600,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -21588,7 +21609,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -21597,7 +21618,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -21606,9 +21627,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -21619,7 +21640,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -21628,7 +21649,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -21645,11 +21666,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -21658,7 +21679,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -21687,8 +21708,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -21703,8 +21724,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -21719,7 +21740,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -21746,8 +21767,8 @@
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "lodash": "^3.0.0"
+        "chalk": "1.1.3",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -21764,8 +21785,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -21774,7 +21795,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -21785,7 +21806,7 @@
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "dev": true,
       "requires": {
-        "emitter-component": "^1.1.1"
+        "emitter-component": "1.1.1"
       }
     },
     "stream-combiner": {
@@ -21794,8 +21815,8 @@
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
+        "duplexer": "0.1.1",
+        "through": "2.3.8"
       }
     },
     "stream-counter": {
@@ -21822,9 +21843,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -21833,7 +21854,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -21842,7 +21863,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -21851,7 +21872,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -21860,8 +21881,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       }
     },
     "strip-eof": {
@@ -21894,8 +21915,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "sw-precache": {
@@ -21904,16 +21925,16 @@
       "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
       "dev": true,
       "requires": {
-        "dom-urls": "^1.1.0",
-        "es6-promise": "^4.0.5",
-        "glob": "^7.1.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.template": "^4.4.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "pretty-bytes": "^4.0.2",
-        "sw-toolbox": "^3.4.0",
-        "update-notifier": "^2.3.0"
+        "dom-urls": "1.1.0",
+        "es6-promise": "4.2.4",
+        "glob": "7.1.2",
+        "lodash.defaults": "4.2.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "pretty-bytes": "4.0.2",
+        "sw-toolbox": "3.6.0",
+        "update-notifier": "2.5.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -21930,8 +21951,8 @@
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "dev": true,
       "requires": {
-        "path-to-regexp": "^1.0.1",
-        "serviceworker-cache-polyfill": "^4.0.0"
+        "path-to-regexp": "1.7.0",
+        "serviceworker-cache-polyfill": "4.0.0"
       }
     },
     "table": {
@@ -21940,12 +21961,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.1",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21960,7 +21981,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -21969,9 +21990,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -21986,8 +22007,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -21996,7 +22017,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -22005,7 +22026,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -22016,11 +22037,11 @@
       "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
+        "array-back": "2.0.0",
+        "deep-extend": "0.6.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
       }
     },
     "term-size": {
@@ -22029,7 +22050,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "ternary-stream": {
@@ -22038,10 +22059,10 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.0",
-        "fork-stream": "^0.0.4",
-        "merge-stream": "^1.0.0",
-        "through2": "^2.0.1"
+        "duplexify": "3.6.0",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "test-value": {
@@ -22050,8 +22071,8 @@
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
+        "array-back": "2.0.0",
+        "typical": "2.6.1"
       }
     },
     "text-table": {
@@ -22072,7 +22093,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "thenify-all": {
@@ -22081,7 +22102,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": ">= 3.1.0 < 4"
+        "thenify": "3.3.0"
       }
     },
     "through": {
@@ -22096,8 +22117,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -22106,8 +22127,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -22135,7 +22156,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -22144,8 +22165,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
+        "is-absolute": "1.0.0",
+        "is-negated-glob": "1.0.0"
       }
     },
     "to-fast-properties": {
@@ -22160,7 +22181,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -22169,7 +22190,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -22180,10 +22201,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -22192,8 +22213,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "to-through": {
@@ -22202,7 +22223,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3"
+        "through2": "2.0.3"
       }
     },
     "tr46": {
@@ -22211,7 +22232,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "trim-newlines": {
@@ -22232,7 +22253,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -22266,13 +22287,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
-      "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+      "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
       "dev": true,
       "requires": {
-        "commander": "~2.16.0",
-        "source-map": "~0.6.1"
+        "commander": "2.16.0",
+        "source-map": "0.6.1"
       }
     },
     "unc-path-regex": {
@@ -22287,15 +22308,15 @@
       "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "bach": "^1.0.0",
-        "collection-map": "^1.0.0",
-        "es6-weak-map": "^2.0.1",
-        "last-run": "^1.1.0",
-        "object.defaults": "^1.0.0",
-        "object.reduce": "^1.0.0",
-        "undertaker-registry": "^1.0.0"
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "bach": "1.2.0",
+        "collection-map": "1.0.0",
+        "es6-weak-map": "2.0.2",
+        "last-run": "1.1.1",
+        "object.defaults": "1.1.0",
+        "object.reduce": "1.0.1",
+        "undertaker-registry": "1.0.1"
       }
     },
     "undertaker-registry": {
@@ -22316,8 +22337,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -22338,10 +22359,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -22350,7 +22371,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -22359,10 +22380,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -22373,8 +22394,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
       }
     },
     "unique-string": {
@@ -22383,7 +22404,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "universalify": {
@@ -22398,8 +22419,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -22408,9 +22429,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -22450,16 +22471,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -22468,7 +22489,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -22477,9 +22498,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "supports-color": {
@@ -22488,7 +22509,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -22517,7 +22538,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "use": {
@@ -22553,7 +22574,7 @@
       "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "vali-date": {
@@ -22563,13 +22584,13 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-or-function": {
@@ -22584,12 +22605,12 @@
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "dev": true,
       "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
+        "clone": "2.1.2",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.2",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-fs": {
@@ -22598,23 +22619,23 @@
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
       "dev": true,
       "requires": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
-        "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
+        "fs-mkdirp-stream": "1.0.0",
+        "glob-stream": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "is-valid-glob": "1.0.0",
+        "lazystream": "1.0.0",
+        "lead": "1.0.0",
+        "object.assign": "4.1.0",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.6",
+        "remove-bom-buffer": "3.0.0",
+        "remove-bom-stream": "1.2.0",
+        "resolve-options": "1.1.0",
+        "through2": "2.0.3",
+        "to-through": "2.0.0",
+        "value-or-function": "3.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemap": "1.1.0"
       }
     },
     "vinyl-sourcemap": {
@@ -22623,13 +22644,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
+        "append-buffer": "1.0.2",
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "normalize-path": "2.1.1",
+        "now-and-later": "2.0.0",
+        "remove-bom-buffer": "3.0.0",
+        "vinyl": "2.2.0"
       }
     },
     "vinyl-sourcemaps-apply": {
@@ -22638,7 +22659,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -22667,11 +22688,11 @@
       "integrity": "sha512-TYlFljSc896b5+0FmMiw0JAMrHNBiHx0IAFC/dQR3Dxdb9Nx43ohm6wMWTlPXQn4sk/0WkqfgoAA6SLxyvPCLQ==",
       "dev": true,
       "requires": {
-        "dom5": "^1.3.1",
-        "es6-promise": "^2.1.0",
-        "hydrolysis": "^1.19.1",
-        "nopt": "^3.0.1",
-        "path-posix": "^1.0.0"
+        "dom5": "1.3.6",
+        "es6-promise": "2.3.0",
+        "hydrolysis": "1.25.0",
+        "nopt": "3.0.6",
+        "path-posix": "1.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -22686,13 +22707,13 @@
           "integrity": "sha1-6Cekk6RDsVbhtYKi5MO9wAQPLuc=",
           "dev": true,
           "requires": {
-            "@types/node": "6.0.*"
+            "@types/node": "6.0.116"
           },
           "dependencies": {
             "@types/node": {
-              "version": "6.0.114",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.114.tgz",
-              "integrity": "sha512-5ViC9dwf1VIAtrOFTvOuN04lJgw28eKjuy0Vg2Bd/fSlxKP2feCSkIw04ZgOENL2ywdWrtbkthp1XVLEjJmouw==",
+              "version": "6.0.116",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.116.tgz",
+              "integrity": "sha512-vToa8YEeulfyYg1gSOeHjvvIRqrokng62VMSj2hoZrwZNcYrp2h3AWo6KeBVuymIklQUaY5zgVJvVsC4KiiLkQ==",
               "dev": true
             }
           }
@@ -22709,11 +22730,11 @@
           "integrity": "sha1-pwiKn8XzsI3J9u2kx6uuskGUXg0=",
           "dev": true,
           "requires": {
-            "@types/clone": "^0.1.29",
-            "@types/node": "^4.0.30",
-            "@types/parse5": "^0.0.31",
-            "clone": "^1.0.2",
-            "parse5": "^1.4.1"
+            "@types/clone": "0.1.30",
+            "@types/node": "4.2.23",
+            "@types/parse5": "0.0.31",
+            "clone": "1.0.4",
+            "parse5": "1.5.1"
           }
         },
         "parse5": {
@@ -22730,18 +22751,18 @@
       "integrity": "sha512-+HmZ5C2WNksNcti41ZihUL5b8ms8q6mOanXKK2jm3aBTnx7vqtkvdFPVJUbapglLWC0RReScBbhT0YuYbdoEOw==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@polymer/sinonjs": "^1.14.1",
-        "@polymer/test-fixture": "^3.0.0-pre.1",
-        "@webcomponents/webcomponentsjs": "^2.0.0",
-        "accessibility-developer-tools": "^2.12.0",
-        "async": "^1.5.2",
-        "chai": "^3.5.0",
-        "lodash": "^3.10.1",
-        "mocha": "^3.4.2",
-        "sinon": "^1.17.1",
-        "sinon-chai": "^2.10.0",
-        "stacky": "^1.3.1"
+        "@polymer/polymer": "3.0.5",
+        "@polymer/sinonjs": "1.17.1",
+        "@polymer/test-fixture": "3.0.0-pre.21",
+        "@webcomponents/webcomponentsjs": "2.0.4",
+        "accessibility-developer-tools": "2.12.0",
+        "async": "1.5.2",
+        "chai": "3.5.0",
+        "lodash": "3.10.1",
+        "mocha": "3.5.3",
+        "sinon": "1.17.7",
+        "sinon-chai": "2.14.0",
+        "stacky": "1.3.1"
       },
       "dependencies": {
         "async": {
@@ -22770,9 +22791,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -22781,7 +22802,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -22796,7 +22817,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -22817,8 +22838,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -22827,7 +22848,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -22838,12 +22859,12 @@
       "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
       "dev": true,
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
       }
     },
     "wordwrap": {
@@ -22858,8 +22879,8 @@
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
       }
     },
     "wrap-ansi": {
@@ -22868,8 +22889,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -22884,7 +22905,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -22893,9 +22914,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "xdg-basedir": {
@@ -22928,19 +22949,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^5.0.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
       }
     },
     "yargs-parser": {
@@ -22949,7 +22970,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   },
   "scripts": {
     "build": "gulp",
-    "test": "npm run lint && polymer test --npm --module-resolution=node",
+    "css-build-shadow": "polymer-css-build -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build/css-build-shadow.html -o test/css-build/css-build.js",
+    "css-build-shady": "polymer-css-build --build-for-shady -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build/css-build-shady.html -o test/css-build/css-build.js",
+    "test": "npm run lint && npm run css-build-shadow && npm run css-build-shady && polymer test --npm --module-resolution=node",
     "serve": "polymer serve --npm --module-resolution=node",
     "lint": "gulp lint",
     "generate-types": "gulp generate-types && npm run verify-types",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "parse5": "^4.0.0",
     "polymer-build": "^3.0.4",
     "polymer-cli": "^1.7.0",
+    "polymer-css-build": "^0.3.0-alpha.7",
     "through2": "^2.0.0",
     "typescript": "^2.9.2",
     "wct-browser-legacy": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "parse5": "^4.0.0",
     "polymer-build": "^3.0.4",
     "polymer-cli": "^1.7.0",
-    "polymer-css-build": "^0.3.0",
+    "polymer-css-build": "^0.4.0",
     "through2": "^2.0.0",
     "typescript": "^2.9.2",
     "wct-browser-legacy": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "parse5": "^4.0.0",
     "polymer-build": "^3.0.4",
     "polymer-cli": "^1.7.0",
-    "polymer-css-build": "^0.3.0-alpha.7",
+    "polymer-css-build": "^0.3.0-alpha.8",
     "through2": "^2.0.0",
     "typescript": "^2.9.2",
     "wct-browser-legacy": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "scripts": {
     "build": "gulp",
-    "css-build-shadow": "polymer-css-build -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build/css-build-shadow.html -o test/css-build/css-build.js",
-    "css-build-shady": "polymer-css-build --build-for-shady -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build/css-build-shady.html -o test/css-build/css-build.js",
+    "css-build-shadow": "rm -rf test/css-build-shadow; mkdir -p test/css-build-shadow; polymer-css-build -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build-shadow/css-build.html -o test/css-build-shadow/css-build.js",
+    "css-build-shady": "rm -rf test/css-build-shady; mkdir -p test/css-build-shady; polymer-css-build --build-for-shady -f test/css-build/css-build.html -f test/css-build/css-build.js -o test/css-build-shady/css-build.html -o test/css-build-shady/css-build.js",
     "test": "npm run lint && npm run css-build-shadow && npm run css-build-shady && polymer test --npm --module-resolution=node",
     "serve": "polymer serve --npm --module-resolution=node",
     "lint": "gulp lint",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "parse5": "^4.0.0",
     "polymer-build": "^3.0.4",
     "polymer-cli": "^1.7.0",
-    "polymer-css-build": "^0.3.0-alpha.8",
+    "polymer-css-build": "^0.3.0",
     "through2": "^2.0.0",
     "typescript": "^2.9.2",
     "wct-browser-legacy": "^1.0.0"

--- a/test/css-build/css-build.html
+++ b/test/css-build/css-build.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--
 @license
-Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -58,12 +58,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     const arena = document.querySelector('#arena');
 
     function assertComputed(node, expectedValue, property = 'border-top-width') {
-      let propertyValue;
-      if (window.ShadyCSS) {
-        propertyValue = window.ShadyCSS.getComputedStyleValue(node, property);
-      } else {
-        propertyValue = window.getComputedStyle(node).getPropertyValue(property).trim();
-      }
+      const propertyValue = window.getComputedStyle(node).getPropertyValue(property).trim();
       assert.equal(propertyValue, expectedValue, `css property ${property}`);
     }
 
@@ -98,6 +93,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('::slotted applied', function() {
         const span = document.createElement('span');
         el.appendChild(span);
+        if (window.ShadyDOM && window.ShadyDOM.inUse) {
+          window.ShadyDOM.flush();
+        }
         assertComputed(span, '10px', 'padding-left');
       });
     });

--- a/test/css-build/css-build.html
+++ b/test/css-build/css-build.html
@@ -27,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
   </custom-style>
+
   <dom-module id="css-build">
     <template>
       <style>
@@ -49,12 +50,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <slot></slot>
       </div>
     </template>
-    <script type="module" src="./css-build.js"></script>
   </dom-module>
 
   <div id="arena"></div>
 
   <script type="module">
+    import './css-build.js';
+
     const arena = document.querySelector('#arena');
 
     function assertComputed(node, expectedValue, property = 'border-top-width') {

--- a/test/css-build/css-build.html
+++ b/test/css-build/css-build.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../unit/wct-browser-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+  <script type="module" src="../../polymer-legacy.js"></script>
+</head>
+<body>
+  <custom-style>
+    <style is="custom-style">
+      html {
+        --mixin: {
+          background-color: rgb(123, 123, 123);
+        };
+        --border: 10px dotted orange;
+      }
+    </style>
+  </custom-style>
+  <dom-module id="css-build">
+    <template>
+      <style>
+        :host {
+          @apply --mixin;
+          display: block;
+        }
+        :host(.ignore-background) {
+          background-color: rgb(255, 0, 0);
+        }
+        #div {
+          border: var(--border, 2px solid black);
+        }
+        #container ::slotted(*) {
+          padding-left: 10px;
+        }
+      </style>
+      <div id="div"></div>
+      <div id="container">
+        <slot></slot>
+      </div>
+    </template>
+    <script type="module" src="./css-build.js"></script>
+  </dom-module>
+
+  <div id="arena"></div>
+
+  <script type="module">
+    const arena = document.querySelector('#arena');
+
+    function assertComputed(node, expectedValue, property = 'border-top-width') {
+      let propertyValue;
+      if (window.ShadyCSS) {
+        propertyValue = window.ShadyCSS.getComputedStyleValue(node, property);
+      } else {
+        propertyValue = window.getComputedStyle(node).getPropertyValue(property).trim();
+      }
+      assert.equal(propertyValue, expectedValue, `css property ${property}`);
+    }
+
+    suite('CSS Build tests', function() {
+      let el;
+      setup(function() {
+        el = document.createElement('css-build');
+        arena.appendChild(el);
+      });
+
+      teardown(function() {
+        arena.innerHTML = '';
+      });
+
+      test('mixins applied', function() {
+        assertComputed(el, 'rgb(123, 123, 123)', 'background-color');
+      });
+
+      test('CSS Custom Properties applied', function() {
+        const div = el.shadowRoot.querySelector('#div');
+        assertComputed(div, '10px');
+      });
+
+      test(':host() applied', function() {
+        el.classList.add('ignore-background');
+        if (!window.ShadyCSS.nativeCss) {
+          window.ShadyCSS.styleDocument();
+        }
+        assertComputed(el, 'rgb(255, 0, 0)', 'background-color');
+      });
+
+      test('::slotted applied', function() {
+        const span = document.createElement('span');
+        el.appendChild(span);
+        assertComputed(span, '10px', 'padding-left');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/css-build/css-build.js
+++ b/test/css-build/css-build.js
@@ -1,15 +1,11 @@
 /**
 @license
-Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-
 import { Polymer } from '../../lib/legacy/polymer-fn.js';
-
-Polymer({
-  is: 'css-build'
-});
+Polymer({ is: 'css-build' });

--- a/test/css-build/css-build.js
+++ b/test/css-build/css-build.js
@@ -1,0 +1,15 @@
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+import { Polymer } from '../../lib/legacy/polymer-fn.js';
+
+Polymer({
+  is: 'css-build'
+});

--- a/test/css-build/css-build.js
+++ b/test/css-build/css-build.js
@@ -7,5 +7,40 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-import { Polymer } from '../../lib/legacy/polymer-fn.js';
-Polymer({ is: 'css-build' });
+import {Polymer} from '../../lib/legacy/polymer-fn.js';
+import {PolymerElement, html} from '../../polymer-element.js';
+
+Polymer({
+  is: 'css-build'
+});
+
+class CssBuildClass extends PolymerElement {
+  static get is() {
+    return 'css-build-class';
+  }
+  static get template() {
+    return html`
+      <style>
+        :host {
+          @apply --mixin;
+          display: block;
+        }
+        :host(.ignore-background) {
+          background-color: rgb(255, 0, 0);
+        }
+        #div {
+          border: var(--border, 2px solid black);
+        }
+        #container ::slotted(*) {
+          padding-left: 10px;
+        }
+      </style>
+      <div id="div"></div>
+      <div id="container">
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+customElements.define(CssBuildClass.is, CssBuildClass);

--- a/test/runner.html
+++ b/test/runner.html
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/html-tag.html',
       // 'unit/multi-style.html',
       'css-build/css-build.html',
-      'css-build/css-build-shadow.html'
+      'css-build-shadow/css-build.html'
     ];
 
     function combinations(suites, flags) {
@@ -123,7 +123,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     suites = combinations(suites, flags);
     // css-build-shady can only be used with ShadyDOM enabled
-    suites.push(...combinations(['css-build/css-build-shady.html'], flags.slice(1)));
+    suites.push(...combinations(['css-build-shady/css-build.html'], flags.slice(1)));
     console.log('Testing suites:\n\t' + suites.join('\n\t'));
 
     WCT.loadSuites(suites);

--- a/test/runner.html
+++ b/test/runner.html
@@ -81,8 +81,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/dir.html',
       'unit/disable-upgrade.html',
       'unit/shady-unscoped-style.html',
-      'unit/html-tag.html'
-      // 'unit/multi-style.html'
+      'unit/html-tag.html',
+      // 'unit/multi-style.html',
+      'css-build/css-build.html',
+      'css-build/css-build-shadow.html'
     ];
 
     function combinations(suites, flags) {
@@ -120,6 +122,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // flags.push(addUrlOption(last, 'wc-shimcssproperties=true'));
     }
     suites = combinations(suites, flags);
+    // css-build-shady can only be used with ShadyDOM enabled
+    suites.push(...combinations(['css-build/css-build-shady.html'], flags.slice(1)));
     console.log('Testing suites:\n\t' + suites.join('\n\t'));
 
     WCT.loadSuites(suites);


### PR DESCRIPTION
- Skip calling into ShadyCSS `prepareTemplate` if the template and ShadyCSS
`styleElement` if the css build is optimial for conditions current runtime
conditions
- Add tests using polymer-css-build
- Add travis steps for tests

Blocked by
- [x] Update polymer-css-build to put `css-build` tag on the template in the dom-module
- [x] Update ShadyCSS to not remove shady scoping from built templates