### PR TITLE
Improve support for `disable-upgrade` [3.x]

### DIFF
--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { LegacyElementMixin } from './legacy-element-mixin.js';
 import { legacyOptimizations } from '../utils/settings.js';
+import {DisableUpgradeMixin} from '../mixins/disable-upgrade-mixin.js';
 
 const lifecycleProps = {
   attached: true,
@@ -79,6 +80,8 @@ function copyProperties(source, target, excludeProps) {
 export function mixinBehaviors(behaviors, klass) {
   return GenerateClassFromInfo({}, LegacyElementMixin(klass), behaviors);
 }
+
+const LegacyElementClass = Polymer.LegacyElementMixin(HTMLElement);
 
 // NOTE:
 // 1.x
@@ -502,9 +505,10 @@ export const Class = function(info, mixin) {
   if (!info) {
     console.warn('Polymer.Class requires `info` argument');
   }
-  let klass = mixin ? mixin(LegacyElementMixin(HTMLElement)) :
-      LegacyElementMixin(HTMLElement);
+  let klass = mixin ? mixin(LegacyElementClass) :
+      LegacyElementClass;
   klass = GenerateClassFromInfo(info, klass, info.behaviors);
+  klass = DisableUpgradeMixin(klass);
   // decorate klass with registration info
   klass.is = klass.prototype.is = info.is;
   return klass;

--- a/lib/mixins/disable-upgrade-mixin.js
+++ b/lib/mixins/disable-upgrade-mixin.js
@@ -7,22 +7,21 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-import { ElementMixin } from './element-mixin.js';
 
-import { dedupingMixin } from '../utils/mixin.js';
-
-const DISABLED_ATTR = 'disable-upgrade';
+const DISABLE_UPGRADE = 'disable-upgrade';
 
 /**
  * Element class mixin that allows the element to boot up in a non-enabled
  * state when the `disable-upgrade` attribute is present. This mixin is
  * designed to be used with element classes like PolymerElement that perform
  * initial startup work when they are first connected. When the
- * `disable-upgrade` attribute is removed, if the element is connected, it
- * boots up and "enables" as it otherwise would; if it is not connected, the
- * element boots up when it is next connected.
+ * `disable-upgrade` attribute is removed, the element
+ * boots up and "enables" as it otherwise would.
  *
- * Using `disable-upgrade` with PolymerElement prevents any data propagation
+ * For legacy elements, it also prevents the `created` method from being called
+ * and event listeners from being added.
+ *
+ * Using `disable-upgrade` with Polymer.Element prevents any data propagation
  * to the element, any element DOM from stamping, or any work done in
  * connected/disconnctedCallback from occuring, but it does not prevent work
  * done in the element constructor.
@@ -35,33 +34,28 @@ const DISABLED_ATTR = 'disable-upgrade';
  *
  * @mixinFunction
  * @polymer
- * @appliesMixin ElementMixin
+ * @appliesMixin Polymer.ElementMixin
+ * @memberof Polymer
+ * @param {Object} base base class on which to apply mixin
+ * @return {Object} class with mixin applied
  */
-export const DisableUpgradeMixin = dedupingMixin((base) => {
-
-  /**
-   * @constructor
-   * @extends {base}
-   * @implements {Polymer_ElementMixin}
-   * @private
-   */
-  const superClass = ElementMixin(base);
+export const DisableUpgradeMixin = (base) => {
 
   /**
    * @polymer
    * @mixinClass
    * @implements {Polymer_DisableUpgradeMixin}
    */
-  class DisableUpgradeClass extends superClass {
+  class DisableUpgradeClass extends base {
 
     /** @override */
     static get observedAttributes() {
-      return super.observedAttributes.concat(DISABLED_ATTR);
+      return super.observedAttributes.concat(DISABLE_UPGRADE);
     }
 
     /** @override */
     attributeChangedCallback(name, old, value, namespace) {
-      if (name == DISABLED_ATTR) {
+      if (name == DISABLE_UPGRADE) {
         if (!this.__dataEnabled && value == null && this.isConnected) {
           super.connectedCallback();
         }
@@ -70,18 +64,16 @@ export const DisableUpgradeMixin = dedupingMixin((base) => {
       }
     }
 
-    /*
-      NOTE: cannot gate on attribute because this is called before
-      attributes are delivered. Therefore, we stub this out and
-      call `super._initializeProperties()` manually.
-    */
-   /** @override */
-    _initializeProperties() {}
+    // disable while `disable-upgrade` is on
+    created() {}
+
+    // disable while `disable-upgrade` is on
+    _applyListeners() {}
 
     // prevent user code in connected from running
     /** @override */
     connectedCallback() {
-      if (this.__dataEnabled || !this.hasAttribute(DISABLED_ATTR)) {
+      if (this.__dataEnabled || !this.hasAttribute(DISABLE_UPGRADE)) {
         super.connectedCallback();
       }
     }
@@ -89,11 +81,19 @@ export const DisableUpgradeMixin = dedupingMixin((base) => {
     // prevent element from turning on properties
     /** @override */
     _enableProperties() {
-      if (!this.hasAttribute(DISABLED_ATTR)) {
-        if (!this.__dataEnabled) {
-          super._initializeProperties();
+      if (!this.__dataEnabled) {
+        if (!this.hasAttribute(DISABLE_UPGRADE)) {
+          // When enabling, run previously disabled lifecycle.
+          // NOTE: This alters the timing of disabled lifecycle for all
+          // elements that support `disable-upgrade`
+          if (super.created) {
+            super.created();
+          }
+          if (super._applyListeners) {
+            super._applyListeners();
+          }
+          super._enableProperties();
         }
-        super._enableProperties();
       }
     }
 
@@ -109,4 +109,4 @@ export const DisableUpgradeMixin = dedupingMixin((base) => {
 
   return DisableUpgradeClass;
 
-});
+};

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -39,6 +39,8 @@ const TYPES = {
 /** @const {RegExp} */
 const capitalAttributeRegex = /[A-Z]/;
 
+const DISABLE_UPGRADE = 'disable-upgrade';
+
 /**
  * @typedef {{
  * name: (string | undefined),
@@ -2549,6 +2551,9 @@ export const PropertyEffects = dedupingMixin(superClass => {
             literal += ' ' + node.getAttribute(name);
           }
           node.setAttribute(name, literal);
+        }
+        if (kind == 'attribute' && name == DISABLE_UPGRADE) {
+          node.setAttribute(DISABLE_UPGRADE, '');
         }
         // Clear attribute before removing, since IE won't allow removing
         // `value` attribute if it previously had a value (can't

--- a/test/unit/disable-upgrade.html
+++ b/test/unit/disable-upgrade.html
@@ -232,9 +232,6 @@ suite('disable-upgrade-legacy', function() {
   });
 
   test('elements call `registered` as expected with `disable-upgrade`', function() {
-    assert.notOk(el.$.disabledRegEl.hasRegistered);
-    assert.notOk(el.$.disabledRegBoundEl.hasRegistered);
-    el.enable();
     assert.ok(el.$.disabledRegEl.hasRegistered);
     assert.ok(el.$.disabledRegBoundEl.hasRegistered);
   });


### PR DESCRIPTION
Instead of overridding`_initializeProperties` which can create ordering infidelities, instead now simply defers `_enableProperties` and on `LegacyElements`, `created` and `_applyListeners`.
