### PR TITLE
Update jsdoc for PropertyEffects.splice

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -1873,7 +1873,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
      *
      * @param {string | !Array<string|number>} path Path to array.
      * @param {number} start Index from which to start removing/inserting.
-     * @param {number} deleteCount Number of items to remove.
+     * @param {number=} deleteCount Number of items to remove.
      * @param {...*} items Items to insert into array.
      * @return {Array} Array of removed items.
      * @public


### PR DESCRIPTION
Array.prototype.splice has its "deleteCount" parameter optional. When omitted, all
items of the arrays are removed. This works with a polymer element
"splice" method, but the typing does not correspond and TypeScript
prevents it.

----

Please let me know if I should:

- extend the jsdoc definition of the deleteCount param to specify that
when omitted all items are removed (I assumed that the comment "The
arguments after `path` and return value match that of "Array.prototype.slice" was enough)

- add a test for the case elem.splice('array', 0). I assumed that this
may end up testing the Array API and not useful

- make the same change for the 2.x branch and/or anywhere else

### Reference Issue
Fixes #5366
