### PR TITLE
Avoid initializing properties unnecessarily (perf benefit). [3.x]

### DIFF
--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -136,7 +136,7 @@ export const DirMixin = dedupingMixin((base) => {
     constructor() {
       super();
       /** @type {boolean} */
-      this.__autoDirOptOut = false;
+          this.__autoDirOptOut;
     }
 
     /**

--- a/lib/mixins/properties-changed.js
+++ b/lib/mixins/properties-changed.js
@@ -157,14 +157,21 @@ export const PropertiesChanged = dedupingMixin(
 
     constructor() {
       super();
-      this.__dataEnabled = false;
-      this.__dataReady = false;
-      this.__dataInvalid = false;
+      /** @type {boolean} */
+      this.__dataEnabled;
+      /** @type {boolean} */
+      this.__dataReady;
+      /** @type {boolean} */
+      this.__dataInvalid;
       this.__data = {};
-      this.__dataPending = null;
-      this.__dataOld = null;
-      this.__dataInstanceProps = null;
-      this.__serializing = false;
+      /** @type {Object} */
+      this.__dataPending;
+      /** @type {Object} */
+      this.__dataOld;
+      /** @type {Object} */
+      this.__dataInstanceProps;
+      /** @type {boolean} */
+      this.__serializing;
       this._initializeProperties();
     }
 

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -1137,16 +1137,25 @@ export const PropertyEffects = dedupingMixin(superClass => {
     _initializeProperties() {
       super._initializeProperties();
       hostStack.registerHost(this);
-      this.__dataClientsReady = false;
-      this.__dataPendingClients = null;
-      this.__dataToNotify = null;
-      this.__dataLinkedPaths = null;
-      this.__dataHasPaths = false;
+      /** @type {boolean} */
+      this.__dataClientsReady;
+      /** @type {Array<PropertyEffects>} */
+      this.__dataPendingClients;
+      /** @type {Object} */
+      this.__dataToNotify;
+      /** @type {Object} */
+      this.__dataLinkedPaths;
+      /** @type {boolean} */
+      this.__dataHasPaths;
       // May be set on instance prior to upgrade
-      this.__dataCompoundStorage = this.__dataCompoundStorage || null;
-      this.__dataHost = this.__dataHost || null;
+      /** @type {Array<string>} */
+      this.__dataCompoundStorage;
+      /** @type {PropertyEffects} */
+      this.__dataHost;
+      /** @type {Object} */
       this.__dataTemp = {};
-      this.__dataClientsInitialized = false;
+      /** @type {boolean} */
+      this.__dataClientsInitialized;
     }
 
     /**


### PR DESCRIPTION
Due to the megamorphic nature of code in base classes with many extensions such as these, we saw these initializations _costing_ more than helping with "object shaping."