### PR TITLE
The return type of mixinBehaviors is unknown

### DIFF
--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -33,7 +33,7 @@ let metaProps = {
  * @template T
  * @param {!Object|!Array<!Object>} behaviors Behavior object or array of behaviors.
  * @param {function(new:T)} klass Element class.
- * @return {function(new:T)} Returns a new Element class extended by the
+ * @return {?} Returns a new Element class extended by the
  * passed in `behaviors` and also by `LegacyElementMixin`.
  * @suppress {invalidCasts, checkTypes}
  */


### PR DESCRIPTION
It's more than just the input class. Leaving it unknown allows the user to add annotations like:

```
 * @constructor
 * @extends {Polymer.Element}
 * @implements {IronValidatableBehaviorInterface}
```
