### PR TITLE
Fix/suppress upcoming JSCompiler build errors

### DIFF
--- a/lib/utils/gestures.js
+++ b/lib/utils/gestures.js
@@ -178,9 +178,10 @@ let mouseCanceller = function(mouseEvent) {
     for (let i = 0; i < path.length; i++) {
       if (path[i].nodeType === Node.ELEMENT_NODE) {
         if (path[i].localName === 'label') {
-          clickedLabels.push(path[i]);
+          clickedLabels.push(/** @type {!HTMLLabelElement} */ (path[i]));
         } else if (canBeLabelled(path[i])) {
-          let ownerLabels = matchingLabels(path[i]);
+          let ownerLabels =
+              matchingLabels(/** @type {!HTMLElement} */ (path[i]));
           // check if one of the clicked labels is labelling this element
           for (let j = 0; j < ownerLabels.length; j++) {
             clickFromLabel = clickFromLabel || clickedLabels.indexOf(ownerLabels[j]) > -1;
@@ -386,7 +387,7 @@ export function deepTargetFind(x, y) {
  * @return {EventTarget} Returns the event target.
  */
 function _findOriginalTarget(ev) {
-  const path = getComposedPath(ev);
+  const path = getComposedPath(/** @type {?Event} */ev);
   // It shouldn't be, but sometimes path is empty (window on Safari).
   return path.length > 0 ? path[0] : ev.target;
 }


### PR DESCRIPTION
Upstreaming cl/236195240 from the jscompiler team.

These errors come from the compiler incorrectly overriding JSDoc on a declaration with its right-hand-side. In some cases the JSDoc should not have been there; in other cases the JSDoc was correct and this reveals an error elsewhere.