### PR TITLE
Remove `@override` from static methods on mixins.

### DIFF
--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -109,6 +109,9 @@ export const DirMixin = dedupingMixin((base) => {
   class Dir extends elementBase {
 
     /**
+     * @param {string} cssText .
+     * @param {string} baseURI .
+     * @return {string} .
      * @suppress {missingProperties} Interfaces in closure do not inherit statics, but classes do
      */
     static _processStyleText(cssText, baseURI) {

--- a/lib/mixins/dir-mixin.js
+++ b/lib/mixins/dir-mixin.js
@@ -109,7 +109,6 @@ export const DirMixin = dedupingMixin((base) => {
   class Dir extends elementBase {
 
     /**
-     * @override
      * @suppress {missingProperties} Interfaces in closure do not inherit statics, but classes do
      */
     static _processStyleText(cssText, baseURI) {

--- a/lib/mixins/disable-upgrade-mixin.js
+++ b/lib/mixins/disable-upgrade-mixin.js
@@ -56,7 +56,6 @@ export const DisableUpgradeMixin = dedupingMixin((base) => {
   class DisableUpgradeClass extends superClass {
 
     /**
-     * @override
      * @suppress {missingProperties} go/missingfnprops
      */
     static get observedAttributes() {

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -325,7 +325,6 @@ export const ElementMixin = dedupingMixin(base => {
      * find the template.
      * @return {void}
      * @protected
-     * @override
      * @suppress {missingProperties} Interfaces in closure do not inherit statics, but classes do
      */
    static _finalizeClass() {
@@ -357,7 +356,6 @@ export const ElementMixin = dedupingMixin(base => {
      * and property effects for all of the properties.
      * @return {void}
      * @protected
-     * @override
      */
      static createProperties(props) {
       for (let p in props) {
@@ -724,7 +722,6 @@ export const ElementMixin = dedupingMixin(base => {
      * code. This map determines which method templates should have accessors
      * created for them.
      *
-     * @override
      * @suppress {missingProperties} Interfaces in closure do not inherit statics, but classes do
      */
     static _parseTemplateContent(template, templateInfo, nodeInfo) {

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -354,6 +354,7 @@ export const ElementMixin = dedupingMixin(base => {
     /**
      * Override of PropertiesChanged createProperties to create accessors
      * and property effects for all of the properties.
+     * @param {!Object} props .
      * @return {void}
      * @protected
      */
@@ -722,6 +723,10 @@ export const ElementMixin = dedupingMixin(base => {
      * code. This map determines which method templates should have accessors
      * created for them.
      *
+     * @param {!HTMLTemplateElement} template Template
+     * @param {!TemplateInfo} templateInfo Template metadata for current template
+     * @param {!NodeInfo} nodeInfo Node metadata for current template.
+     * @return {boolean} .
      * @suppress {missingProperties} Interfaces in closure do not inherit statics, but classes do
      */
     static _parseTemplateContent(template, templateInfo, nodeInfo) {

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2484,7 +2484,6 @@ export const PropertyEffects = dedupingMixin(superClass => {
      * with one or more metadata objects capturing the source(s) of the
      * binding.
      *
-     * @override
      * @param {Node} node Node to parse
      * @param {TemplateInfo} templateInfo Template metadata for current template
      * @param {NodeInfo} nodeInfo Node metadata for current template node
@@ -2517,7 +2516,6 @@ export const PropertyEffects = dedupingMixin(superClass => {
      * with one or more metadata objects capturing the source(s) of the
      * binding.
      *
-     * @override
      * @param {Element} node Node to parse
      * @param {TemplateInfo} templateInfo Template metadata for current template
      * @param {NodeInfo} nodeInfo Node metadata for current template node
@@ -2581,7 +2579,6 @@ export const PropertyEffects = dedupingMixin(superClass => {
      * binding the properties that a nested template depends on to the template
      * as `_host_<property>`.
      *
-     * @override
      * @param {Node} node Node to parse
      * @param {TemplateInfo} templateInfo Template metadata for current template
      * @param {NodeInfo} nodeInfo Node metadata for current template node


### PR DESCRIPTION
Closure compiler is improving its handling of class inheritance, and it does not understand our mixins well enough to notice that these methods override their superclasses. These annotations cause compiler errors in an upcoming version of the compiler.
