### PR TITLE
Avoid initializing properties unnecessarily (perf benefit), alternate. [2.x]

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -113,13 +113,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return ['__updateSelection(multi, items.*)'];
       }
 
-      constructor() {
-        super();
-        this.__lastItems = null;
-        this.__lastMulti = null;
-        this.__selectedMap = null;
-      }
-
       __updateSelection(multi, itemsInfo) {
         let path = itemsInfo.path;
         if (path == 'items') {
@@ -336,6 +329,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
+
+    /** @type {?Array} */
+    ArraySelectorMixin.prototype.__lastItems;
+    /** @type {?boolean} */
+    ArraySelectorMixin.prototype.__lastMulti;
+    /** @type {?Map} */
+    ArraySelectorMixin.prototype.__selectedMap;
 
     return ArraySelectorMixin;
 

--- a/lib/elements/dom-bind.html
+++ b/lib/elements/dom-bind.html
@@ -60,9 +60,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (Polymer.strictTemplatePolicy) {
           throw new Error(`strictTemplatePolicy: dom-bind not allowed`);
         }
-        this.root = null;
-        this.$ = null;
-        this.__children = null;
       }
 
       /** @return {void} */
@@ -133,6 +130,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
+
+    /** @type {?DocumentFragment} */
+    DomBind.prototype.root;
+    /** @type {?Object} */
+    DomBind.prototype.$;
+    /** @type {?Array} */
+    DomBind.prototype.__children;
 
     customElements.define('dom-bind', DomBind);
 

--- a/lib/elements/dom-if.html
+++ b/lib/elements/dom-if.html
@@ -84,15 +84,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     }
 
-    constructor() {
-      super();
-      this.__renderDebouncer = null;
-      this.__invalidProps = null;
-      this.__instance = null;
-      this._lastIf = false;
-      this.__ctor = null;
-    }
-
     __debounceRender() {
       // Render is async for 2 reasons:
       // 1. To eliminate dom creation trashing if user code thrashes `if` in the
@@ -283,6 +274,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   }
+
+  /** @type {?Object} */
+  DomIf.prototype.__renderDebouncer;
+  /** @type {?Object} */
+  DomIf.prototype.__invalidProps;
+  /** @type {?Object} */
+  DomIf.prototype.__instance;
+  /** @type {?boolean} */
+  DomIf.prototype._lastIf;
+  /** @type {?Object} */
+  DomIf.prototype.__ctor;
 
   customElements.define(DomIf.is, DomIf);
 

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -294,16 +294,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.__instances = [];
       this.__limit = Infinity;
       this.__pool = [];
-      this.__renderDebouncer = null;
       this.__itemsIdxToInstIdx = {};
-      this.__chunkCount = null;
-      this.__lastChunkTime = null;
-      this.__sortFn = null;
-      this.__filterFn = null;
-      this.__observePaths = null;
-      this.__ctor = null;
       this.__isDetached = true;
-      this.template = null;
     }
 
     /**
@@ -729,6 +721,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   }
+
+  /** @type {?Object} */
+  DomRepeat.prototype.__renderDebouncer;
+  /** @type {?number} */
+  DomRepeat.prototype.__chunkCount;
+  /** @type {?number} */
+  DomRepeat.prototype.__lastChunkTime;
+  /** @type {?Function} */
+  DomRepeat.prototype.__sortFn;
+  /** @type {?Function} */
+  DomRepeat.prototype.__filterFn;
+  /** @type {?string} */
+  DomRepeat.prototype.__observePaths;
+  /** @type {?Object} */
+  DomRepeat.prototype.__ctor;
+  /** @type {?HTMLTemplateElement} */
+  DomRepeat.prototype.template;
 
   customElements.define(DomRepeat.is, DomRepeat);
 

