### PR TITLE
Add @export

### DIFF
--- a/lib/elements/custom-style.js
+++ b/lib/elements/custom-style.js
@@ -72,6 +72,7 @@ export class CustomStyle extends HTMLElement {
    * call any style modules referenced via the `include` attribute will be
    * concatenated to this element's `<style>`.
    *
+   * @export
    * @return {HTMLStyleElement} This element's light-DOM `<style>`
    */
   getStyle() {


### PR DESCRIPTION
CustomStyle#getStyle is referred to as customStyle['getStyle'] in a few places, so it needs to be exported

Externalizing cl/212875987 from @samccone 