### PR TITLE
[2.x] Use set and clear debouncer upon completion. Fixes #5250

### DIFF
--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -40,6 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._timer = this._asyncModule.run(() => {
         this._timer = null;
         this._callback();
+        debouncerQueue.delete(this);
       });
     }
     /**
@@ -115,5 +116,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   /** @const */
   Polymer.Debouncer = Debouncer;
+
+  let debouncerQueue = new Set();
+  
+  /**
+   * Adds a `Debouncer` to a list of globally flushable tasks.
+   *
+   * @param {!Debouncer} debouncer Debouncer to enqueue
+   * @return {void}
+   */
+  Polymer.enqueueDebouncer = function(debouncer) {
+    if (debouncerQueue.has(debouncer)) {
+      debouncerQueue.delete(debouncer);
+    }
+    debouncerQueue.add(debouncer);
+  };
+  
+  Polymer.flushDebouncers = function() {
+    const didFlush = Boolean(debouncerQueue.size);
+    debouncerQueue.forEach(debouncer => {
+      try {
+        debouncer.flush();
+      } catch(e) {
+        setTimeout(() => {
+          throw e;
+        });
+      }
+    });
+    debouncerQueue = new Set();
+    return didFlush;
+  };
+
 })();
 </script>

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -122,6 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /**
    * Adds a `Debouncer` to a list of globally flushable tasks.
    *
+   * @memberof Polymer
    * @param {!Debouncer} debouncer Debouncer to enqueue
    * @return {void}
    */

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -39,8 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._callback = callback;
       this._timer = this._asyncModule.run(() => {
         this._timer = null;
-        this._callback();
         debouncerQueue.delete(this);
+        this._callback();
       });
     }
     /**
@@ -51,7 +51,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     cancel() {
       if (this.isActive()) {
         this._cancelAsync();
-        this._timer = null;
         // Canceling a debouncer removes its spot from the flush queue,
         // so if a debouncer is manually canceled and re-debounced, it
         // will reset its flush order (this is a very minor difference from 1.x)
@@ -65,7 +64,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {void}
      */
     _cancelAsync() {
-      this._asyncModule.cancel(/** @type {number} */(this._timer));
+      if (this.isActive()) {
+        this._asyncModule.cancel(/** @type {number} */(this._timer));
+        this._timer = null;
+      }
     }
     /**
      * Flushes an active debouncer and returns a reference to itself.
@@ -158,7 +160,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       }
     });
-    debouncerQueue = new Set();
     return didFlush;
   };
 

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -127,6 +127,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @return {void}
    */
   Polymer.enqueueDebouncer = function(debouncer) {
+    // Re-enqueued debouncers are put at the end of the queue; for Set, this
+    // means removing and re-adding, since forEach traverses insertion order
     if (debouncerQueue.has(debouncer)) {
       debouncerQueue.delete(debouncer);
     }
@@ -135,6 +137,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   
   Polymer.flushDebouncers = function() {
     const didFlush = Boolean(debouncerQueue.size);
+    // If new debouncers are added while flushing, Set.forEach will ensure
+    // newly added ones are also flushed
     debouncerQueue.forEach(debouncer => {
       try {
         debouncer.flush();

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -50,9 +50,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     cancel() {
       if (this.isActive()) {
-        this._asyncModule.cancel(this._timer);
+        this._cancelAsync();
         this._timer = null;
+        debouncerQueue.delete(this);
       }
+    }
+    /**
+     * Cancels a debouncer's async callback.
+     *
+     * @return {void}
+     */
+    _cancelAsync() {
+      this._asyncModule.cancel(/** @type {number} */(this._timer));
     }
     /**
      * Flushes an active debouncer and returns a reference to itself.
@@ -105,7 +114,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     static debounce(debouncer, asyncModule, callback) {
       if (debouncer instanceof Debouncer) {
-        debouncer.cancel();
+        // Cancel the async callback, but leave in debouncerQueue if it was
+        // enqueued, to maintain 1.x flush order
+        debouncer._cancelAsync();
       } else {
         debouncer = new Debouncer();
       }
@@ -127,11 +138,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * @return {void}
    */
   Polymer.enqueueDebouncer = function(debouncer) {
-    // Re-enqueued debouncers are put at the end of the queue; for Set, this
-    // means removing and re-adding, since forEach traverses insertion order
-    if (debouncerQueue.has(debouncer)) {
-      debouncerQueue.delete(debouncer);
-    }
     debouncerQueue.add(debouncer);
   };
   

--- a/lib/utils/debounce.html
+++ b/lib/utils/debounce.html
@@ -52,6 +52,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.isActive()) {
         this._cancelAsync();
         this._timer = null;
+        // Canceling a debouncer removes its spot from the flush queue,
+        // so if a debouncer is manually canceled and re-debounced, it
+        // will reset its flush order (this is a very minor difference from 1.x)
+        // Re-debouncing via the `debounce` API retains the 1.x FIFO flush order
         debouncerQueue.delete(this);
       }
     }

--- a/lib/utils/flush.html
+++ b/lib/utils/flush.html
@@ -8,36 +8,10 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="boot.html">
+<link rel="import" href="debounce.html">
 <script>
 (function() {
   'use strict';
-
-  let debouncerQueue = [];
-
-  /**
-   * Adds a `Polymer.Debouncer` to a list of globally flushable tasks.
-   *
-   * @memberof Polymer
-   * @param {!Polymer.Debouncer} debouncer Debouncer to enqueue
-   * @return {void}
-   */
-  Polymer.enqueueDebouncer = function(debouncer) {
-    debouncerQueue.push(debouncer);
-  };
-
-  function flushDebouncers() {
-    const didFlush = Boolean(debouncerQueue.length);
-    while (debouncerQueue.length) {
-      try {
-        debouncerQueue.shift().flush();
-      } catch(e) {
-        setTimeout(() => {
-          throw e;
-        });
-      }
-    }
-    return didFlush;
-  }
 
   /**
    * Forces several classes of asynchronously queued tasks to flush:
@@ -54,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (window.ShadyCSS && window.ShadyCSS.ScopingShim) {
         window.ShadyCSS.ScopingShim.flush();
       }
-      debouncers = flushDebouncers();
+      debouncers = Polymer.flushDebouncers();
     } while (shadyDOM || debouncers);
   };
 

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -216,16 +216,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
       Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.timeOut, timeoutCallback));
       // Set of short-running debouncers enqueued in the middle of first set
-      const nestedCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() =>
-        actualCallbacks.push(nestedCallbacks[i])));
+      const nestedCallbacks = [];
+      for (let i=0; i<150; i++) {
+        nestedCallbacks.push(sinon.spy(() =>
+          actualCallbacks.push(nestedCallbacks[i])));
+      }
       // First set of short-running debouncers
-      const microtaskCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() => {
-        actualCallbacks.push(microtaskCallbacks[i]);
-        if (i === 125) {
-          nestedCallbacks.forEach(cb => 
-            Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
-        }
-      }));
+      const microtaskCallbacks = [];
+      for (let i=0; i<150; i++) {
+        microtaskCallbacks.push(sinon.spy(() => {
+          actualCallbacks.push(microtaskCallbacks[i]);
+          if (i === 125) {
+            nestedCallbacks.forEach(cb => 
+              Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
+          }
+        }));
+      }
       microtaskCallbacks.forEach(cb => 
         Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
       // Expect short before long

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -34,6 +34,86 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({is: 'x-basic'});
   });
 
+  suite('enqueueDebouncer & flush', function() {
+  
+    // NOTE: This is a regression test; the bug it fixed only occurred if the
+    // debouncer was flushed before any microtasks run, hence it should be
+    // first in this file
+    test('re-enqueue canceled debouncer', function() {
+      const cb = sinon.spy();
+      let db;
+      db = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb);
+      Polymer.enqueueDebouncer(db);
+      db.cancel();
+      assert.equal(db.isActive(), false);
+      assert.equal(cb.callCount, 0);
+      db = Polymer.Debouncer.debounce(db, Polymer.Async.microTask, cb);
+      Polymer.enqueueDebouncer(db);
+      Polymer.flush();
+      assert.isTrue(cb.calledOnce);
+    });
+  
+    test('flushDebouncers from enqueued debouncer', function(done) {
+      const cb = sinon.spy(() => Polymer.flush());
+      let db = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb);
+      Polymer.enqueueDebouncer(db);
+      setTimeout(() => {
+        assert.isTrue(cb.calledOnce);
+        done();
+      });
+    });
+  
+    const testEnqueue = (shouldFlush, done) => {
+      const actualOrder = [];
+      const enqueue = (type, {db, cb} = {}) => {
+        cb = cb || (() => actualOrder.push(cb));
+        db = Polymer.Debouncer.debounce(db, type, cb);
+        Polymer.enqueueDebouncer(db);
+        return {db, cb};
+      };
+      const db1 = enqueue(Polymer.Async.microTask);
+      const db2 = enqueue(Polymer.Async.microTask);
+      const db3 = enqueue(Polymer.Async.timeOut);
+      const db4 = enqueue(Polymer.Async.microTask);
+      enqueue(Polymer.Async.microTask, db2);
+      enqueue(Polymer.Async.microTask, db1);
+      if (shouldFlush) {
+        Polymer.flush();
+        assert.deepEqual(actualOrder, [db1.cb, db2.cb, db3.cb, db4.cb]);
+        done();
+      } else {
+        Polymer.Async.timeOut.run(() => {
+          assert.deepEqual(actualOrder, [db4.cb, db2.cb, db1.cb, db3.cb]);
+          done();
+        });
+      }
+    };
+  
+    test('non-flushed', function(done) {
+      testEnqueue(false, done);
+    });
+  
+    test('flushed', function(done) {
+      testEnqueue(true, done);
+    });
+  
+    test('reentrant flush', function() {
+      const cb2 = sinon.spy();
+      let db2;
+      const cb1 = sinon.spy(() => {
+        Polymer.flush();
+        db2 = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb2);
+        Polymer.enqueueDebouncer(db2);
+      });
+      const db1 = Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb1);
+      Polymer.enqueueDebouncer(db1);
+      Polymer.flush();
+      assert.isTrue(cb1.calledOnce);
+      assert.isTrue(cb2.calledOnce);
+    });
+  
+  });
+
   suite('debounce', function() {
     var element;
 
@@ -207,43 +287,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-    });
-  });
-
-  suite('enqueueDebouncer & flush', function() {
-
-    const testEnqueue = (shouldFlush, done) => {
-      const actualOrder = [];
-      const enqueue = (type, {db, cb} = {}) => {
-        cb = cb || (() => actualOrder.push(cb));
-        db = Polymer.Debouncer.debounce(db, type, cb);
-        Polymer.enqueueDebouncer(db);
-        return {db, cb};
-      };
-      const db1 = enqueue(Polymer.Async.microTask);
-      const db2 = enqueue(Polymer.Async.microTask);
-      const db3 = enqueue(Polymer.Async.timeOut);
-      const db4 = enqueue(Polymer.Async.microTask);
-      enqueue(Polymer.Async.microTask, db2);
-      enqueue(Polymer.Async.microTask, db1);
-      if (shouldFlush) {
-        Polymer.flush();
-        assert.deepEqual(actualOrder, [db1.cb, db2.cb, db3.cb, db4.cb]);
-        done();
-      } else {
-        Polymer.Async.timeOut.run(() => {
-          assert.deepEqual(actualOrder, [db4.cb, db2.cb, db1.cb, db3.cb]);
-          done();
-        });
-      }
-    };
-
-    test('non-flushed', function(done) {
-      testEnqueue(false, done);
-    });
-
-    test('flushed', function(done) {
-      testEnqueue(true, done);
     });
 
   });

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -211,47 +211,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
   suite('enqueueDebouncer & flush', function() {
-    function testEnqueue(shouldFlush, done) {
-      // Longer-running debouncer
-      const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
-      Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.timeOut, timeoutCallback));
-      // Set of short-running debouncers enqueued in the middle of first set
-      const nestedCallbacks = [];
-      for (let i=0; i<150; i++) {
-        nestedCallbacks.push(sinon.spy(() =>
-          actualCallbacks.push(nestedCallbacks[i])));
-      }
-      // First set of short-running debouncers
-      const microtaskCallbacks = [];
-      for (let i=0; i<150; i++) {
-        microtaskCallbacks.push(sinon.spy(() => {
-          actualCallbacks.push(microtaskCallbacks[i]);
-          if (i === 125) {
-            nestedCallbacks.forEach(cb => 
-              Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
-          }
-        }));
-      }
-      microtaskCallbacks.forEach(cb => 
-        Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
-      // Expect short before long
-      let expectedCallbacks;
-      const actualCallbacks = [];
-      const verify = () => {
-        actualCallbacks.forEach(cb => assert.isTrue(cb.calledOnce));
-        assert.deepEqual(expectedCallbacks, actualCallbacks);
-        done();
+
+    const testEnqueue = (shouldFlush, done) => {
+      const actualOrder = [];
+      let i=1;
+      const enqueue = (type, {db, cb} = {}) => {
+        cb = cb || (() => actualOrder.push(cb));
+        db = Polymer.Debouncer.debounce(db, type, cb);
+        Polymer.enqueueDebouncer(db);
+        return {db, cb};
       };
+      const db1 = enqueue(Polymer.Async.microTask);
+      const db2 = enqueue(Polymer.Async.microTask);
+      const db3 = enqueue(Polymer.Async.timeOut);
+      const db4 = enqueue(Polymer.Async.microTask);
+      enqueue(Polymer.Async.microTask, db2);
+      enqueue(Polymer.Async.microTask, db1);
       if (shouldFlush) {
-        expectedCallbacks = [timeoutCallback, ...microtaskCallbacks, ...nestedCallbacks];
         Polymer.flush();
-        // When flushing, order is order of enqueing
-        verify();
+        assert.deepEqual(actualOrder, [db1.cb, db2.cb, db3.cb, db4.cb]);
+        done();
       } else {
-        expectedCallbacks = [...microtaskCallbacks, ...nestedCallbacks, timeoutCallback];
-        Polymer.Async.timeOut.run(verify);
+        Polymer.Async.timeOut.run(() => {
+          assert.deepEqual(actualOrder, [db4.cb, db2.cb, db1.cb, db3.cb]);
+          done();
+        });
       }
-    }
+    };
 
     test('non-flushed', function(done) {
       testEnqueue(false, done);

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -209,6 +209,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
   });
+
+  suite('enqueueDebouncer & flush', function() {
+    function testEnqueue(shouldFlush, done) {
+      // Longer-running debouncer
+      const timeoutCallback = sinon.spy(() => actualCallbacks.push(timeoutCallback));
+      Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.timeOut, timeoutCallback));
+      // Set of short-running debouncers enqueued in the middle of first set
+      const nestedCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() =>
+        actualCallbacks.push(nestedCallbacks[i])));
+      // First set of short-running debouncers
+      const microtaskCallbacks = new Array(150).fill().map((_, i) => sinon.spy(() => {
+        actualCallbacks.push(microtaskCallbacks[i]);
+        if (i === 125) {
+          nestedCallbacks.forEach(cb => 
+            Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
+        }
+      }));
+      microtaskCallbacks.forEach(cb => 
+        Polymer.enqueueDebouncer(Polymer.Debouncer.debounce(null, Polymer.Async.microTask, cb)));
+      // Expect short before long
+      let expectedCallbacks;
+      const actualCallbacks = [];
+      const verify = () => {
+        actualCallbacks.forEach(cb => assert.isTrue(cb.calledOnce));
+        assert.deepEqual(expectedCallbacks, actualCallbacks);
+        done();
+      };
+      if (shouldFlush) {
+        expectedCallbacks = [timeoutCallback, ...microtaskCallbacks, ...nestedCallbacks];
+        Polymer.flush();
+        // When flushing, order is order of enqueing
+        verify();
+      } else {
+        expectedCallbacks = [...microtaskCallbacks, ...nestedCallbacks, timeoutCallback];
+        Polymer.Async.timeOut.run(verify);
+      }
+    }
+
+    test('non-flushed', function(done) {
+      testEnqueue(false, done);
+    });
+
+    test('flushed', function(done) {
+      testEnqueue(true, done);
+    });
+
+  });
 </script>
 </body>
 </html>

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -214,7 +214,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     const testEnqueue = (shouldFlush, done) => {
       const actualOrder = [];
-      let i=1;
       const enqueue = (type, {db, cb} = {}) => {
         cb = cb || (() => actualOrder.push(cb));
         db = Polymer.Debouncer.debounce(db, type, cb);

--- a/types/lib/utils/debounce.d.ts
+++ b/types/lib/utils/debounce.d.ts
@@ -80,4 +80,10 @@ declare namespace Polymer {
      */
     isActive(): boolean;
   }
+
+
+  /**
+   * Adds a `Debouncer` to a list of globally flushable tasks.
+   */
+  function enqueueDebouncer(debouncer: Debouncer): void;
 }

--- a/types/lib/utils/debounce.d.ts
+++ b/types/lib/utils/debounce.d.ts
@@ -69,6 +69,11 @@ declare namespace Polymer {
     cancel(): void;
 
     /**
+     * Cancels a debouncer's async callback.
+     */
+    _cancelAsync(): void;
+
+    /**
      * Flushes an active debouncer and returns a reference to itself.
      */
     flush(): void;

--- a/types/lib/utils/flush.d.ts
+++ b/types/lib/utils/flush.d.ts
@@ -12,14 +12,9 @@
 // tslint:disable:variable-name Describing an API that's defined elsewhere.
 
 /// <reference path="boot.d.ts" />
+/// <reference path="debounce.d.ts" />
 
 declare namespace Polymer {
-
-
-  /**
-   * Adds a `Polymer.Debouncer` to a list of globally flushable tasks.
-   */
-  function enqueueDebouncer(debouncer: Polymer.Debouncer): void;
 
 
   /**


### PR DESCRIPTION
### Description
The queue used to allow debouncers to be flushable did not have a mechanism to be cleared outside of calling `flush()`.

This change switches the queue to use a `Set` instead of an `Array` to allow for O(1) removals, and ensures debouncers are cleared from the queue once they run.

### Reference Issue
Fixes #5250