### PR TITLE
Remove meaningless "undefined" in settings.js

### DIFF
--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -23,8 +23,7 @@ export const useNativeCustomElements = !(window.customElements.polyfillWrapFlush
  * `rootPath` to provide a stable application mount path when
  * using client side routing.
  */
-export let rootPath = undefined ||
-  pathFromUrl(document.baseURI || window.location.href);
+export let rootPath = pathFromUrl(document.baseURI || window.location.href);
 
 /**
  * Sets the global rootPath property used by `ElementMixin` and


### PR DESCRIPTION
I think this came from `Polymer.rootPath || ...` in 2.x (https://github.com/Polymer/polymer/blob/2.x/lib/utils/settings.html#L45)