### PR TITLE
Use relative path module specifier in gen-tsd autoImport setting.

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -15,7 +15,7 @@
     "Polymer_PropertyEffects": "PropertyEffects"
   },
   "autoImport": {
-    "interfaces": [
+    "./interfaces": [
       "PolymerElementPropertiesMeta",
       "PolymerElementProperties",
       "PolymerInit",
@@ -32,7 +32,7 @@
       "GestureRecognizer",
       "IdleDeadline"
     ],
-    "lib/utils/debounce.js": [
+    "./lib/utils/debounce.js": [
       "Debouncer"
     ]
   }


### PR DESCRIPTION
An upcoming change to the type generator will assume that a module specifier that does not begin with "." is a bare module specifier.
