### PR TITLE
Apply LegacyDataMixin to TemplatizeInstanceBase. Fixes #5422

### DIFF
--- a/lib/legacy/legacy-data-mixin.js
+++ b/lib/legacy/legacy-data-mixin.js
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import { Class } from './class.js';
 import { Polymer } from '../../polymer-legacy.js';
 import { dedupingMixin } from '../utils/mixin.js';
+import { templatize } from '../utils/templatize.js';
 
 const UndefinedArgumentError = class extends Error {
   constructor(message, arg) {
@@ -148,6 +149,15 @@ Polymer.Class = (info, mixin) => Class(info,
     mixin(LegacyDataMixin(superClass)) : 
     LegacyDataMixin(superClass)
 );
+
+// Apply LegacyDataMixin to Templatizer instances as well, and defer
+// runtime switch to the root's host (_methodHost)
+templatize.mixin = 
+  dedupingMixin(superClass => class extends LegacyDataMixin(superClass) {
+    get _legacyUndefinedCheck() {
+      return this._methodHost && this._methodHost._legacyUndefinedCheck;
+    }
+  });
 
 console.info('LegacyDataMixin will be applied to all legacy elements.\n' +
               'Set `_legacyUndefinedCheck: true` on element class to enable.');

--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -334,6 +334,10 @@ function createTemplatizerClass(template, templateInfo, options) {
   // Anonymous class created by the templatize
   let base = options.mutableData ?
     MutableTemplateInstanceBase : TemplateInstanceBase;
+    // Affordance for global mixins onto TemplatizeInstance
+    if (templatize.mixin) {
+      base = templatize.mixin(base);
+    }
   /**
    * @constructor
    * @extends {base}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,7 +1574,7 @@
       "dependencies": {
         "@types/doctrine": {
           "version": "0.0.3",
-          "resolved": "http://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz",
           "integrity": "sha1-6JLSk8ksnB0/mvcsFaVU+8fgiVo=",
           "dev": true
         },
@@ -1954,7 +1954,7 @@
     },
     "@types/clean-css": {
       "version": "3.4.30",
-      "resolved": "http://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
       "integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0=",
       "dev": true
     },
@@ -1996,7 +1996,7 @@
     },
     "@types/events": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
@@ -2042,7 +2042,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.2",
-      "resolved": "http://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
       "dev": true,
       "requires": {
@@ -2095,7 +2095,7 @@
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "http://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
       "dev": true
     },
@@ -2177,9 +2177,9 @@
       "integrity": "sha512-0OyrmVc7S+INtzoqP2ofAo+OdVn2Nj0Qvq4wD9FEGN7nMmLRxaD2mzy6hD6EslzxUSuGH302CDU4KXiY66SEqg=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.1.3.tgz",
-      "integrity": "sha512-0UHJNY88lR3pnEYtBVT7F8cuuxOiITQGWJa0LxoELqkBSB7IabzJFOj5K99PajD3CGAsWpjB0CAeijfe376Y1w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.0.tgz",
+      "integrity": "sha512-WYW4VT4lk0Qk6apSS/mU/wRh4CP+DxJ7FeU1pxmXIdon64+GMMSx6llVyW3jLD4cTwENu2sN23+iIxoRJwTtsw==",
       "dev": true
     },
     "abbrev": {
@@ -3398,7 +3398,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3439,7 +3439,7 @@
     },
     "chai": {
       "version": "3.5.0",
-      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
@@ -3927,7 +3927,7 @@
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -4101,7 +4101,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -4129,7 +4129,7 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
@@ -5546,7 +5546,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5749,7 +5749,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -6679,7 +6679,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -7205,7 +7205,7 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -7252,7 +7252,7 @@
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
@@ -7333,7 +7333,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -7351,7 +7351,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7469,7 +7469,7 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -8222,7 +8222,7 @@
       "dependencies": {
         "@types/resolve": {
           "version": "0.0.7",
-          "resolved": "http://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
           "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
           "dev": true,
           "requires": {
@@ -8383,25 +8383,25 @@
         },
         "babel-plugin-transform-member-expression-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-Jy69Ki1DQbhsJNzYQ3SuWqNwKHQ=",
           "dev": true
         },
         "babel-plugin-transform-merge-sibling-variables": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-SKMw0oKT4xjQcXXCYMdIWec5i0M=",
           "dev": true
         },
         "babel-plugin-transform-minify-booleans": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-He72nCITUDipHeH10T11njRkxDw=",
           "dev": true
         },
         "babel-plugin-transform-property-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
           "dev": true,
           "requires": {
@@ -8416,13 +8416,13 @@
         },
         "babel-plugin-transform-remove-console": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-xXF6+fdpGLKCHPrvRNgkXU6pQiw=",
           "dev": true
         },
         "babel-plugin-transform-remove-debugger": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ=",
           "dev": true
         },
@@ -8437,19 +8437,19 @@
         },
         "babel-plugin-transform-simplify-comparison-operators": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0=",
           "dev": true
         },
         "babel-plugin-transform-undefined-to-void": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I=",
           "dev": true
         },
         "babel-preset-minify": {
           "version": "0.4.0-alpha.caaefb4c",
-          "resolved": "http://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
+          "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
           "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
           "dev": true,
           "requires": {
@@ -8553,7 +8553,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -9593,7 +9593,7 @@
         },
         "@polymer/test-fixture": {
           "version": "0.0.3",
-          "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
           "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
           "dev": true
         },
@@ -9669,19 +9669,19 @@
         },
         "@types/clean-css": {
           "version": "3.4.30",
-          "resolved": "http://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
+          "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
           "integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0=",
           "dev": true
         },
         "@types/clone": {
           "version": "0.1.30",
-          "resolved": "http://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+          "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
           "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
           "dev": true
         },
         "@types/compression": {
           "version": "0.0.33",
-          "resolved": "http://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+          "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
           "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
           "dev": true,
           "requires": {
@@ -9705,13 +9705,13 @@
         },
         "@types/cssbeautify": {
           "version": "0.3.1",
-          "resolved": "http://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
           "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8=",
           "dev": true
         },
         "@types/del": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/@types/del/-/del-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/del/-/del-3.0.1.tgz",
           "integrity": "sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==",
           "dev": true,
           "requires": {
@@ -9720,7 +9720,7 @@
         },
         "@types/doctrine": {
           "version": "0.0.1",
-          "resolved": "http://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
           "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0=",
           "dev": true
         },
@@ -9738,7 +9738,7 @@
         },
         "@types/events": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
           "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
           "dev": true
         },
@@ -9766,13 +9766,13 @@
         },
         "@types/fast-levenshtein": {
           "version": "0.0.1",
-          "resolved": "http://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
           "integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY=",
           "dev": true
         },
         "@types/findup-sync": {
           "version": "0.3.29",
-          "resolved": "http://registry.npmjs.org/@types/findup-sync/-/findup-sync-0.3.29.tgz",
+          "resolved": "https://registry.npmjs.org/@types/findup-sync/-/findup-sync-0.3.29.tgz",
           "integrity": "sha1-7AyAWX5e0VcoIgfnYspyVMrVdjI=",
           "dev": true,
           "requires": {
@@ -9837,7 +9837,7 @@
         },
         "@types/html-minifier": {
           "version": "3.5.2",
-          "resolved": "http://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
           "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
           "dev": true,
           "requires": {
@@ -9848,7 +9848,7 @@
         },
         "@types/inquirer": {
           "version": "0.0.32",
-          "resolved": "http://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
+          "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
           "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
           "dev": true,
           "requires": {
@@ -9858,7 +9858,7 @@
         },
         "@types/is-windows": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
           "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
           "dev": true
         },
@@ -9907,7 +9907,7 @@
         },
         "@types/opn": {
           "version": "3.0.28",
-          "resolved": "http://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+          "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
           "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
           "dev": true,
           "requires": {
@@ -9916,7 +9916,7 @@
         },
         "@types/parse5": {
           "version": "2.2.34",
-          "resolved": "http://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
           "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
           "dev": true,
           "requires": {
@@ -9925,7 +9925,7 @@
         },
         "@types/path-is-inside": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
           "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw==",
           "dev": true
         },
@@ -9943,7 +9943,7 @@
         },
         "@types/relateurl": {
           "version": "0.2.28",
-          "resolved": "http://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+          "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
           "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
           "dev": true
         },
@@ -9959,7 +9959,7 @@
         },
         "@types/resolve": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
           "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
           "dev": true,
           "requires": {
@@ -9968,13 +9968,13 @@
         },
         "@types/rimraf": {
           "version": "0.0.28",
-          "resolved": "http://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
+          "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
           "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
           "dev": true
         },
         "@types/rx": {
           "version": "4.1.1",
-          "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
           "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
           "dev": true,
           "requires": {
@@ -10190,7 +10190,7 @@
         },
         "@types/vinyl-fs": {
           "version": "0.0.28",
-          "resolved": "http://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-0.0.28.tgz",
+          "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-0.0.28.tgz",
           "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
           "dev": true,
           "requires": {
@@ -10201,7 +10201,7 @@
         },
         "@types/whatwg-url": {
           "version": "6.4.0",
-          "resolved": "http://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
           "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
           "dev": true,
           "requires": {
@@ -10226,7 +10226,7 @@
         },
         "@types/yeoman-generator": {
           "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
           "integrity": "sha512-vch2UFd6k7DdfWEv/alRwZIRXQoxZNUDpfLOK24+005dzE1HVnwSWfETF3WxJnWlsOcH87wU4uzldAE/7F/6Lw==",
           "dev": true,
           "requires": {
@@ -10264,7 +10264,7 @@
         },
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -10273,7 +10273,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -10304,7 +10304,7 @@
           "dependencies": {
             "semver": {
               "version": "5.0.3",
-              "resolved": "http://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
               "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
               "dev": true
             }
@@ -10559,7 +10559,7 @@
         },
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
           "dev": true
         },
@@ -10656,7 +10656,7 @@
         },
         "babel-helper-is-nodes-equiv": {
           "version": "0.0.1",
-          "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
           "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
           "dev": true
         },
@@ -10796,25 +10796,25 @@
         },
         "babel-plugin-transform-member-expression-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-Jy69Ki1DQbhsJNzYQ3SuWqNwKHQ=",
           "dev": true
         },
         "babel-plugin-transform-merge-sibling-variables": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-SKMw0oKT4xjQcXXCYMdIWec5i0M=",
           "dev": true
         },
         "babel-plugin-transform-minify-booleans": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-He72nCITUDipHeH10T11njRkxDw=",
           "dev": true
         },
         "babel-plugin-transform-property-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
           "dev": true,
           "requires": {
@@ -10829,13 +10829,13 @@
         },
         "babel-plugin-transform-remove-console": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-xXF6+fdpGLKCHPrvRNgkXU6pQiw=",
           "dev": true
         },
         "babel-plugin-transform-remove-debugger": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ=",
           "dev": true
         },
@@ -10850,19 +10850,19 @@
         },
         "babel-plugin-transform-simplify-comparison-operators": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0=",
           "dev": true
         },
         "babel-plugin-transform-undefined-to-void": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I=",
           "dev": true
         },
         "babel-preset-minify": {
           "version": "0.4.0-alpha.caaefb4c",
-          "resolved": "http://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
+          "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
           "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
           "dev": true,
           "requires": {
@@ -11087,7 +11087,7 @@
         },
         "bl": {
           "version": "1.2.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
           "requires": {
@@ -11097,7 +11097,7 @@
         },
         "blob": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
           "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
           "dev": true
         },
@@ -11416,7 +11416,7 @@
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
@@ -11495,7 +11495,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -11505,7 +11505,7 @@
         },
         "cancel-token": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
           "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
           "dev": true,
           "requires": {
@@ -11534,7 +11534,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11634,7 +11634,7 @@
         },
         "cleankill": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
           "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
           "dev": true
         },
@@ -12257,7 +12257,7 @@
               "dependencies": {
                 "pify": {
                   "version": "2.3.0",
-                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                   "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                   "dev": true
                 }
@@ -12348,7 +12348,7 @@
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
@@ -12647,7 +12647,7 @@
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
@@ -12817,7 +12817,7 @@
         },
         "external-editor": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
           "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
           "dev": true,
           "requires": {
@@ -13261,7 +13261,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
@@ -13285,7 +13285,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
               "dev": true
             }
@@ -13331,7 +13331,7 @@
         },
         "follow-redirects": {
           "version": "0.0.7",
-          "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
           "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
           "dev": true,
           "requires": {
@@ -13478,15 +13478,13 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13503,22 +13501,19 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13649,8 +13644,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13664,7 +13658,6 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13681,7 +13674,6 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13690,15 +13682,13 @@
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.2.4",
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
               "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -13719,7 +13709,6 @@
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13808,8 +13797,7 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13823,7 +13811,6 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13961,7 +13948,6 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14049,7 +14035,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -14218,7 +14204,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -14330,7 +14316,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -14624,7 +14610,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -14794,7 +14780,7 @@
         },
         "inquirer": {
           "version": "1.2.3",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
           "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
           "dev": true,
           "requires": {
@@ -14873,7 +14859,7 @@
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
@@ -15010,7 +14996,7 @@
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
@@ -15252,7 +15238,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -15358,7 +15344,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -15545,7 +15531,7 @@
         },
         "magic-string": {
           "version": "0.22.5",
-          "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
           "dev": true,
           "requires": {
@@ -15618,7 +15604,7 @@
         },
         "media-typer": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
           "dev": true
         },
@@ -15688,7 +15674,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -15811,7 +15797,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -15838,7 +15824,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -15847,7 +15833,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
@@ -16023,7 +16009,7 @@
             },
             "chalk": {
               "version": "0.4.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
               "dev": true,
               "requires": {
@@ -16034,7 +16020,7 @@
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
               "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
               "dev": true
             }
@@ -16204,7 +16190,7 @@
         },
         "opn": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
           "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
           "dev": true,
           "requires": {
@@ -16223,7 +16209,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.10",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
               "dev": true
             }
@@ -16513,7 +16499,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -16700,7 +16686,7 @@
           "dependencies": {
             "@types/resolve": {
               "version": "0.0.7",
-              "resolved": "http://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
               "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
               "dev": true,
               "requires": {
@@ -16877,7 +16863,7 @@
           "dependencies": {
             "@types/mz": {
               "version": "0.0.29",
-              "resolved": "http://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+              "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
               "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
               "dev": true,
               "requires": {
@@ -17121,7 +17107,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -18441,7 +18427,7 @@
         },
         "stacky": {
           "version": "1.3.1",
-          "resolved": "http://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
           "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
           "dev": true,
           "requires": {
@@ -18451,7 +18437,7 @@
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
             }
@@ -18545,7 +18531,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -18747,7 +18733,7 @@
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
               "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
               "dev": true
             }
@@ -18786,7 +18772,7 @@
         },
         "text-encoding": {
           "version": "0.6.4",
-          "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
           "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
           "dev": true
         },
@@ -18828,7 +18814,7 @@
         },
         "through": {
           "version": "2.3.8",
-          "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
@@ -19219,7 +19205,7 @@
         },
         "update-notifier": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
           "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
           "dev": true,
           "requires": {
@@ -19244,7 +19230,7 @@
             },
             "boxen": {
               "version": "0.6.0",
-              "resolved": "http://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
               "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
               "dev": true,
               "requires": {
@@ -19287,7 +19273,7 @@
             },
             "got": {
               "version": "5.7.1",
-              "resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
               "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
               "dev": true,
               "requires": {
@@ -19319,7 +19305,7 @@
             },
             "package-json": {
               "version": "2.4.0",
-              "resolved": "http://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
               "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
               "dev": true,
               "requires": {
@@ -19343,13 +19329,13 @@
             },
             "uuid": {
               "version": "2.0.3",
-              "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
               "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
               "dev": true
             },
             "widest-line": {
               "version": "1.0.0",
-              "resolved": "http://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
               "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
               "dev": true,
               "requires": {
@@ -19705,7 +19691,7 @@
           "dependencies": {
             "async": {
               "version": "2.0.1",
-              "resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
               "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
               "dev": true,
               "requires": {
@@ -19748,7 +19734,7 @@
             },
             "request": {
               "version": "2.85.0",
-              "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
               "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
               "dev": true,
               "requires": {
@@ -20210,7 +20196,7 @@
             },
             "lodash": {
               "version": "3.10.1",
-              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
             },
@@ -20243,7 +20229,7 @@
             },
             "ms": {
               "version": "0.7.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
               "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M=",
               "dev": true
             },
@@ -20292,7 +20278,7 @@
               "dependencies": {
                 "debug": {
                   "version": "2.1.3",
-                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                   "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
                   "dev": true,
                   "requires": {
@@ -20506,7 +20492,7 @@
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
           "dev": true,
           "optional": true
@@ -21165,7 +21151,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -21714,7 +21700,7 @@
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
@@ -21984,7 +21970,7 @@
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
@@ -21994,7 +21980,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -23000,13 +22986,13 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@polymer/gen-typescript-declarations": "^1.5.1",
     "@polymer/iron-component-page": "^3.0.0-pre.12",
     "@polymer/test-fixture": "^3.0.0-pre.12",
-    "@webcomponents/webcomponentsjs": "^2.1.3",
+    "@webcomponents/webcomponentsjs": "^2.2.0",
     "babel-eslint": "^7.2.3",
     "babel-preset-minify": "^0.2.0",
     "del": "^3.0.0",

--- a/test/unit/legacy-data.html
+++ b/test/unit/legacy-data.html
@@ -24,6 +24,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div id="child"
         computed-single="[[computeSingle(inlineSingleDep)]]"
         computed-multi="[[computeMulti(inlineMultiDep1, inlineMultiDep2)]]">
+        <dom-if if>
+          <template><div id="ifChild" computed-multi="[[computeMulti(inlineMultiIfDep1, inlineMultiIfDep2)]]"></div></template>
+        </dom-if>
       </div>
     </template>
     <script type="module">
@@ -41,6 +44,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           inlineSingleDep: String,
           inlineMultiDep1: String,
           inlineMultiDep2: String,
+          inlineMultiIfDep1: String,
+          inlineMultiIfDep2: String,
           computedSingle: {
             computed: 'computeSingle(computedSingleDep)'
           },
@@ -128,8 +133,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <script>
-  (function() {
+  <test-fixture id="declarative-multi-if-one-computed-inline">
+    <template>
+      <x-data inline-multi-if-dep1="b"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-if-all-computed-inline">
+    <template>
+      <x-data inline-multi-if-dep1="b" inline-multi-if-dep2="c"></x-data>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+    import {flush} from '../../lib/utils/flush.js';
 
     let el;
 
@@ -156,6 +173,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         el._legacyUndefinedCheck = check;
         Object.assign(el, props);
         document.body.appendChild(el);
+        flush();
       }
 
       teardown(() => {
@@ -172,6 +190,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const inlineSingleDep = 'inlineSingleDep';
       const inlineMultiDep1 = 'inlineMultiDep1';
       const inlineMultiDep2 = 'inlineMultiDep2';
+      const inlineMultiIfDep1 = 'inlineMultiIfDep1';
+      const inlineMultiIfDep2 = 'inlineMultiIfDep2';
 
       suite('check disabled', () => {
         test('no arguments defined', () => {
@@ -239,6 +259,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setupElement(false, {inlineMultiDep1, inlineMultiDep2});
           assertEffects({computeMulti: 1});
           assert.equal(el.$.child.computedMulti, '[inlineMultiDep1,inlineMultiDep2]');
+        });
+        test('one inline computeMulti argument defined in dom-if', () => {
+          setupElement(false, {inlineMultiIfDep1});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,undefined]');
+        });
+        test('all inline computeMulti argument defined in dom-if', () => {
+          setupElement(false, {inlineMultiIfDep1, inlineMultiIfDep2});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,inlineMultiIfDep2]');
         });
       });
 
@@ -309,6 +339,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertEffects({computeMulti: 1});
           assert.equal(el.$.child.computedMulti, '[inlineMultiDep1,inlineMultiDep2]');
         });
+        test('one inline computeMulti argument defined in dom-if', () => {
+          setupElement(true, {inlineMultiIfDep1});
+          assertEffects({warn: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, undefined);
+        });
+        test('all inline computeMulti argument defined in dom-if', () => {
+          setupElement(true, {inlineMultiIfDep1, inlineMultiIfDep2});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,inlineMultiIfDep2]');
+        });
       });
     });
 
@@ -361,7 +401,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         test('inline all computeMulti defined', () => {
           el = fixture('declarative-multi-all-computed-inline');
+          assertEffects({computeMulti: 1});
           assert.equal(el.$.child.computedMulti, '[b,c]');
+        });
+        test('one inline computeMulti argument defined in dom-if', () => {
+          el = fixture('declarative-multi-if-one-computed-inline');
+          flush();
+          assertEffects({computeMulti: 0, warn: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, undefined);
+        });
+        test('all inline computeMulti argument defined in dom-if', () => {
+          el = fixture('declarative-multi-if-all-computed-inline');
+          flush();
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[b,c]');
         });
       });
     });
@@ -377,7 +430,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
     
-  })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Ensure `LegacyDataMixin` is applied to Templatizer instances when loaded.  A wrapped mixin ensures the `_legacyUndefinedCheck` settings is forwarded from the host element.

This change brings master in line with the version of legacy-data-mixin added to 2.x.

### Reference Issue
Fixes #5422 
