### PR TITLE
Adds `legacyUndefined` setting

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -19,11 +19,13 @@ import { camelToDashCase, dashToCamelCase } from '../utils/case-map.js';
 import { PropertyAccessors } from './property-accessors.js';
 /* for annotated effects */
 import { TemplateStamp } from './template-stamp.js';
-import { sanitizeDOMValue } from '../utils/settings.js';
+import { sanitizeDOMValue, legacyUndefined } from '../utils/settings.js';
 
 // Monotonically increasing unique ID used for de-duping effects triggered
 // from multiple properties in the same turn
 let dedupeId = 0;
+
+const NOOP = {};
 
 /**
  * Property effect types; effects are stored on the prototype using these keys
@@ -432,6 +434,10 @@ function runComputedEffects(inst, changedProps, oldProps, hasPaths) {
  */
 function runComputedEffect(inst, property, props, oldProps, info) {
   let result = runMethodEffect(inst, property, props, oldProps, info);
+  // Abort if method returns a no-op result
+  if (result === NOOP) {
+    return;
+  }
   let computedProp = info.methodInfo;
   if (inst.__dataHasAccessor && inst.__dataHasAccessor[computedProp]) {
     inst._setPendingProperty(computedProp, result, true);
@@ -579,7 +585,10 @@ function runBindingEffect(inst, path, props, oldProps, info, hasPaths, nodeList)
   } else {
     let value = info.evaluator._evaluateBinding(inst, part, path, props, oldProps, hasPaths);
     // Propagate value to child
-    applyBindingValue(inst, node, binding, part, value);
+    // Abort if value is a no-op result
+    if (value !== NOOP) {
+      applyBindingValue(inst, node, binding, part, value);
+    }
   }
 }
 
@@ -816,7 +825,7 @@ function runMethodEffect(inst, property, props, oldProps, info) {
   let fn = context[info.methodName];
   if (fn) {
     let args = inst._marshalArgs(info.args, property, props);
-    return fn.apply(context, args);
+    return args === NOOP ? NOOP : fn.apply(context, args);
   } else if (!info.dynamicFn) {
     console.warn('method `' + info.methodName + '` not defined');
   }
@@ -2214,6 +2223,11 @@ export const PropertyEffects = dedupingMixin(superClass => {
           } else {
             value = structured ? getArgValue(data, props, name) : data[name];
           }
+        }
+        // When the `legacyUndefined` flag is enabled, pass a no-op value
+        // so that the observer, computed property, or compound binding is aborted.
+        if (legacyUndefined && value === undefined) {
+          return NOOP;
         }
         values[i] = value;
       }

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2226,7 +2226,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
         }
         // When the `legacyUndefined` flag is enabled, pass a no-op value
         // so that the observer, computed property, or compound binding is aborted.
-        if (legacyUndefined && value === undefined) {
+        if (legacyUndefined && value === undefined && args.length > 1) {
           return NOOP;
         }
         values[i] = value;

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -158,3 +158,22 @@ export let syncInitialRender = false;
 export const setSyncInitialRender = function(useSyncInitialRender) {
   syncInitialRender = useSyncInitialRender;
 };
+
+/**
+ * Setting to retain the legacy Polymer 1 behavior for multi-property
+ * observers around undefined values. Observers and computed property methods
+ * are not called until no argument is undefined.
+ */
+export let legacyUndefined = false;
+
+/**
+ * Sets `legacyUndefined` globally for all elements to enable legacy
+ * multi-property behavior for undefined values.
+ *
+ * @param {boolean} useLegacyUndefined enable or disable legacy
+ * multi-property behavior for undefined.
+ * @return {void}
+ */
+export const setLegacyUndefined = function(useLegacyUndefined) {
+  legacyUndefined = useLegacyUndefined;
+};

--- a/test/runner.html
+++ b/test/runner.html
@@ -87,6 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/shady-unscoped-style.html',
       'unit/html-tag.html',
       'unit/legacy-data.html',
+      'unit/legacy-undefined.html',
       // 'unit/multi-style.html'
       'unit/class-properties.html'
     ];

