### PR TITLE
Suppress upcoming jscompiler errors.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,7 @@ const header =
 `/**
  * @fileoverview Generated typings for Polymer mixins
  * @externs
+ * @suppress {checkPrototypalTypes}
  *
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.

--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -1,4 +1,5 @@
 /**
+ * @suppress {checkPrototypalTypes}
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt

--- a/lib/mixins/disable-upgrade-mixin.js
+++ b/lib/mixins/disable-upgrade-mixin.js
@@ -1,4 +1,5 @@
 /**
+ * @suppress {checkPrototypalTypes}
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -1,4 +1,5 @@
 /**
+ * @suppress {checkPrototypalTypes}
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -1,4 +1,5 @@
 /**
+ * @suppress {checkPrototypalTypes}
 @license
 Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt


### PR DESCRIPTION
These errors don't exist yet, but we need to suppress them in the files that will have them so that we're not broken when they're turned on.
