### PR TITLE
Don't run Firefox in headless mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 script:
 - npm run generate-types
 - node ./node_modules/.bin/polymer test --npm --module-resolution=node -l chrome
-- node ./node_modules/.bin/polymer test --npm --module-resolution=node -l firefox
+- xvfb-run node ./node_modules/.bin/polymer test --npm --module-resolution=node -l firefox
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then travis_wait 30 ./util/travis-sauce-test.sh; fi
 env:
   global:

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,9 +10,6 @@
           "headless",
           "disable-gpu",
           "no-sandbox"
-        ],
-        "firefox": [
-          "-headless"
         ]
       }
     }


### PR DESCRIPTION
Disable Firefox headless mode in attempt to avoid Travis timeouts.

If this works, will take this PR as resolution, otherwise will fall back to https://github.com/Polymer/polymer/pull/5345.

Fixes #5336