### PR TITLE
Update several string references which can be renamed by closure-compiler

### DIFF
--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -199,13 +199,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           let sidx = 0;
           this.__selectedMap.forEach(idx => {
             if (idx >= 0) {
-              this.linkPaths(`${JSCompiler_renameProperty('items', this)}.` + idx, `${JSCompiler_renameProperty('selected', this)}.` + sidx++);
+              this.linkPaths(`${JSCompiler_renameProperty('items', this)}.${idx}`, `${JSCompiler_renameProperty('selected', this)}.${sidx++}`);
             }
           });
         } else {
           this.__selectedMap.forEach(idx => {
-            this.linkPaths(JSCompiler_renameProperty('selected', this), `${JSCompiler_renameProperty('items', this)}.` + idx);
-            this.linkPaths(JSCompiler_renameProperty('selectedItem', this), `${JSCompiler_renameProperty('items', this)}.` + idx);
+            this.linkPaths(JSCompiler_renameProperty('selected', this), `${JSCompiler_renameProperty('items', this)}.${idx}`);
+            this.linkPaths(JSCompiler_renameProperty('selectedItem', this), `${JSCompiler_renameProperty('items', this)}.${idx}`);
           });
         }
       }
@@ -260,7 +260,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       __selectedIndexForItemIndex(idx) {
-        let selected = this.__dataLinkedPaths[`${JSCompiler_renameProperty('items', this)}.` + idx];
+        let selected = this.__dataLinkedPaths[`${JSCompiler_renameProperty('items', this)}.${idx}`];
         if (selected) {
           return parseInt(selected.slice(`${JSCompiler_renameProperty('selected', this)}.`.length), 10);
         }

--- a/lib/elements/array-selector.html
+++ b/lib/elements/array-selector.html
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       __updateSelection(multi, itemsInfo) {
         let path = itemsInfo.path;
-        if (path == 'items') {
+        if (path == JSCompiler_renameProperty('items', this)) {
           // Case 1 - items array changed, so diff against previous array and
           // deselect any removed items and adjust selected indices
           let newItems = itemsInfo.base || [];
@@ -137,14 +137,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           this.__lastItems = newItems;
           this.__lastMulti = multi;
-        } else if (itemsInfo.path == 'items.splices') {
+        } else if (itemsInfo.path == `${JSCompiler_renameProperty('items', this)}.splices`) {
           // Case 2 - got specific splice information describing the array mutation:
           // deselect any removed items and adjust selected indices
           this.__applySplices(itemsInfo.value.indexSplices);
         } else {
           // Case 3 - an array element was changed, so deselect the previous
           // item for that index if it was previously selected
-          let part = path.slice('items.'.length);
+          let part = path.slice(`${JSCompiler_renameProperty('items', this)}.`.length);
           let idx = parseInt(part, 10);
           if ((part.indexOf('.') < 0) && part == idx) {
             this.__deselectChangedIdx(idx);
@@ -182,7 +182,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         selected.forEach((idx, item) => {
           if (idx < 0) {
             if (this.multi) {
-              this.splice('selected', sidx, 1);
+              this.splice(JSCompiler_renameProperty('selected', this), sidx, 1);
             } else {
               this.selected = this.selectedItem = null;
             }
@@ -199,13 +199,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           let sidx = 0;
           this.__selectedMap.forEach(idx => {
             if (idx >= 0) {
-              this.linkPaths('items.' + idx, 'selected.' + sidx++);
+              this.linkPaths(`${JSCompiler_renameProperty('items', this)}.` + idx, `${JSCompiler_renameProperty('selected', this)}.` + sidx++);
             }
           });
         } else {
           this.__selectedMap.forEach(idx => {
-            this.linkPaths('selected', 'items.' + idx);
-            this.linkPaths('selectedItem', 'items.' + idx);
+            this.linkPaths(JSCompiler_renameProperty('selected', this), `${JSCompiler_renameProperty('items', this)}.` + idx);
+            this.linkPaths(JSCompiler_renameProperty('selectedItem', this), `${JSCompiler_renameProperty('items', this)}.` + idx);
           });
         }
       }
@@ -260,9 +260,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       __selectedIndexForItemIndex(idx) {
-        let selected = this.__dataLinkedPaths['items.' + idx];
+        let selected = this.__dataLinkedPaths[`${JSCompiler_renameProperty('items', this)}.` + idx];
         if (selected) {
-          return parseInt(selected.slice('selected.'.length), 10);
+          return parseInt(selected.slice(`${JSCompiler_renameProperty('selected', this)}.`.length), 10);
         }
       }
 
@@ -282,7 +282,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
           this.__updateLinks();
           if (this.multi) {
-            this.splice('selected', sidx, 1);
+            this.splice(JSCompiler_renameProperty('selected', this), sidx, 1);
           } else {
             this.selected = this.selectedItem = null;
           }
@@ -326,7 +326,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.__selectedMap.set(item, idx);
           this.__updateLinks();
           if (this.multi) {
-            this.push('selected', item);
+            this.push(JSCompiler_renameProperty('selected', this), item);
           } else {
             this.selected = this.selectedItem = item;
           }

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -384,7 +384,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               if (prop == this.as) {
                 this.items[idx] = value;
               }
-              let path = Polymer.Path.translate(this.as, 'items.' + idx, prop);
+              let path = Polymer.Path.translate(this.as, `${JSCompiler_renameProperty('items', this)}.` + idx, prop);
               this.notifyPath(path, value);
             }
           }

--- a/lib/elements/dom-repeat.html
+++ b/lib/elements/dom-repeat.html
@@ -384,7 +384,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               if (prop == this.as) {
                 this.items[idx] = value;
               }
-              let path = Polymer.Path.translate(this.as, `${JSCompiler_renameProperty('items', this)}.` + idx, prop);
+              let path = Polymer.Path.translate(this.as, `${JSCompiler_renameProperty('items', this)}.${idx}`, prop);
               this.notifyPath(path, value);
             }
           }


### PR DESCRIPTION
I stumbled across a few path references in Polymer that were not reflected. For users who are not using the `EXPORT_ALL` policy of closure compiler, the properties would have been renamed inconsistently.

Once https://github.com/google/closure-compiler/pull/3184 is merged, the compiler will be able to handle reflection of observer and computed properties paths. However references to paths within other code, such as those to `notifyPath`, will still need to be manually reflected.