### PR TITLE
Avoid initializing properties unnecessarily (perf benefit). [2.x]

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -15,6 +15,27 @@
 * @interface
 */
 function Polymer_PropertiesChanged(){}
+/** @type {boolean} */
+Polymer_PropertiesChanged.prototype.__dataEnabled;
+
+/** @type {boolean} */
+Polymer_PropertiesChanged.prototype.__dataReady;
+
+/** @type {boolean} */
+Polymer_PropertiesChanged.prototype.__dataInvalid;
+
+/** @type {Object} */
+Polymer_PropertiesChanged.prototype.__dataPending;
+
+/** @type {Object} */
+Polymer_PropertiesChanged.prototype.__dataOld;
+
+/** @type {Object} */
+Polymer_PropertiesChanged.prototype.__dataInstanceProps;
+
+/** @type {boolean} */
+Polymer_PropertiesChanged.prototype.__serializing;
+
 /**
 * @param {string} property Name of the property
 * @param {boolean=} readOnly When true, no setter is created; the
@@ -314,6 +335,12 @@ Polymer_TemplateStamp._contentForTemplate = function(template){};
 * @extends {Polymer_PropertyAccessors}
 */
 function Polymer_PropertyEffects(){}
+/** @type {!Object} */
+Polymer_PropertyEffects.prototype.__dataPending;
+
+/** @type {!Object} */
+Polymer_PropertyEffects.prototype.__dataOld;
+
 /** @type {boolean} */
 Polymer_PropertyEffects.prototype.__dataClientsReady;
 
@@ -343,12 +370,6 @@ Polymer_PropertyEffects.prototype.__dataClientsInitialized;
 
 /** @type {!Object} */
 Polymer_PropertyEffects.prototype.__data;
-
-/** @type {!Object} */
-Polymer_PropertyEffects.prototype.__dataPending;
-
-/** @type {!Object} */
-Polymer_PropertyEffects.prototype.__dataOld;
 
 /** @type {Object} */
 Polymer_PropertyEffects.prototype.__computeEffects;

--- a/lib/mixins/dir-mixin.html
+++ b/lib/mixins/dir-mixin.html
@@ -136,7 +136,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         constructor() {
           super();
           /** @type {boolean} */
-          this.__autoDirOptOut = false;
+          this.__autoDirOptOut;
         }
 
         /**

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -155,14 +155,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         constructor() {
           super();
-          this.__dataEnabled = false;
-          this.__dataReady = false;
-          this.__dataInvalid = false;
+          /** @type {boolean} */
+          this.__dataEnabled;
+          /** @type {boolean} */
+          this.__dataReady;
+          /** @type {boolean} */
+          this.__dataInvalid;
           this.__data = {};
-          this.__dataPending = null;
-          this.__dataOld = null;
-          this.__dataInstanceProps = null;
-          this.__serializing = false;
+          /** @type {Object} */
+          this.__dataPending;
+          /** @type {Object} */
+          this.__dataOld;
+          /** @type {Object} */
+          this.__dataInstanceProps;
+          /** @type {boolean} */
+          this.__serializing;
           this._initializeProperties();
         }
 

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1145,16 +1145,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _initializeProperties() {
         super._initializeProperties();
         hostStack.registerHost(this);
-        this.__dataClientsReady = false;
-        this.__dataPendingClients = null;
-        this.__dataToNotify = null;
-        this.__dataLinkedPaths = null;
-        this.__dataHasPaths = false;
+        /** @type {boolean} */
+        this.__dataClientsReady;
+        /** @type {Array<PropertyEffects>} */
+        this.__dataPendingClients;
+        /** @type {Object} */
+        this.__dataToNotify;
+        /** @type {Object} */
+        this.__dataLinkedPaths;
+        /** @type {boolean} */
+        this.__dataHasPaths;
         // May be set on instance prior to upgrade
-        this.__dataCompoundStorage = this.__dataCompoundStorage || null;
-        this.__dataHost = this.__dataHost || null;
+        /** @type {Array<string>} */
+        this.__dataCompoundStorage;
+        /** @type {PropertyEffects} */
+        this.__dataHost;
+        /** @type {Object} */
         this.__dataTemp = {};
-        this.__dataClientsInitialized = false;
+        /** @type {boolean} */
+        this.__dataClientsInitialized;
       }
 
       /**


### PR DESCRIPTION
Due to the megamorphic nature of code in base classes with many extensions such as these, we saw these initializations _costing_ more than helping with "object shaping."
