### PR TITLE
Improve  support for`disable-upgrade` [2.x]

### DIFF
--- a/externs/closure-types.js
+++ b/externs/closure-types.js
@@ -1304,6 +1304,35 @@ Polymer_LegacyElementMixin.prototype._error = function(args){};
 Polymer_LegacyElementMixin.prototype._logf = function(methodName, args){};
 /**
 * @interface
+* @extends {Polymer_ElementMixin}
+*/
+function Polymer_DisableUpgradeMixin(){}
+/**
+* @override
+*/
+Polymer_DisableUpgradeMixin.prototype._enableProperties = function(){};
+/**
+* @override
+*/
+Polymer_DisableUpgradeMixin.prototype.attributeChangedCallback = function(name, old, value, namespace){};
+/**
+* @override
+*/
+Polymer_DisableUpgradeMixin.prototype.connectedCallback = function(){};
+/**
+* @override
+*/
+Polymer_DisableUpgradeMixin.prototype.disconnectedCallback = function(){};
+/**
+* @return {undefined}
+*/
+Polymer_DisableUpgradeMixin.prototype.created = function(){};
+/**
+* @return {undefined}
+*/
+Polymer_DisableUpgradeMixin.prototype._applyListeners = function(){};
+/**
+* @interface
 */
 function Polymer_MutableData(){}
 /**
@@ -1392,31 +1421,6 @@ function Polymer_StrictBindingParser(){}
 * @return {Array.<!BindingPart>}
 */
 Polymer_StrictBindingParser._parseBindings = function(text, templateInfo){};
-/**
-* @interface
-* @extends {Polymer_ElementMixin}
-*/
-function Polymer_DisableUpgradeMixin(){}
-/**
-* @override
-*/
-Polymer_DisableUpgradeMixin.prototype._initializeProperties = function(){};
-/**
-* @override
-*/
-Polymer_DisableUpgradeMixin.prototype._enableProperties = function(){};
-/**
-* @override
-*/
-Polymer_DisableUpgradeMixin.prototype.attributeChangedCallback = function(name, old, value, namespace){};
-/**
-* @override
-*/
-Polymer_DisableUpgradeMixin.prototype.connectedCallback = function(){};
-/**
-* @override
-*/
-Polymer_DisableUpgradeMixin.prototype.disconnectedCallback = function(){};
 /**
 * @interface
 */

