### PR TITLE
Add a template setter to ElementMixin

### DIFF
--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -375,7 +375,7 @@ export const ElementMixin = dedupingMixin(base => {
      *     }
      *   }
      *
-     * @return {HTMLTemplateElement|string} Template to be stamped
+     * @return {!HTMLTemplateElement|string} Template to be stamped
      */
     static get template() {
       if (!this.hasOwnProperty(JSCompiler_renameProperty('_template', this))) {
@@ -387,6 +387,15 @@ export const ElementMixin = dedupingMixin(base => {
           Object.getPrototypeOf(/** @type {PolymerElementConstructor}*/ (this).prototype).constructor.template;
       }
       return this._template;
+    }
+
+    /**
+     * Set the template.
+     *
+     * @param {!HTMLTemplateElement|string} value Template to set.
+     */
+    static set template(value) {
+      this._template = value;
     }
 
     /**

--- a/test/unit/polymer.element.html
+++ b/test/unit/polymer.element.html
@@ -266,6 +266,26 @@ class SubNewTemplate extends window.MyElement {
 }
 
 customElements.define('sub-new-template', SubNewTemplate);
+
+/**
+ * Instead of overriding the static getter, this element has its template
+ * assigned directly to the constructor.
+ */
+class SubNewTemplateAssigned extends window.MyElement {
+  static get properties() {
+    return {
+      prop2: {
+        value: 'prop2',
+      }
+    };
+  }
+}
+
+SubNewTemplateAssigned.template = html`
+  <h1>Sub template</h1>
+  <div id="subContent">{{prop2}}</div>`;
+
+customElements.define('sub-new-template-assigned', SubNewTemplateAssigned);
 </script>
 
   <template id="no-dom-module">
@@ -576,6 +596,25 @@ suite('subclass new template', function() {
       assert.equal(el.$.child.textContent, 'Content');
       assert.equal(window.ShadyCSS.getComputedStyleValue(el, 'border-top-width'), '10px');
     });
+  });
+});
+
+suite('subclass new template assigned', function() {
+  let el;
+
+  setup(function() {
+    el = document.createElement('sub-new-template-assigned');
+    document.body.appendChild(el);
+  });
+
+  teardown(function() {
+    document.body.removeChild(el);
+  });
+
+  test('template', function() {
+    assert.equal(el.prop2, 'prop2');
+    assert.equal(el.$.subContent.textContent, el.prop2);
+    assert.notOk(el.$.content);
   });
 });
 


### PR DESCRIPTION
Currently, to assign a template to a Polymer element, you need to override the setter, or call `Object.defineProperty`.

This PR also allows users to simply assign the template onto their constructor.

This is especially useful for TypeScript, which compiles `static template = foo` to `MyClass.template = foo`.