### PR TITLE
Externs should use var instead of let

### DIFF
--- a/externs/webcomponents-externs.js
+++ b/externs/webcomponents-externs.js
@@ -33,7 +33,7 @@ let ShadyDOM = {
 
 window.ShadyDOM = ShadyDOM;
 
-let WebComponents = {};
+var WebComponents = {};
 window.WebComponents = WebComponents;
 
 /** @type {Element} */


### PR DESCRIPTION
Multiple externs may declare the same symbol and that's ok. That doesn't work if an extern is declared with `let` instead of `var`, you get errors like: Duplicate let / const / class / function declaration in the same scope is not allowed.