--- a/lib/legacy/class.html
+++ b/lib/legacy/class.html
@@ -8,6 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="legacy-element-mixin.html">
+<link rel="import" href="../mixins/disable-upgrade-mixin.html">
 <script>
 
   (function() {
@@ -82,6 +83,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function mixinBehaviors(behaviors, klass) {
       return GenerateClassFromInfo({}, Polymer.LegacyElementMixin(klass), behaviors);
     }
+
+    const LegacyElementClass = Polymer.LegacyElementMixin(HTMLElement);
 
     // NOTE:
     // 1.x
@@ -505,12 +508,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!info) {
         console.warn('Polymer.Class requires `info` argument');
       }
-      let klass = mixin ? mixin(Polymer.LegacyElementMixin(HTMLElement)) :
-          Polymer.LegacyElementMixin(HTMLElement);
+      let klass = mixin ? mixin(LegacyElementClass) :
+          LegacyElementClass;
       klass = GenerateClassFromInfo(info, klass, info.behaviors);
-      if (info._enableDisableUpgrade) {
-        klass = Polymer.DisableUpgradeMixin(klass);
-      }
+      klass = Polymer.DisableUpgradeMixin(klass);
       // decorate klass with registration info
       klass.is = klass.prototype.is = info.is;
       return klass;

--- a/lib/mixins/disable-upgrade-mixin.html
+++ b/lib/mixins/disable-upgrade-mixin.html
@@ -46,14 +46,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.DisableUpgradeMixin = (base) => {
 
     /**
-     * @constructor
-     * @extends {base}
-     * @implements {Polymer_ElementMixin}
-     * @private
-     */
-    //const superClass = Polymer.ElementMixin(base);
-
-    /**
      * @polymer
      * @mixinClass
      * @implements {Polymer_DisableUpgradeMixin}

--- a/lib/mixins/disable-upgrade-mixin.html
+++ b/lib/mixins/disable-upgrade-mixin.html
@@ -12,16 +12,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   'use strict';
 
-  const DISABLED_ATTR = 'disable-upgrade';
+  const DISABLE_UPGRADE = 'disable-upgrade';
 
   /**
    * Element class mixin that allows the element to boot up in a non-enabled
    * state when the `disable-upgrade` attribute is present. This mixin is
-   * designed to be used with element classes like Polymer.Element that perform
+   * designed to be used with element classes like PolymerElement that perform
    * initial startup work when they are first connected. When the
-   * `disable-upgrade` attribute is removed, if the element is connected, it
-   * boots up and "enables" as it otherwise would; if it is not connected, the
-   * element boots up when it is next connected.
+   * `disable-upgrade` attribute is removed, the element
+   * boots up and "enables" as it otherwise would.
+   *
+   * For legacy elements, it also prevents the `created` method from being called
+   * and event listeners from being added.
    *
    * Using `disable-upgrade` with Polymer.Element prevents any data propagation
    * to the element, any element DOM from stamping, or any work done in
@@ -38,8 +40,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @polymer
    * @appliesMixin Polymer.ElementMixin
    * @memberof Polymer
+   * @param {Object} base base class on which to apply mixin
+   * @return {Object} class with mixin applied
    */
-  Polymer.DisableUpgradeMixin = Polymer.dedupingMixin((base) => {
+  Polymer.DisableUpgradeMixin = (base) => {
 
     /**
      * @constructor
@@ -47,23 +51,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @implements {Polymer_ElementMixin}
      * @private
      */
-    const superClass = Polymer.ElementMixin(base);
+    //const superClass = Polymer.ElementMixin(base);
 
     /**
      * @polymer
      * @mixinClass
      * @implements {Polymer_DisableUpgradeMixin}
      */
-    class DisableUpgradeClass extends superClass {
+    class DisableUpgradeClass extends base {
 
       /** @override */
       static get observedAttributes() {
-        return super.observedAttributes.concat(DISABLED_ATTR);
+        return super.observedAttributes.concat(DISABLE_UPGRADE);
       }
 
       /** @override */
       attributeChangedCallback(name, old, value, namespace) {
-        if (name == DISABLED_ATTR) {
+        if (name == DISABLE_UPGRADE) {
           if (!this.__dataEnabled && value == null && this.isConnected) {
             super.connectedCallback();
           }
@@ -72,18 +76,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
-      /*
-        NOTE: cannot gate on attribute because this is called before
-        attributes are delivered. Therefore, we stub this out and
-        call `super._initializeProperties()` manually.
-      */
-     /** @override */
-      _initializeProperties() {}
+      // disable while `disable-upgrade` is on
+      created() {}
+
+      // disable while `disable-upgrade` is on
+      _applyListeners() {}
 
       // prevent user code in connected from running
       /** @override */
       connectedCallback() {
-        if (this.__dataEnabled || !this.hasAttribute(DISABLED_ATTR)) {
+        if (this.__dataEnabled || !this.hasAttribute(DISABLE_UPGRADE)) {
           super.connectedCallback();
         }
       }
@@ -91,9 +93,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // prevent element from turning on properties
       /** @override */
       _enableProperties() {
-        if (!this.hasAttribute(DISABLED_ATTR)) {
-          if (!this.__dataEnabled) {
-            super._initializeProperties();
+        if (!this.__dataEnabled) {
+          if (!this.hasAttribute(DISABLE_UPGRADE)) {
+            // When enabling, run previously disabled lifecycle.
+            // NOTE: This alters the timing of disabled lifecycle for all
+            // elements that support `disable-upgrade`
+            if (super.created) {
+              super.created();
+            }
+            if (super._applyListeners) {
+              super._applyListeners();
+            }
+            super._enableProperties();
           }
           super._enableProperties();
         }
@@ -111,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     return DisableUpgradeClass;
 
-  });
+  };
 
 })();
 

--- a/lib/mixins/disable-upgrade-mixin.html
+++ b/lib/mixins/disable-upgrade-mixin.html
@@ -106,7 +106,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
             super._enableProperties();
           }
-          super._enableProperties();
         }
       }
 

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -46,6 +46,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /** @const {RegExp} */
   const capitalAttributeRegex = /[A-Z]/;
 
+  const DISABLE_UPGRADE = 'disable-upgrade';
+
   /**
    * @typedef {{
    * name: (string | undefined),
@@ -2557,6 +2559,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               literal += ' ' + node.getAttribute(name);
             }
             node.setAttribute(name, literal);
+          }
+          if (kind == 'attribute' && name == DISABLE_UPGRADE) {
+            node.setAttribute(DISABLE_UPGRADE, '');
           }
           // Clear attribute before removing, since IE won't allow removing
           // `value` attribute if it previously had a value (can't

--- a/package-lock.json
+++ b/package-lock.json
@@ -2475,7 +2475,7 @@
     },
     "@polymer/test-fixture": {
       "version": "0.0.3",
-      "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
       "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
       "dev": true
     },
@@ -2598,7 +2598,7 @@
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "http://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
@@ -2787,7 +2787,7 @@
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "http://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
@@ -4462,7 +4462,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -4706,7 +4706,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4902,7 +4902,7 @@
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
       "dev": true
     },
@@ -5570,7 +5570,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -6470,7 +6470,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -6524,7 +6524,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -6571,7 +6571,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -7724,7 +7724,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -8936,7 +8936,7 @@
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
@@ -9010,7 +9010,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -9300,7 +9300,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -9311,7 +9311,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -9520,7 +9520,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
@@ -9539,7 +9539,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -10808,7 +10808,7 @@
         },
         "@types/mz": {
           "version": "0.0.29",
-          "resolved": "http://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+          "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
           "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
           "dev": true,
           "requires": {
@@ -11000,25 +11000,25 @@
         },
         "babel-plugin-transform-member-expression-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-Jy69Ki1DQbhsJNzYQ3SuWqNwKHQ=",
           "dev": true
         },
         "babel-plugin-transform-merge-sibling-variables": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-SKMw0oKT4xjQcXXCYMdIWec5i0M=",
           "dev": true
         },
         "babel-plugin-transform-minify-booleans": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-He72nCITUDipHeH10T11njRkxDw=",
           "dev": true
         },
         "babel-plugin-transform-property-literals": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
           "dev": true,
           "requires": {
@@ -11033,13 +11033,13 @@
         },
         "babel-plugin-transform-remove-console": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-xXF6+fdpGLKCHPrvRNgkXU6pQiw=",
           "dev": true
         },
         "babel-plugin-transform-remove-debugger": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ=",
           "dev": true
         },
@@ -11054,19 +11054,19 @@
         },
         "babel-plugin-transform-simplify-comparison-operators": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0=",
           "dev": true
         },
         "babel-plugin-transform-undefined-to-void": {
           "version": "6.10.0-alpha.f95869d4",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
           "integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I=",
           "dev": true
         },
         "babel-preset-minify": {
           "version": "0.4.0-alpha.caaefb4c",
-          "resolved": "http://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
+          "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
           "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
           "dev": true,
           "requires": {
@@ -11181,7 +11181,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -11463,7 +11463,7 @@
             },
             "@types/resolve": {
               "version": "0.0.7",
-              "resolved": "http://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
               "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
               "dev": true,
               "requires": {
@@ -12473,7 +12473,7 @@
       "dependencies": {
         "debug": {
           "version": "2.1.3",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
           "dev": true,
           "requires": {
@@ -12482,7 +12482,7 @@
         },
         "depd": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
           "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
           "dev": true
         },
@@ -12527,7 +12527,7 @@
         },
         "ms": {
           "version": "0.7.0",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
           "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M=",
           "dev": true
         },
@@ -13101,7 +13101,7 @@
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
@@ -13111,7 +13111,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -13445,7 +13445,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true,
           "optional": true
@@ -13485,7 +13485,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -14411,7 +14411,7 @@
       "dependencies": {
         "async": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
@@ -14448,7 +14448,7 @@
         },
         "request": {
           "version": "2.85.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "dev": true,
           "requires": {
@@ -14542,7 +14542,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -14674,7 +14674,7 @@
     },
     "xmlbuilder": {
       "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true,
       "optional": true

--- a/test/unit/disable-upgrade.html
+++ b/test/unit/disable-upgrade.html
@@ -229,9 +229,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('elements call `registered` as expected with `disable-upgrade`', function() {
-        assert.notOk(el.$.disabledRegEl.hasRegistered);
-        assert.notOk(el.$.disabledRegBoundEl.hasRegistered);
-        el.enable();
         assert.ok(el.$.disabledRegEl.hasRegistered);
         assert.ok(el.$.disabledRegBoundEl.hasRegistered);
       });

--- a/types/lib/legacy/class.d.ts
+++ b/types/lib/legacy/class.d.ts
@@ -9,6 +9,7 @@
  */
 
 /// <reference path="legacy-element-mixin.d.ts" />
+/// <reference path="../mixins/disable-upgrade-mixin.d.ts" />
 
 declare namespace Polymer {
 

--- a/types/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/types/lib/mixins/disable-upgrade-mixin.d.ts
@@ -16,11 +16,13 @@ declare namespace Polymer {
   /**
    * Element class mixin that allows the element to boot up in a non-enabled
    * state when the `disable-upgrade` attribute is present. This mixin is
-   * designed to be used with element classes like Polymer.Element that perform
+   * designed to be used with element classes like PolymerElement that perform
    * initial startup work when they are first connected. When the
-   * `disable-upgrade` attribute is removed, if the element is connected, it
-   * boots up and "enables" as it otherwise would; if it is not connected, the
-   * element boots up when it is next connected.
+   * `disable-upgrade` attribute is removed, the element
+   * boots up and "enables" as it otherwise would.
+   *
+   * For legacy elements, it also prevents the `created` method from being called
+   * and event listeners from being added.
    *
    * Using `disable-upgrade` with Polymer.Element prevents any data propagation
    * to the element, any element DOM from stamping, or any work done in
@@ -40,10 +42,19 @@ declare namespace Polymer {
   }
 
   interface DisableUpgradeMixin extends Polymer.ElementMixin, Polymer.PropertyEffects, Polymer.TemplateStamp, Polymer.PropertyAccessors, Polymer.PropertiesChanged, Polymer.PropertiesMixin {
-    _initializeProperties(): void;
     _enableProperties(): void;
     attributeChangedCallback(name: any, old: any, value: any, namespace: any): void;
     connectedCallback(): void;
     disconnectedCallback(): void;
+
+    /**
+     * disable while `disable-upgrade` is on
+     */
+    created(): void;
+
+    /**
+     * disable while `disable-upgrade` is on
+     */
+    _applyListeners(): void;
   }
 }


### PR DESCRIPTION
Instead of overridding`_initializeProperties` which can create ordering infidelities, instead now simply defers `_enableProperties` and on `LegacyElements`, `created` and `_applyListeners`.
