### PR TITLE
Add cast for compilation

### DIFF
--- a/lib/legacy/polymer.dom.js
+++ b/lib/legacy/polymer.dom.js
@@ -54,13 +54,13 @@ export class DomApi {
    * Returns an instance of `FlattenedNodesObserver` that
    * listens for node changes on this element.
    *
-   * @param {function(this:Element, { target: !Element, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Called when direct or distributed children
+   * @param {function(this:HTMLElement, { target: !HTMLElement, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Called when direct or distributed children
    *   of this element changes
    * @return {!FlattenedNodesObserver} Observer instance
    */
   observeNodes(callback) {
     return new FlattenedNodesObserver(
-        /** @type {!Element} */(this.node), callback);
+        /** @type {!HTMLElement} */(this.node), callback);
   }
 
   /**

--- a/lib/utils/flattened-nodes-observer.js
+++ b/lib/utils/flattened-nodes-observer.js
@@ -252,7 +252,8 @@ export class FlattenedNodesObserver {
       addedNodes: [],
       removedNodes: []
     };
-    let newNodes = this.constructor.getFlattenedNodes(this._target);
+    let newNodes = this.constructor.getFlattenedNodes(
+        /** @type {!HTMLElement} */ (this._target));
     let splices = calculateSplices(newNodes,
       this._effectiveNodes);
     // process removals

--- a/lib/utils/flattened-nodes-observer.js
+++ b/lib/utils/flattened-nodes-observer.js
@@ -96,8 +96,8 @@ export class FlattenedNodesObserver {
   }
 
   /**
-   * @param {!Element} target Node on which to listen for changes.
-   * @param {?function(this: Element, { target: !Element, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Function called when there are additions
+   * @param {!HTMLElement} target Node on which to listen for changes.
+   * @param {?function(this: Element, { target: !HTMLElement, addedNodes: !Array<!Element>, removedNodes: !Array<!Element> }):void} callback Function called when there are additions
    * or removals from the target's list of flattened nodes.
    */
   constructor(target, callback) {
@@ -113,7 +113,7 @@ export class FlattenedNodesObserver {
     this._nativeChildrenObserver = null;
     this._connected = false;
     /**
-     * @type {!Element}
+     * @type {!HTMLElement}
      * @private
      */
     this._target = target;
@@ -252,8 +252,7 @@ export class FlattenedNodesObserver {
       addedNodes: [],
       removedNodes: []
     };
-    let newNodes = this.constructor.getFlattenedNodes(
-        /** @type {!HTMLElement} */ (this._target));
+    let newNodes = this.constructor.getFlattenedNodes(this._target);
     let splices = calculateSplices(newNodes,
       this._effectiveNodes);
     // process removals


### PR DESCRIPTION
this._target is an Element, getFlattenedNodes accepts an HTMLElement

Upcoming version of closure compiler type checks this better, and caught this