--- a/lib/legacy/legacy-element-mixin.html
+++ b/lib/legacy/legacy-element-mixin.html
@@ -72,15 +72,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     class LegacyElement extends legacyElementBase {
 
-      constructor() {
-        super();
-        /** @type {boolean} */
-        this.isAttached;
-        /** @type {WeakMap<!Element, !Object<string, !Function>>} */
-        this.__boundListeners;
-        /** @type {Object<string, Function>} */
-        this._debouncers;
-      }
+      // constructor() {
+      //   super();
+      //   /** @type {boolean} */
+      //   this.isAttached;
+      //   /** @type {WeakMap<!Element, !Object<string, !Function>>} */
+      //   this.__boundListeners;
+      //   /** @type {Object<string, Function>} */
+      //   this._debouncers;
+      // }
 
       /**
        * Forwards `importMeta` from the prototype (i.e. from the info object
@@ -1007,6 +1007,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
+
+    /** @type {boolean} */
+    LegacyElement.prototype.isAttached;
+    /** @type {WeakMap<!Element, !Object<string, !Function>>} */
+    LegacyElement.prototype.__boundListeners;
+    /** @type {Object<string, Function>} */
+    LegacyElement.prototype._debouncers;
 
     LegacyElement.prototype.is = '';
 

--- a/lib/mixins/dir-mixin.html
+++ b/lib/mixins/dir-mixin.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     const EL_DIR_REPLACMENT = ':host([dir="$2"]) $1';
 
     const DIR_CHECK = /:dir\((?:ltr|rtl)\)/;
-    
+
     const SHIM_SHADOW = Boolean(window['ShadyDOM'] && window['ShadyDOM']['inUse']);
 
     /**
@@ -133,12 +133,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return replacedText;
         }
 
-        constructor() {
-          super();
-          /** @type {boolean} */
-          this.__autoDirOptOut = false;
-        }
-
         /**
          * @suppress {invalidCasts} Closure doesn't understand that `this` is an HTMLElement
          * @return {void}
@@ -179,6 +173,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         }
       }
+
+      //   /** @type {boolean} */
+      Dir.prototype.__autoDirOptOut;
 
       Dir.__activateDir = false;
 

--- a/lib/mixins/element-mixin.html
+++ b/lib/mixins/element-mixin.html
@@ -481,22 +481,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return this._importPath;
       }
 
-      constructor() {
-        super();
-        /** @type {HTMLTemplateElement} */
-        this._template;
-        /** @type {string} */
-        this._importPath;
-        /** @type {string} */
-        this.rootPath;
-        /** @type {string} */
-        this.importPath;
-        /** @type {StampedTemplate | HTMLElement | ShadowRoot} */
-        this.root;
-        /** @type {!Object<string, !Element>} */
-        this.$;
-      }
-
       /**
        * Overrides the default `Polymer.PropertyAccessors` to ensure class
        * metaprogramming related to property accessors and effects has
@@ -724,6 +708,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
+
+    /** @type {HTMLTemplateElement} */
+    PolymerElement.prototype._template;
+    /** @type {string} */
+    PolymerElement.prototype._importPath;
+    /** @type {string} */
+    PolymerElement.prototype.rootPath;
+    /** @type {string} */
+    PolymerElement.prototype.importPath;
+    /** @type {StampedTemplate | HTMLElement | ShadowRoot} */
+    PolymerElement.prototype.root;
+    /** @type {!Object<string, !Element>} */
+    PolymerElement.prototype.$;
 
     return PolymerElement;
   });

--- a/lib/mixins/properties-changed.html
+++ b/lib/mixins/properties-changed.html
@@ -155,14 +155,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         constructor() {
           super();
-          this.__dataEnabled = false;
-          this.__dataReady = false;
-          this.__dataInvalid = false;
           this.__data = {};
-          this.__dataPending = null;
-          this.__dataOld = null;
-          this.__dataInstanceProps = null;
-          this.__serializing = false;
           this._initializeProperties();
         }
 
@@ -525,6 +518,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
       }
+
+      /** @type {?boolean} */
+      PropertiesChanged.prototype.__dataEnabled = false;
+      /** @type {?boolean} */
+      PropertiesChanged.prototype.__dataReady = false;
+      /** @type {?boolean} */
+      PropertiesChanged.prototype.__dataInvalid = false;
+      /** @type {?Object} */
+      PropertiesChanged.prototype.__dataPending = null;
+      /** @type {?Object} */
+      PropertiesChanged.prototype.__dataOld = null;
+      /** @type {?Object} */
+      PropertiesChanged.prototype.__dataInstanceProps = null;
+      /** @type {?boolean} */
+      PropertiesChanged.prototype.__serializing = false;
 
       return PropertiesChanged;
     });

--- a/lib/mixins/property-effects.html
+++ b/lib/mixins/property-effects.html
@@ -1095,44 +1095,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // path changes dirty check against `__dataTemp` only during one "turn"
         // and are cleared when `__dataCounter` returns to 0.
         this.__dataCounter = 0;
