### PR TITLE
[3.x] Use set and clear debouncer upon completion. Fixes #5250.

### DIFF
--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -136,8 +136,6 @@ export const enqueueDebouncer = function(debouncer) {
   debouncerQueue.add(debouncer);
 };
 
-window.debouncerQueue = debouncerQueue;
-
 /**
  * Flushes any enqueued debouncers
  *

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -123,6 +123,8 @@ let debouncerQueue = new Set();
  * @return {void}
  */
 export const enqueueDebouncer = function(debouncer) {
+  // Re-enqueued debouncers are put at the end of the queue; for Set, this
+  // means removing and re-adding, since forEach traverses insertion order
   if (debouncerQueue.has(debouncer)) {
     debouncerQueue.delete(debouncer);
   }
@@ -136,6 +138,8 @@ export const enqueueDebouncer = function(debouncer) {
  */
 export const flushDebouncers = function() {
   const didFlush = Boolean(debouncerQueue.size);
+  // If new debouncers are added while flushing, Set.forEach will ensure
+  // newly added ones are also flushed
   debouncerQueue.forEach(debouncer => {
     try {
       debouncer.flush();

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -47,6 +47,7 @@ export class Debouncer {
     if (this.isActive()) {
       this._asyncModule.cancel(/** @type {number} */(this._timer));
       this._timer = null;
+      debouncerQueue.delete(this);
     }
   }
   /**
@@ -112,3 +113,38 @@ export class Debouncer {
     return debouncer;
   }
 }
+
+let debouncerQueue = new Set();
+
+/**
+ * Adds a `Debouncer` to a list of globally flushable tasks.
+ *
+ * @param {!Debouncer} debouncer Debouncer to enqueue
+ * @return {void}
+ */
+export const enqueueDebouncer = function(debouncer) {
+  if (debouncerQueue.has(debouncer)) {
+    debouncerQueue.delete(debouncer);
+  }
+  debouncerQueue.add(debouncer);
+};
+
+/**
+ * Flushes any enqueued debouncers
+ *
+ * @return {void}
+ */
+export const flushDebouncers = function() {
+  const didFlush = Boolean(debouncerQueue.size);
+  debouncerQueue.forEach(debouncer => {
+    try {
+      debouncer.flush();
+    } catch(e) {
+      setTimeout(() => {
+        throw e;
+      });
+    }
+  });
+  debouncerQueue = new Set();
+  return didFlush;
+};

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -48,6 +48,10 @@ export class Debouncer {
     if (this.isActive()) {
       this._cancelAsync();
       this._timer = null;
+      // Canceling a debouncer removes its spot from the flush queue,
+      // so if a debouncer is manually canceled and re-debounced, it
+      // will reset its flush order (this is a very minor difference from 1.x)
+      // Re-debouncing via the `debounce` API retains the 1.x FIFO flush order
       debouncerQueue.delete(this);
     }
   }

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -36,6 +36,7 @@ export class Debouncer {
     this._timer = this._asyncModule.run(() => {
       this._timer = null;
       this._callback();
+      debouncerQueue.delete(this);
     });
   }
   /**

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -45,10 +45,18 @@ export class Debouncer {
    */
   cancel() {
     if (this.isActive()) {
-      this._asyncModule.cancel(/** @type {number} */(this._timer));
+      this._cancelAsync();
       this._timer = null;
       debouncerQueue.delete(this);
     }
+  }
+  /**
+   * Cancels a debouncer's async callback.
+   *
+   * @return {void}
+   */
+  _cancelAsync() {
+    this._asyncModule.cancel(/** @type {number} */(this._timer));
   }
   /**
    * Flushes an active debouncer and returns a reference to itself.
@@ -105,7 +113,9 @@ export class Debouncer {
    */
   static debounce(debouncer, asyncModule, callback) {
     if (debouncer instanceof Debouncer) {
-      debouncer.cancel();
+      // Cancel the async callback, but leave in debouncerQueue if it was
+      // enqueued, to maintain 1.x flush order
+      debouncer._cancelAsync();
     } else {
       debouncer = new Debouncer();
     }
@@ -123,13 +133,10 @@ let debouncerQueue = new Set();
  * @return {void}
  */
 export const enqueueDebouncer = function(debouncer) {
-  // Re-enqueued debouncers are put at the end of the queue; for Set, this
-  // means removing and re-adding, since forEach traverses insertion order
-  if (debouncerQueue.has(debouncer)) {
-    debouncerQueue.delete(debouncer);
-  }
   debouncerQueue.add(debouncer);
 };
+
+window.debouncerQueue = debouncerQueue;
 
 /**
  * Flushes any enqueued debouncers

--- a/lib/utils/flush.js
+++ b/lib/utils/flush.js
@@ -11,32 +11,8 @@ import './boot.js';
 /* eslint-disable no-unused-vars */
 import { Debouncer } from '../utils/debounce.js';  // used in type annotations
 /* eslint-enable no-unused-vars */
-
-let debouncerQueue = [];
-
-/**
- * Adds a `Debouncer` to a list of globally flushable tasks.
- *
- * @param {!Debouncer} debouncer Debouncer to enqueue
- * @return {void}
- */
-export const enqueueDebouncer = function(debouncer) {
-  debouncerQueue.push(debouncer);
-};
-
-function flushDebouncers() {
-  const didFlush = Boolean(debouncerQueue.length);
-  while (debouncerQueue.length) {
-    try {
-      debouncerQueue.shift().flush();
-    } catch(e) {
-      setTimeout(() => {
-        throw e;
-      });
-    }
-  }
-  return didFlush;
-}
+import { flushDebouncers } from '../utils/debounce.js';  // used in type annotations
+export { enqueueDebouncer } from '../utils/debounce.js';  // used in type annotations
 
 /**
  * Forces several classes of asynchronously queued tasks to flush:

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -217,11 +217,7 @@ suite('debounce', function() {
       const actualOrder = [];
       let i=1;
       const enqueue = (type, {db, cb} = {}) => {
-        // cb = cb || (() => actualOrder.push(cb));
-        if (!cb) {
-          cb = (() => actualOrder.push(cb));
-          Object.defineProperty(cb, 'name', {value: `db${i}`}); i++;
-        }
+        cb = cb || (() => actualOrder.push(cb));
         db = Debouncer.debounce(db, type, cb);
         enqueueDebouncer(db);
         return {db, cb};

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -248,11 +248,9 @@ suite('debounce', function() {
       testEnqueue(false, done);
     });
 
-    test.only('flushed', function(done) {
+    test('flushed', function(done) {
       testEnqueue(true, done);
     });
-
-    test('re-enqueued ')
 
   });
 });

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -212,55 +212,47 @@ suite('debounce', function() {
   });
 
   suite('enqueueDebouncer & flush', function() {
-    function testEnqueue(shouldFlush, done) {
-      // Longer-running debouncer
-      const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
-      enqueueDebouncer(Debouncer.debounce(null, timeOut, timeoutCallback));
-      // Set of short-running debouncers enqueued in the middle of first set
-      const nestedCallbacks = [];
-      for (let i=0; i<150; i++) {
-        nestedCallbacks.push(sinon.spy(() =>
-          actualCallbacks.push(nestedCallbacks[i])));
-      }
-      // First set of short-running debouncers
-      const microtaskCallbacks = [];
-      for (let i=0; i<150; i++) {
-        microtaskCallbacks.push(sinon.spy(() => {
-          actualCallbacks.push(microtaskCallbacks[i]);
-          if (i === 125) {
-            nestedCallbacks.forEach(cb => 
-              enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
-          }
-        }));
-      }
-      microtaskCallbacks.forEach(cb => 
-        enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
-      // Expect short before long
-      let expectedCallbacks;
-      const actualCallbacks = [];
-      const verify = () => {
-        actualCallbacks.forEach(cb => assert.isTrue(cb.calledOnce));
-        assert.deepEqual(expectedCallbacks, actualCallbacks);
-        done();
+
+    const testEnqueue = (shouldFlush, done) => {
+      const actualOrder = [];
+      let i=1;
+      const enqueue = (type, {db, cb} = {}) => {
+        // cb = cb || (() => actualOrder.push(cb));
+        if (!cb) {
+          cb = (() => actualOrder.push(cb));
+          Object.defineProperty(cb, 'name', {value: `db${i}`}); i++;
+        }
+        db = Debouncer.debounce(db, type, cb);
+        enqueueDebouncer(db);
+        return {db, cb};
       };
+      const db1 = enqueue(microTask);
+      const db2 = enqueue(microTask);
+      const db3 = enqueue(timeOut);
+      const db4 = enqueue(microTask);
+      enqueue(microTask, db2);
+      enqueue(microTask, db1);
       if (shouldFlush) {
-        expectedCallbacks = [timeoutCallback, ...microtaskCallbacks, ...nestedCallbacks];
         flush();
-        // When flushing, order is order of enqueing
-        verify();
+        assert.deepEqual(actualOrder, [db1.cb, db2.cb, db3.cb, db4.cb]);
+        done();
       } else {
-        expectedCallbacks = [...microtaskCallbacks, ...nestedCallbacks, timeoutCallback];
-        timeOut.run(verify);
+        timeOut.run(() => {
+          assert.deepEqual(actualOrder, [db4.cb, db2.cb, db1.cb, db3.cb]);
+          done();
+        });
       }
-    }
+    };
 
     test('non-flushed', function(done) {
       testEnqueue(false, done);
     });
 
-    test('flushed', function(done) {
+    test.only('flushed', function(done) {
       testEnqueue(true, done);
     });
+
+    test('re-enqueued ')
 
   });
 });

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -33,6 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import { Polymer } from '../../polymer-legacy.js';
 import { Debouncer } from '../../lib/utils/debounce.js';
 import { microTask, timeOut, animationFrame, idlePeriod } from '../../lib/utils/async.js';
+import { enqueueDebouncer, flush } from '../../lib/utils/flush.js';
 Polymer({is: 'x-basic'});
 
 suite('debounce', function() {
@@ -206,6 +207,53 @@ suite('debounce', function() {
         assert.isTrue(callback.calledTwice, 'callback should be called twice');
         done();
       });
+    });
+
+  });
+
+  suite('enqueueDebouncer & flush', function() {
+    function testEnqueue(shouldFlush, done) {
+      // Longer-running debouncer
+      const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
+      enqueueDebouncer(Debouncer.debounce(null, timeOut, timeoutCallback));
+      // Set of short-running debouncers enqueued in the middle of first set
+      const nestedCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() =>
+        actualCallbacks.push(nestedCallbacks[i])));
+      // First set of short-running debouncers
+      const microtaskCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() => {
+        actualCallbacks.push(microtaskCallbacks[i]);
+        if (i === 125) {
+          nestedCallbacks.forEach(cb => 
+            enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
+        }
+      }));
+      microtaskCallbacks.forEach(cb => 
+        enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
+      // Expect short before long
+      let expectedCallbacks;
+      const actualCallbacks = [];
+      const verify = () => {
+        actualCallbacks.forEach(cb => assert.isTrue(cb.calledOnce));
+        assert.deepEqual(expectedCallbacks, actualCallbacks);
+        done();
+      };
+      if (shouldFlush) {
+        expectedCallbacks = [timeoutCallback, ...microtaskCallbacks, ...nestedCallbacks];
+        flush();
+        // When flushing, order is order of enqueing
+        verify();
+      } else {
+        expectedCallbacks = [...microtaskCallbacks, ...nestedCallbacks, timeoutCallback];
+        timeOut.run(verify);
+      }
+    }
+
+    test('non-flushed', function(done) {
+      testEnqueue(false, done);
+    });
+
+    test('flushed', function(done) {
+      testEnqueue(true, done);
     });
 
   });

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -217,16 +217,22 @@ suite('debounce', function() {
       const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
       enqueueDebouncer(Debouncer.debounce(null, timeOut, timeoutCallback));
       // Set of short-running debouncers enqueued in the middle of first set
-      const nestedCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() =>
-        actualCallbacks.push(nestedCallbacks[i])));
+      const nestedCallbacks = [];
+      for (let i=0; i<150; i++) {
+        nestedCallbacks.push(sinon.spy(() =>
+          actualCallbacks.push(nestedCallbacks[i])));
+      }
       // First set of short-running debouncers
-      const microtaskCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() => {
-        actualCallbacks.push(microtaskCallbacks[i]);
-        if (i === 125) {
-          nestedCallbacks.forEach(cb => 
-            enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
-        }
-      }));
+      const microtaskCallbacks = [];
+      for (let i=0; i<150; i++) {
+        microtaskCallbacks.push(sinon.spy(() => {
+          actualCallbacks.push(microtaskCallbacks[i]);
+          if (i === 125) {
+            nestedCallbacks.forEach(cb => 
+              enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
+          }
+        }));
+      }
       microtaskCallbacks.forEach(cb => 
         enqueueDebouncer(Debouncer.debounce(null, microTask, cb)));
       // Expect short before long

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -215,7 +215,6 @@ suite('debounce', function() {
 
     const testEnqueue = (shouldFlush, done) => {
       const actualOrder = [];
-      let i=1;
       const enqueue = (type, {db, cb} = {}) => {
         cb = cb || (() => actualOrder.push(cb));
         db = Debouncer.debounce(db, type, cb);


### PR DESCRIPTION
### Description
The queue used to allow debouncers to be flushable did not have a mechanism to be cleared outside of calling `flush()`.

This change switches the queue to use a `Set` instead of an `Array` to allow for O(1) removals, and ensures debouncers are cleared from the queue once they run.

### Reference Issue
Fixes #5250