### PR TITLE
Expand type of LegacyElementMixin#listen and unlisten to accept EventTargets

### DIFF
--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -409,13 +409,13 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * Convenience method to add an event listener on a given element,
      * late bound to a named method on this element.
      *
-     * @param {Element} node Element to add event listener to.
+     * @param {?EventTarget} node Element to add event listener to.
      * @param {string} eventName Name of event to listen for.
      * @param {string} methodName Name of handler method on `this` to call.
      * @return {void}
      */
     listen(node, eventName, methodName) {
-      node = /** @type {!Element} */ (node || this);
+      node = /** @type {!EventTarget} */ (node || this);
       let hbl = this.__boundListeners ||
         (this.__boundListeners = new WeakMap());
       let bl = hbl.get(node);
@@ -434,14 +434,14 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * Convenience method to remove an event listener from a given element,
      * late bound to a named method on this element.
      *
-     * @param {Element} node Element to remove event listener from.
+     * @param {?EventTarget} node Element to remove event listener from.
      * @param {string} eventName Name of event to stop listening to.
      * @param {string} methodName Name of handler method on `this` to not call
      anymore.
      * @return {void}
      */
     unlisten(node, eventName, methodName) {
-      node = /** @type {!Element} */ (node || this);
+      node = /** @type {!EventTarget} */ (node || this);
       let bl = this.__boundListeners && this.__boundListeners.get(node);
       let key = eventName + methodName;
       let handler = bl && bl[key];


### PR DESCRIPTION
It's a legal argument to pass in, and it'll help some folks migrate to v2

Internalized as cl/213519858