-        /** @type {boolean} */
-        this.__dataClientsReady;
-        /** @type {Array} */
-        this.__dataPendingClients;
-        /** @type {Object} */
-        this.__dataToNotify;
-        /** @type {Object} */
-        this.__dataLinkedPaths;
-        /** @type {boolean} */
-        this.__dataHasPaths;
-        /** @type {Object} */
-        this.__dataCompoundStorage;
-        /** @type {Polymer_PropertyEffects} */
-        this.__dataHost;
-        /** @type {!Object} */
-        this.__dataTemp;
-        /** @type {boolean} */
-        this.__dataClientsInitialized;
-        /** @type {!Object} */
-        this.__data;
-        /** @type {!Object} */
-        this.__dataPending;
-        /** @type {!Object} */
-        this.__dataOld;
-        /** @type {Object} */
-        this.__computeEffects;
-        /** @type {Object} */
-        this.__reflectEffects;
-        /** @type {Object} */
-        this.__notifyEffects;
-        /** @type {Object} */
-        this.__propagateEffects;
-        /** @type {Object} */
-        this.__observeEffects;
-        /** @type {Object} */
-        this.__readOnly;
-        /** @type {!TemplateInfo} */
-        this.__templateInfo;
       }
 
       get PROPERTY_EFFECT_TYPES() {
@@ -1145,16 +1107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _initializeProperties() {
         super._initializeProperties();
         hostStack.registerHost(this);
-        this.__dataClientsReady = false;
-        this.__dataPendingClients = null;
-        this.__dataToNotify = null;
-        this.__dataLinkedPaths = null;
-        this.__dataHasPaths = false;
-        // May be set on instance prior to upgrade
-        this.__dataCompoundStorage = this.__dataCompoundStorage || null;
-        this.__dataHost = this.__dataHost || null;
         this.__dataTemp = {};
-        this.__dataClientsInitialized = false;
       }
 
       /**
@@ -2752,6 +2705,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
     }
+
+    /** @type {boolean} */
+    PropertyEffects.prototype.__dataClientsReady;
+    /** @type {Array} */
+    PropertyEffects.prototype.__dataPendingClients;
+    /** @type {Object} */
+    PropertyEffects.prototype.__dataToNotify;
+    /** @type {Object} */
+    PropertyEffects.prototype.__dataLinkedPaths;
+    /** @type {boolean} */
+    PropertyEffects.prototype.__dataHasPaths;
+    /** @type {Object} */
+    PropertyEffects.prototype.__dataCompoundStorage;
+    /** @type {Polymer_PropertyEffects} */
+    PropertyEffects.prototype.__dataHost;
+    /** @type {!Object} */
+    PropertyEffects.prototype.__dataTemp;
+    /** @type {boolean} */
+    PropertyEffects.prototype.__dataClientsInitialized;
+    /** @type {!Object} */
+    PropertyEffects.prototype.__data;
+    /** @type {!Object} */
+    PropertyEffects.prototype.__dataPending;
+    /** @type {!Object} */
+    PropertyEffects.prototype.__dataOld;
+    /** @type {Object} */
+    PropertyEffects.prototype.__computeEffects;
+    /** @type {Object} */
+    PropertyEffects.prototype.__reflectEffects;
+    /** @type {Object} */
+    PropertyEffects.prototype.__notifyEffects;
+    /** @type {Object} */
+    PropertyEffects.prototype.__propagateEffects;
+    /** @type {Object} */
+    PropertyEffects.prototype.__observeEffects;
+    /** @type {Object} */
+    PropertyEffects.prototype.__readOnly;
+    /** @type {!TemplateInfo} */
+    PropertyEffects.prototype.__templateInfo;
 
     // make a typing for closure :P
     PropertyEffectsType = PropertyEffects;

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -20,11 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @memberof Polymer
    */
   class Debouncer {
-    constructor() {
-      this._asyncModule = null;
-      this._callback = null;
-      this._timer = null;
-    }
+
     /**
      * Sets the scheduler; that is, a module with the Async interface,
      * a callback and optional arguments to be passed to the run function
@@ -112,6 +108,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return debouncer;
     }
   }
+
+  /** @type {Object} */
+  Debouncer.prototype._asyncModule;
+  /** @type {Function} */
+  Debouncer.prototype._callback;
+  /** @type {Object} */
+  Debouncer.prototype._timer;
 
   /** @const */
   Polymer.Debouncer = Debouncer;


### PR DESCRIPTION
Avoiding this in mixin `constructors` and `_initializeProperties` is a slight performance help in some cases.

Alternative to https://github.com/Polymer/polymer/pull/5439