### PR TITLE
Add explicit null template for array-selector

### DIFF
--- a/lib/elements/array-selector.js
+++ b/lib/elements/array-selector.js
@@ -426,6 +426,7 @@ class ArraySelector extends baseArraySelector {
   // Not needed to find template; can be removed once the analyzer
   // can find the tag name from customElements.define call
   static get is() { return 'array-selector'; }
+  static get template() { return null; }
 }
 customElements.define(ArraySelector.is, ArraySelector);
 export { ArraySelector };


### PR DESCRIPTION
This makes the element compatible with strictTemplatePolicy.

Fixes #5415.