### PR TITLE
Avoid Firefox timeout issue on Travis by testing on Sauce. Fixes #5336

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
 script:
 - npm run generate-types
 - node ./node_modules/.bin/polymer test --npm --module-resolution=node -l chrome
-- node ./node_modules/.bin/polymer test --npm --module-resolution=node -l firefox
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then travis_wait 30 ./util/travis-sauce-test.sh; fi
 env:
   global:

--- a/util/travis-sauce-test.sh
+++ b/util/travis-sauce-test.sh
@@ -9,4 +9,4 @@
 # subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 #
 set -x
-node ./node_modules/.bin/polymer test --npm --module-resolution=node -s 'windows 10/microsoftedge@15' -s 'windows 10/microsoftedge@17' -s 'windows 8.1/internet explorer@11' -s 'os x 10.11/safari@9' -s 'macos 10.12/safari@10' -s 'macos 10.13/safari@11' -s 'Linux/chrome@41'
+node ./node_modules/.bin/polymer test --npm --module-resolution=node -s 'windows 10/microsoftedge@15' -s 'windows 10/microsoftedge@17' -s 'windows 8.1/internet explorer@11' -s 'os x 10.11/safari@9' -s 'macos 10.12/safari@10' -s 'macos 10.13/safari@11' -s 'Linux/chrome@41' -s 'Linux/firefox'


### PR DESCRIPTION
Firefox tests have been failing on Travis at around test 100 +/- 10 very consistently.  They do not fail locally or on Sauce, and there is no good way to debug Travis since there is no interactive VM mode.  For now, shifting Firefox testing to Sauce.  The main loss here is that external PR's won't get the benefit of testing on 2 browsers, will now be only Chrome.

Note, will test https://github.com/Polymer/polymer/pull/5346 first as preferred solution; if that still fails will use this as resolution.

Fixes #5336