### PR TITLE
Export EventApi, same as DomApi

### DIFF
--- a/lib/legacy/polymer.dom.js
+++ b/lib/legacy/polymer.dom.js
@@ -248,7 +248,7 @@ function forwardProperties(proto, properties) {
  * Event API wrapper class returned from `dom.(target)` when
  * `target` is an `Event`.
  */
-class EventApi {
+export class EventApi {
   constructor(event) {
     this.event = event;
   }


### PR DESCRIPTION
Both TypeScript and Closure need to be able to reach a class in order to use it for typing, and this is a useful type to annotate values with.
