### PR TITLE
Collapse imports for file into one statement

### DIFF
--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -9,14 +9,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 import '../utils/boot.js';
 
-import { rootPath } from '../utils/settings.js';
+import { rootPath, strictTemplatePolicy, allowTemplateFromDomModule } from '../utils/settings.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { stylesFromTemplate, stylesFromModuleImports } from '../utils/style-gather.js';
 import { pathFromUrl, resolveCss, resolveUrl } from '../utils/resolve-url.js';
 import { DomModule } from '../elements/dom-module.js';
 import { PropertyEffects } from './property-effects.js';
 import { PropertiesMixin } from './properties-mixin.js';
-import { strictTemplatePolicy, allowTemplateFromDomModule } from '../utils/settings.js';
 
 /**
  * Current Polymer version in Semver notation.

--- a/polymer-element.js
+++ b/polymer-element.js
@@ -8,9 +8,10 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-import { ElementMixin } from './lib/mixins/element-mixin.js';
-export { version } from './lib/mixins/element-mixin.js';
+import { ElementMixin, version } from './lib/mixins/element-mixin.js';
 export { html } from './lib/utils/html-tag.js';
+
+export { version };
 
 /**
  * Base class that provides the core API for Polymer's meta-programming


### PR DESCRIPTION
This is a warning in the internal build system, and it does make the code a bit easier to read this way.

no-op change

