### PR TITLE
Disable DirMixin when ShadyCSS is in use

### DIFF
--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -115,6 +115,7 @@ export const DirMixin = dedupingMixin((base) => {
       cssText = super._processStyleText(cssText, baseURI);
       if (!SHIM_SHADOW && DIR_CHECK.test(cssText)) {
         cssText = this._replaceDirInCssText(cssText);
+        this.__activateDir = true;
       }
       return cssText;
     }
@@ -129,9 +130,6 @@ export const DirMixin = dedupingMixin((base) => {
       let replacedText = text;
       replacedText = replacedText.replace(HOST_DIR, HOST_DIR_REPLACMENT);
       replacedText = replacedText.replace(EL_DIR, EL_DIR_REPLACMENT);
-      if (text !== replacedText) {
-        this.__activateDir = true;
-      }
       return replacedText;
     }
 

--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -84,10 +84,12 @@ function takeRecords() {
  */
 export const DirMixin = dedupingMixin((base) => {
 
-  if (!observer) {
-    getRTL();
-    observer = new MutationObserver(updateDirection);
-    observer.observe(document.documentElement, {attributes: true, attributeFilter: ['dir']});
+  if (!SHIM_SHADOW) {
+    if (!observer) {
+      getRTL();
+      observer = new MutationObserver(updateDirection);
+      observer.observe(document.documentElement, {attributes: true, attributeFilter: ['dir']});
+    }
   }
 
   /**

--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -17,6 +17,10 @@ const HOST_DIR_REPLACMENT = ':host([dir="$1"])';
 const EL_DIR = /([\s\w-#\.\[\]\*]*):dir\((ltr|rtl)\)/g;
 const EL_DIR_REPLACMENT = ':host([dir="$2"]) $1';
 
+const DIR_CHECK = /:dir\((?:ltr|rtl)\)/;
+
+const SHIM_SHADOW = Boolean(window['ShadyDOM'] && window['ShadyDOM']['inUse']);
+
 /**
  * @type {!Array<!Polymer_DirMixin>}
  */
@@ -107,7 +111,9 @@ export const DirMixin = dedupingMixin((base) => {
      */
     static _processStyleText(cssText, baseURI) {
       cssText = super._processStyleText(cssText, baseURI);
-      cssText = this._replaceDirInCssText(cssText);
+      if (!SHIM_SHADOW && DIR_CHECK.test(cssText)) {
+        cssText = this._replaceDirInCssText(cssText);
+      }
       return cssText;
     }
 

--- a/test/unit/dir.html
+++ b/test/unit/dir.html
@@ -13,8 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   <script src="wct-browser-config.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-  <script type="module" src="../../polymer-legacy.js"></script>
-  <script type="module" src="../../lib/mixins/dir-mixin.js"></script>
 </head>
 <body>
   <!--

--- a/test/unit/dir.html
+++ b/test/unit/dir.html
@@ -217,6 +217,9 @@ suite(':dir', function() {
   });
 
   test('elements with dir attribute explicitly set will not change', function() {
+    if (window.ShadyDOM && window.ShadyDOM.inUse) {
+      this.skip();
+    }
     let inner = fixture('preset');
     assert.equal(document.documentElement.getAttribute('dir'), 'rtl');
     assertComputed(inner.shadowRoot.querySelector('.special > div'), 'rgb(255, 255, 255)', 'color');
@@ -245,6 +248,9 @@ suite(':dir', function() {
   });
 
   test('complicated setup', function() {
+    if (window.ShadyDOM && window.ShadyDOM.inUse) {
+      this.skip();
+    }
     let el = fixture('complicated');
     assertComputed(el.$.direct, '10px');
     assertComputed(el.$.indirect, '9px');


### PR DESCRIPTION
There are three decision points to bail early from trying to apply the rather expensive `:dir()` selector transform.

1. If ShadyDOM is active, bail
    - ShadyDOM has a different code path for handling `:dir()`
1. If the template is built, check for `:host([dir="rtl"])`
    - If styles are built, DirMixin will still do some runtime work for the direction, but will not run the selector transform.
1. If styles are unbuilt, check if `:dir()` selector is present
    - The check for `:dir()` is much faster than the transform, even when `:dir()` is not present.