### PR TITLE
implement native toggleAttribute signature

### DIFF
--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -817,7 +817,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @param {boolean=} bool Boolean to force the attribute on or off.
      *    When unspecified, the state of the attribute will be reversed.
      * @param {Element=} node Node to target.  Defaults to `this`.
-     * @return {void}
+     * @return {boolean}
      */
     toggleAttribute(name, bool, node) {
       node = /** @type {Element} */ (node || this);
@@ -826,8 +826,10 @@ export const LegacyElementMixin = dedupingMixin((base) => {
       }
       if (bool) {
         node.setAttribute(name, '');
+        return true;
       } else {
         node.removeAttribute(name);
+        return false;
       }
     }
 

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -817,7 +817,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @param {boolean=} bool Boolean to force the attribute on or off.
      *    When unspecified, the state of the attribute will be reversed.
      * @param {Element=} node Node to target.  Defaults to `this`.
-     * @return {boolean}
+     * @return {boolean} true if the attribute now exists
      */
     toggleAttribute(name, bool, node) {
       node = /** @type {Element} */ (node || this);


### PR DESCRIPTION
Fixes #5364.

As long as we return bool, we implement the same interface that was natively introduced recently. While keeping our third parameter..