### PR TITLE
Fix another unsafe property assignment in Polymer.

### DIFF
--- a/lib/legacy/polymer.dom.js
+++ b/lib/legacy/polymer.dom.js
@@ -401,14 +401,14 @@ forwardProperties(DomApi.prototype, [
  */
 export const dom = function(obj) {
   obj = obj || document;
-  if (!obj.__domApi) {
+  if (!obj['__domApi']) {
     let helper;
     if (obj instanceof Event) {
       helper = new EventApi(obj);
     } else {
       helper = new DomApi(obj);
     }
-    obj.__domApi = helper;
+    obj['__domApi'] = helper;
   }
-  return obj.__domApi;
+  return obj['__domApi'];
 };


### PR DESCRIPTION
In polymer.dom.js, we stick __domApi on nodes, but we don't prevent that property from being renamed when compiled. It seems that the renamed property can sometimes collide in a bad way with some other unsafe property we stick on nodes in the polyfill (not sure which yet).
