### PR TITLE
Add toggleAttribute to excluded identifiers

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -35,5 +35,8 @@
     "./lib/utils/debounce.js": [
       "Debouncer"
     ]
-  }
+  },
+  "excludeIdentifiers": [
+    "toggleAttribute"
+  ]
 }


### PR DESCRIPTION
TypeScript 3.1 added `Element.toggleAttribute(name, force?)` to its DOM typings which is compatible but not identical to `LegacyElementMixin.toggleAttribute(name, force?, element?)`

#5370 fixes the compatibility issue, but tsc still errors:

```
node_modules/@polymer/app-layout/app-drawer/app-drawer.d.ts:67:11 - error TS2320: Interface 'AppDrawerElement' cannot simultaneously extend types 'LegacyElementMixin' and 'HTMLElement'.
  Named property 'toggleAttribute' of types 'LegacyElementMixin' and 'HTMLElement' are not identical.

67 interface AppDrawerElement extends LegacyElementMixin, HTMLElement {
             ~~~~~~~~~~~~~~~~
```

This patch removes the custom typing of `toggleAttribute()`. We did this before with `scroll()` in iron-scroll-target-behavior (https://github.com/PolymerElements/iron-scroll-target-behavior/pull/48).