--- a/test/unit/legacy-undefined.html
+++ b/test/unit/legacy-undefined.html
@@ -1,0 +1,343 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="wct-browser-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+  <script type="module">
+    import {setLegacyUndefined} from '../../lib/utils/settings.js';
+    setLegacyUndefined(true);
+  </script>
+</head>
+<body>
+
+  <dom-module id="x-data">
+    <template>
+      <div id="child"
+        computed-single="[[computeSingle(inlineSingleDep)]]"
+        computed-multi="[[computeMulti(inlineMultiDep1, inlineMultiDep2)]]">
+        <dom-if if>
+          <template><div id="ifChild" computed-multi="[[computeMulti(inlineMultiIfDep1, inlineMultiIfDep2)]]"></div></template>
+        </dom-if>
+      </div>
+    </template>
+    <script type="module">
+      import {Polymer} from '../../polymer-legacy.js';
+      Polymer({
+        is: 'x-data',
+        _legacyUndefinedCheck: true,
+        properties: {
+          singleProp: String,
+          multiProp1: String,
+          multiProp2: String,
+          computedSingleDep: String,
+          computedMultiDep1: String,
+          computedMultiDep2: String,
+          inlineSingleDep: String,
+          inlineMultiDep1: String,
+          inlineMultiDep2: String,
+          inlineMultiIfDep1: String,
+          inlineMultiIfDep2: String,
+          computedSingle: {
+            computed: 'computeSingle(computedSingleDep)'
+          },
+          computedMulti: {
+            computed: 'computeMulti(computedMultiDep1, computedMultiDep2)'
+          }
+        },
+        observers: [
+          'staticObserver("staticObserver")',
+          'singlePropObserver(singleProp)',
+          'multiPropObserver(multiProp1, multiProp2)',
+          'throws(throwProp)'
+        ],
+        created() {
+          this.singlePropObserver = sinon.spy();
+          this.multiPropObserver = sinon.spy();
+          this.staticObserver = sinon.spy();
+          this.computeSingle = sinon.spy((inlineSingleDep) => `[${inlineSingleDep}]`);
+          this.computeMulti = sinon.spy((inlineMultiDep1, inlineMultiDep2) => `[${inlineMultiDep1},${inlineMultiDep2}]`);
+        },
+        throws() {
+          throw new Error('real error');
+        }
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="declarative-none">
+    <template>
+      <x-data></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-single">
+    <template>
+      <x-data single-prop="a"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-one">
+    <template>
+      <x-data multi-prop1="b"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-all">
+    <template>
+      <x-data multi-prop1="b" multi-prop2="c"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-single-computed">
+    <template>
+      <x-data computed-single-dep="a"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-one-computed">
+    <template>
+      <x-data computed-multi-dep1="b"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-all-computed">
+    <template>
+      <x-data computed-multi-dep1="b" computed-multi-dep2="c"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-single-computed-inline">
+    <template>
+      <x-data inline-single-dep="a"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-one-computed-inline">
+    <template>
+      <x-data inline-multi-dep1="b"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-all-computed-inline">
+    <template>
+      <x-data inline-multi-dep1="b" inline-multi-dep2="c"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-if-one-computed-inline">
+    <template>
+      <x-data inline-multi-if-dep1="b"></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-multi-if-all-computed-inline">
+    <template>
+      <x-data inline-multi-if-dep1="b" inline-multi-if-dep2="c"></x-data>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+    import {flush} from '../../lib/utils/flush.js';
+
+    let el;
+
+    function assertEffects(callCounts) {
+      assert.equal(el.staticObserver.callCount, 1, 'staticObserver call count wrong');
+      assert.equal(el.singlePropObserver.callCount,
+        callCounts.singlePropObserver || 0, 'singlePropObserver call count wrong');
+      assert.equal(el.multiPropObserver.callCount,
+        callCounts.multiPropObserver || 0, 'multiPropObserver call count wrong');
+      assert.equal(el.computeSingle.callCount,
+        callCounts.computeSingle || 0, 'computeSingle call count wrong');
+      assert.equal(el.computeMulti.callCount,
+        callCounts.computeMulti || 0, 'computeMulti call count wrong');
+    }
+
+    suite('imperative', () => {
+
+
+      function setupElement(props) {
+        el = document.createElement('x-data');
+        Object.assign(el, props);
+        document.body.appendChild(el);
+        flush();
+      }
+
+      teardown(() => {
+        el.parentNode.removeChild(el);
+      });
+
+      const singleProp = 'singleProp';
+      const multiProp1 = 'multiProp1';
+      const multiProp2 = 'multiProp2';
+      const computedSingleDep = 'computedSingleDep';
+      const computedMultiDep1 = 'computedMultiDep1';
+      const computedMultiDep2 = 'computedMultiDep2';
+      const inlineSingleDep = 'inlineSingleDep';
+      const inlineMultiDep1 = 'inlineMultiDep1';
+      const inlineMultiDep2 = 'inlineMultiDep2';
+      const inlineMultiIfDep1 = 'inlineMultiIfDep1';
+      const inlineMultiIfDep2 = 'inlineMultiIfDep2';
+
+      suite('check disabled', () => {
+        test('no arguments defined', () => {
+          setupElement({});
+          assertEffects({});
+        });
+        test('singlePropObserver argument defined', () => {
+          setupElement({singleProp});
+          assertEffects({singlePropObserver: 1});
+        });
+        test('one multiPropObserver arguments defined', () => {
+          setupElement({multiProp1});
+          assertEffects({multiPropObserver: 0});
+        });
+        test('all multiPropObserver defined', () => {
+          setupElement({multiProp1, multiProp2});
+          assertEffects({multiPropObserver: 1});
+        });
+        test('singlePropObserver argument undefined', () => {
+          setupElement({singleProp});
+          assertEffects({singlePropObserver: 1});
+          el.singleProp = undefined;
+          assertEffects({singlePropObserver: 1});
+        });
+        test('one multiPropObserver arguments undefined', () => {
+          setupElement({multiProp1, multiProp2});
+          assertEffects({multiPropObserver: 1});
+          el.multiProp1 = undefined;
+          assertEffects({multiPropObserver: 1});
+        });
+        test('all multiPropObserver undefined', () => {
+          setupElement({multiProp1, multiProp2});
+          assertEffects({multiPropObserver: 1});
+          el.multiProp1 = undefined;
+          assertEffects({multiPropObserver: 1});
+          el.multiProp2 = undefined;
+          assertEffects({multiPropObserver: 1});
+        });
+        test('computeSingle argument defined', () => {
+          setupElement({computedSingleDep});
+          assertEffects({computeSingle: 1});
+          assert.equal(el.computedSingle, '[computedSingleDep]');
+        });
+        test('one computeMulti argument defined', () => {
+          setupElement({computedMultiDep1});
+          assertEffects({computeMulti: 0});
+          assert.equal(el.computedMulti, undefined);
+        });
+        test('all computeMulti argument defined', () => {
+          setupElement({computedMultiDep1, computedMultiDep2});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.computedMulti, '[computedMultiDep1,computedMultiDep2]');
+        });
+        test('inline computeSingle argument defined', () => {
+          setupElement({inlineSingleDep});
+          assertEffects({computeSingle: 1});
+          assert.equal(el.$.child.computedSingle, '[inlineSingleDep]');
+        });
+        test('one inline computeMulti argument defined', () => {
+          setupElement({inlineMultiDep1});
+          assertEffects({computeMulti: 0});
+          assert.equal(el.$.child.computedMulti, undefined);
+        });
+        test('all inline computeMulti argument defined', () => {
+          setupElement({inlineMultiDep1, inlineMultiDep2});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$.child.computedMulti, '[inlineMultiDep1,inlineMultiDep2]');
+        });
+        test('one inline computeMulti argument defined in dom-if', () => {
+          setupElement({inlineMultiIfDep1});
+          assertEffects({computeMulti: 0});
+          assert.equal(el.$$('#ifChild').computedMulti, undefined);
+        });
+        test('all inline computeMulti argument defined in dom-if', () => {
+          setupElement({inlineMultiIfDep1, inlineMultiIfDep2});
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,inlineMultiIfDep2]');
+        });
+      });
+
+    });
+
+    suite('declarative', () => {
+
+      setup(() => sinon.spy(console, 'warn'));
+
+      teardown(() => console.warn.restore());
+
+      suite('warn', () => {
+        test('no arguments defined', () => {
+          el = fixture('declarative-none');
+          assertEffects({});
+        });
+        test('singlePropObserver argument defined', () => {
+          el = fixture('declarative-single');
+          assertEffects({singlePropObserver: 1});
+        });
+        test('one multiPropObserver arguments defined', () => {
+          el = fixture('declarative-multi-one');
+          assertEffects({multiPropObserver: 0});
+        });
+        test('all multiPropObserver defined', () => {
+          el = fixture('declarative-multi-all');
+          assertEffects({multiPropObserver: 1});
+        });
+        test('computeSingle argument defined', () => {
+          el = fixture('declarative-single-computed');
+          assertEffects({computeSingle: 1});
+          assert.equal(el.computedSingle, '[a]');
+        });
+        test('one computeMulti arguments defined', () => {
+          el = fixture('declarative-multi-one-computed');
+          assertEffects({computeMulti: 0});
+          assert.equal(el.computedMulti, undefined);
+        });
+        test('all computeMulti defined', () => {
+          el = fixture('declarative-multi-all-computed');
+          assert.equal(el.computedMulti, '[b,c]');
+        });
+        test('inline computeSingle argument defined', () => {
+          el = fixture('declarative-single-computed-inline');
+          assertEffects({computeSingle: 1});
+          assert.equal(el.$.child.computedSingle, '[a]');
+        });
+        test('inline one computeMulti arguments defined', () => {
+          el = fixture('declarative-multi-one-computed-inline');
+          assertEffects({computeMulti: 0});
+          assert.equal(el.$.child.computedMulti, undefined);
+        });
+        test('inline all computeMulti defined', () => {
+          el = fixture('declarative-multi-all-computed-inline');
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$.child.computedMulti, '[b,c]');
+        });
+        test('one inline computeMulti argument defined in dom-if', () => {
+          el = fixture('declarative-multi-if-one-computed-inline');
+          flush();
+          assertEffects({computeMulti: 0});
+          assert.equal(el.$$('#ifChild').computedMulti, undefined);
+        });
+        test('all inline computeMulti argument defined in dom-if', () => {
+          el = fixture('declarative-multi-if-all-computed-inline');
+          flush();
+          assertEffects({computeMulti: 1});
+          assert.equal(el.$$('#ifChild').computedMulti, '[b,c]');
+        });
+      });
+    });
+
+  </script>
+</body>
+</html>

