### PR TITLE
make toggleAttribute match with native signature

### DIFF
--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -816,11 +816,13 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @param {string} name HTML attribute name
      * @param {boolean=} bool Boolean to force the attribute on or off.
      *    When unspecified, the state of the attribute will be reversed.
-     * @param {Element=} node Node to target.  Defaults to `this`.
      * @return {boolean} true if the attribute now exists
      */
-    toggleAttribute(name, bool, node) {
-      node = /** @type {Element} */ (node || this);
+    toggleAttribute(name, bool) {
+      let node = /** @type {Element} */ this;
+      if (arguments.length === 3) {
+        node = /** @type {Element} */ arguments[2];
+      }
       if (arguments.length == 1) {
         bool = !node.hasAttribute(name);
       }


### PR DESCRIPTION
Fixes #5364, again.

This solution is needed instead of #5371 as that would break TS definitions for consumers using TS <3.1.

I had to use `arguments` (unfortunately) because otherwise the function signature does not match the JSDoc, which seems more confusing than a a little `arguments` check.

This produces correct types which are identical to the native `toggleAttribute`, while still supporting our third argument behind the scenes **in JS**.

cc @TimvdLippe 
Supersedes and closes #5371 