### PR TITLE
Quote the getStyle method of the custom style element

### DIFF
--- a/lib/elements/custom-style.html
+++ b/lib/elements/custom-style.html
@@ -77,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @return {HTMLStyleElement} This element's light-DOM `<style>`
      */
-    getStyle() {
+    'getStyle'() {
       if (this._style) {
         return this._style;
       }


### PR DESCRIPTION
The method is [referenced as a quoted property in ShadyCSS](https://github.com/webcomponents/shadycss/blob/566b2d1256f7e31b3ff678542af4ef3696ca04ec/src/custom-style-interface.js#L84) and so needs to be quoted here to ensure closure compiler ADVANCED mode property renaming does not rename this method.