--- a/test/unit/legacy-undefined.html
+++ b/test/unit/legacy-undefined.html
@@ -211,7 +211,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setupElement({singleProp});
           assertEffects({singlePropObserver: 1});
           el.singleProp = undefined;
-          assertEffects({singlePropObserver: 1});
+          assertEffects({singlePropObserver: 2});
         });
         test('one multiPropObserver arguments undefined', () => {
           setupElement({multiProp1, multiProp2});
@@ -277,65 +277,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       teardown(() => console.warn.restore());
 
-      suite('warn', () => {
-        test('no arguments defined', () => {
-          el = fixture('declarative-none');
-          assertEffects({});
-        });
-        test('singlePropObserver argument defined', () => {
-          el = fixture('declarative-single');
-          assertEffects({singlePropObserver: 1});
-        });
-        test('one multiPropObserver arguments defined', () => {
-          el = fixture('declarative-multi-one');
-          assertEffects({multiPropObserver: 0});
-        });
-        test('all multiPropObserver defined', () => {
-          el = fixture('declarative-multi-all');
-          assertEffects({multiPropObserver: 1});
-        });
-        test('computeSingle argument defined', () => {
-          el = fixture('declarative-single-computed');
-          assertEffects({computeSingle: 1});
-          assert.equal(el.computedSingle, '[a]');
-        });
-        test('one computeMulti arguments defined', () => {
-          el = fixture('declarative-multi-one-computed');
-          assertEffects({computeMulti: 0});
-          assert.equal(el.computedMulti, undefined);
-        });
-        test('all computeMulti defined', () => {
-          el = fixture('declarative-multi-all-computed');
-          assert.equal(el.computedMulti, '[b,c]');
-        });
-        test('inline computeSingle argument defined', () => {
-          el = fixture('declarative-single-computed-inline');
-          assertEffects({computeSingle: 1});
-          assert.equal(el.$.child.computedSingle, '[a]');
-        });
-        test('inline one computeMulti arguments defined', () => {
-          el = fixture('declarative-multi-one-computed-inline');
-          assertEffects({computeMulti: 0});
-          assert.equal(el.$.child.computedMulti, undefined);
-        });
-        test('inline all computeMulti defined', () => {
-          el = fixture('declarative-multi-all-computed-inline');
-          assertEffects({computeMulti: 1});
-          assert.equal(el.$.child.computedMulti, '[b,c]');
-        });
-        test('one inline computeMulti argument defined in dom-if', () => {
-          el = fixture('declarative-multi-if-one-computed-inline');
-          flush();
-          assertEffects({computeMulti: 0});
-          assert.equal(el.$$('#ifChild').computedMulti, undefined);
-        });
-        test('all inline computeMulti argument defined in dom-if', () => {
-          el = fixture('declarative-multi-if-all-computed-inline');
-          flush();
-          assertEffects({computeMulti: 1});
-          assert.equal(el.$$('#ifChild').computedMulti, '[b,c]');
-        });
+      test('no arguments defined', () => {
+        el = fixture('declarative-none');
+        assertEffects({});
       });
+      test('singlePropObserver argument defined', () => {
+        el = fixture('declarative-single');
+        assertEffects({singlePropObserver: 1});
+      });
+      test('one multiPropObserver arguments defined', () => {
+        el = fixture('declarative-multi-one');
+        assertEffects({multiPropObserver: 0});
+      });
+      test('all multiPropObserver defined', () => {
+        el = fixture('declarative-multi-all');
+        assertEffects({multiPropObserver: 1});
+      });
+      test('computeSingle argument defined', () => {
+        el = fixture('declarative-single-computed');
+        assertEffects({computeSingle: 1});
+        assert.equal(el.computedSingle, '[a]');
+      });
+      test('one computeMulti arguments defined', () => {
+        el = fixture('declarative-multi-one-computed');
+        assertEffects({computeMulti: 0});
+        assert.equal(el.computedMulti, undefined);
+      });
+      test('all computeMulti defined', () => {
+        el = fixture('declarative-multi-all-computed');
+        assert.equal(el.computedMulti, '[b,c]');
+      });
+      test('inline computeSingle argument defined', () => {
+        el = fixture('declarative-single-computed-inline');
+        assertEffects({computeSingle: 1});
+        assert.equal(el.$.child.computedSingle, '[a]');
+      });
+      test('inline one computeMulti arguments defined', () => {
+        el = fixture('declarative-multi-one-computed-inline');
+        assertEffects({computeMulti: 0});
+        assert.equal(el.$.child.computedMulti, undefined);
+      });
+      test('inline all computeMulti defined', () => {
+        el = fixture('declarative-multi-all-computed-inline');
+        assertEffects({computeMulti: 1});
+        assert.equal(el.$.child.computedMulti, '[b,c]');
+      });
+      test('one inline computeMulti argument defined in dom-if', () => {
+        el = fixture('declarative-multi-if-one-computed-inline');
+        flush();
+        assertEffects({computeMulti: 0});
+        assert.equal(el.$$('#ifChild').computedMulti, undefined);
+      });
+      test('all inline computeMulti argument defined in dom-if', () => {
+        el = fixture('declarative-multi-if-all-computed-inline');
+        flush();
+        assertEffects({computeMulti: 1});
+        assert.equal(el.$$('#ifChild').computedMulti, '[b,c]');
+      });
+
     });
 
   </script>


### PR DESCRIPTION
### Description
Adds `legacyUndefined` setting, which reverts to Polymer 1.x rules around `undefined` in multi-property observers & computing functions.