### PR TITLE
Ensure unresolved.js is an es module

### DIFF
--- a/lib/utils/unresolved.js
+++ b/lib/utils/unresolved.js
@@ -17,3 +17,5 @@ if (document.readyState === 'interactive' || document.readyState === 'complete')
 } else {
   window.addEventListener('DOMContentLoaded', resolve);
 }
+
+export {};


### PR DESCRIPTION
Closure compiler wants all imported files to use ES module syntax to be unambiguous.

