### PR TITLE
JSDoc fixes for API doc generation.

### DIFF
--- a/lib/legacy/legacy-data-mixin.js
+++ b/lib/legacy/legacy-data-mixin.js
@@ -13,6 +13,10 @@ import { Polymer } from '../../polymer-legacy.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { templatize } from '../utils/templatize.js';
 
+/**
+ * @class UndefinedArgumentError
+ * @private
+ */
 const UndefinedArgumentError = class extends Error {
   constructor(message, arg) {
     super(message);
@@ -76,6 +80,8 @@ export const LegacyDataMixin = dedupingMixin(superClass => {
    * @constructor
    * @extends {superClass}
    * @unrestricted
+   * @polymer
+   * @mixinClass
    * @private   */
   class LegacyDataMixin extends superClass {
     /**
@@ -141,17 +147,24 @@ export const LegacyDataMixin = dedupingMixin(superClass => {
 
 });
 
-// LegacyDataMixin is applied to base class _before_ metaprogramming, to
-// ensure override of _addPropertyEffect et.al. are used by metaprogramming
-// performed in _finalizeClass
+/**
+ * LegacyDataMixin is applied to base class _before_ metaprogramming, to
+ * ensure override of _addPropertyEffect et.al. are used by metaprogramming
+ * performed in _finalizeClass
+ * @private
+ */
 Polymer.Class = (info, mixin) => Class(info, 
   superClass => mixin ? 
     mixin(LegacyDataMixin(superClass)) : 
     LegacyDataMixin(superClass)
 );
 
-// Apply LegacyDataMixin to Templatizer instances as well, and defer
-// runtime switch to the root's host (_methodHost)
+/** 
+ * Apply LegacyDataMixin to Templatizer instances as well, and defer
+ * runtime switch to the root's host (_methodHost)
+ * @private
+ * 
+ */
 templatize.mixin = 
   dedupingMixin(superClass => class extends LegacyDataMixin(superClass) {
     get _legacyUndefinedCheck() {

--- a/lib/legacy/legacy-data-mixin.js
+++ b/lib/legacy/legacy-data-mixin.js
@@ -13,10 +13,6 @@ import { Polymer } from '../../polymer-legacy.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { templatize } from '../utils/templatize.js';
 
-/**
- * @class UndefinedArgumentError
- * @private
- */
 const UndefinedArgumentError = class extends Error {
   constructor(message, arg) {
     super(message);
@@ -80,8 +76,6 @@ export const LegacyDataMixin = dedupingMixin(superClass => {
    * @constructor
    * @extends {superClass}
    * @unrestricted
-   * @polymer
-   * @mixinClass
    * @private   */
   class LegacyDataMixin extends superClass {
     /**
@@ -147,24 +141,17 @@ export const LegacyDataMixin = dedupingMixin(superClass => {
 
 });
 
-/**
- * LegacyDataMixin is applied to base class _before_ metaprogramming, to
- * ensure override of _addPropertyEffect et.al. are used by metaprogramming
- * performed in _finalizeClass
- * @private
- */
+// LegacyDataMixin is applied to base class _before_ metaprogramming, to
+// ensure override of _addPropertyEffect et.al. are used by metaprogramming
+// performed in _finalizeClass
 Polymer.Class = (info, mixin) => Class(info, 
   superClass => mixin ? 
     mixin(LegacyDataMixin(superClass)) : 
     LegacyDataMixin(superClass)
 );
 
-/** 
- * Apply LegacyDataMixin to Templatizer instances as well, and defer
- * runtime switch to the root's host (_methodHost)
- * @private
- * 
- */
+// Apply LegacyDataMixin to Templatizer instances as well, and defer
+// runtime switch to the root's host (_methodHost)
 templatize.mixin = 
   dedupingMixin(superClass => class extends LegacyDataMixin(superClass) {
     get _legacyUndefinedCheck() {

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -125,7 +125,6 @@ export {animationFrame};
  * Async interface wrapper around `requestIdleCallback`.  Falls back to
  * `setTimeout` on browsers that do not support `requestIdleCallback`.
  *
- * @namespace
  * @summary Async interface wrapper around `requestIdleCallback`.
  */
 const idlePeriod = {

--- a/lib/utils/async.js
+++ b/lib/utils/async.js
@@ -49,7 +49,6 @@ function microtaskFlush() {
 /**
  * Async interface wrapper around `setTimeout`.
  *
- * @namespace
  * @summary Async interface wrapper around `setTimeout`.
  */
 const timeOut = {
@@ -96,7 +95,6 @@ export {timeOut};
 /**
  * Async interface wrapper around `requestAnimationFrame`.
  *
- * @namespace
  * @summary Async interface wrapper around `requestAnimationFrame`.
  */
 const animationFrame = {
@@ -167,7 +165,6 @@ export {idlePeriod};
  * Promises are avoided as an implementation choice for the time being
  * due to Safari bugs that cause Promises to lack microtask guarantees.
  *
- * @namespace
  * @summary Async interface for enqueuing callbacks that run at microtask
  *   timing.
  */


### PR DESCRIPTION
Tweaks to get API docs to generate for the Async module in 3.x. Previously nothing was generated for this file. This required removing the "namespace" tags. LMK if that messes with something else.

Also tried to suppress weird extra classes in lib/legacy/legacy-data-mixin.js, without success.

Updated generated API docs in PR here:

https://github.com/Polymer/polymer-library-docs/pull/17

Staged:
https://api-doc-update-dot-polymer-library.appspot.com/3.0/api/utils/async [minimal async doc better than none?]
https://api-doc-update-dot-polymer-library.appspot.com/3.0/api/legacy/legacy-data-mixin [extra classes in docs, dunno why.]


