### PR TITLE
Allow value to merge from previous behavior property declaration. Fixes #5503

### DIFF
--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -155,6 +155,27 @@ function flattenBehaviors(behaviors, list, exclude) {
   return list;
 }
 
+/**
+ * Copies property descriptors from source to target, overwriting all fields
+ * of any previous descriptor for a property *except* for `value`, which is
+ * merged in from the target if it does not exist on the source.
+ * 
+ * @param {*} target Target properties object
+ * @param {*} source Source properties object
+ */
+function mergeProperties(target, source) {
+  for (const p in source) {
+    const targetInfo = target[p];
+    const value = targetInfo && targetInfo.value;
+    const sourceInfo = source[p];
+    if (sourceInfo.value === undefined && value !== undefined) {
+      target[p] = Object.assign({value}, sourceInfo);
+    } else {
+      target[p] = sourceInfo;
+    }
+  }
+}
+
 /* Note about construction and extension of legacy classes.
   [Changed in Q4 2018 to optimize performance.]
 
@@ -227,10 +248,10 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       const properties = {};
       if (behaviorList) {
         for (let i=0; i < behaviorList.length; i++) {
-          Object.assign(properties, behaviorList[i].properties);
+          mergeProperties(properties, behaviorList[i].properties);
         }
       }
-      Object.assign(properties, info.properties);
+      mergeProperties(properties, info.properties);
       return properties;
     }
 

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -166,10 +166,9 @@ function flattenBehaviors(behaviors, list, exclude) {
 function mergeProperties(target, source) {
   for (const p in source) {
     const targetInfo = target[p];
-    const value = targetInfo && targetInfo.value;
     const sourceInfo = source[p];
-    if (sourceInfo.value === undefined && value !== undefined) {
-      target[p] = Object.assign({value}, sourceInfo);
+    if (!('value' in sourceInfo) && targetInfo && ('value' in targetInfo)) {
+      target[p] = Object.assign({value: targetInfo.value}, sourceInfo);
     } else {
       target[p] = sourceInfo;
     }

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -403,14 +403,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         {
           properties: {
             foo: { value: 'a' },
-            bar: { value: 'a'}
+            bar: { value: 'a' },
+            ziz: { value: 'a' }
           }
         },
         {
           properties: {
             foo: { value: 'b' },
             bar: String,
-            zot: {value: 'b'}
+            zot: { value: 'b' },
+            ziz: { value: 'b' }
           }
         },
 
@@ -418,7 +420,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       properties: {
         foo: String,
-        zot: String
+        zot: String,
+        ziz: { value: 'c' }
       }
     });
 
@@ -590,6 +593,7 @@ suite('single behavior element', function() {
     assert.equal(el.foo, 'b');
     assert.equal(el.bar, 'a');
     assert.equal(el.zot, 'b');
+    assert.equal(el.ziz, 'c');
   });
 
   test('readOnly not applied when property was previously observed', function() {

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -402,15 +402,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       behaviors: [
         {
           properties: {
-            foo: { value: true },
-            bar: { value: true}
+            foo: { value: 'a' },
+            bar: { value: 'a'}
           }
         },
         {
           properties: {
-            foo: { value: true },
+            foo: { value: 'b' },
             bar: String,
-            zot: {value: true}
+            zot: {value: 'b'}
           }
         },
 
@@ -587,9 +587,9 @@ suite('single behavior element', function() {
 
   test('behavior default values can be overridden', function() {
     const el = fixture('override-default-value');
-    assert.notOk(el.foo);
-    assert.notOk(el.bar);
-    assert.notOk(el.zot);
+    assert.equal(el.foo, 'b');
+    assert.equal(el.bar, 'a');
+    assert.equal(el.zot, 'b');
   });
 
   test('readOnly not applied when property was previously observed', function() {


### PR DESCRIPTION
### Description
Ensure the `value` field from an earlier behavior's property declaration is carried forward if any successive declaration for the same property omits `value`.  This was the [1.x behavior](https://github.com/Polymer/polymer/blob/a6660bd72521cb9918753d14f7216820abbc35c4/src/standard/configure.html#L105-L118), which overwrote the configuration value when present for each successive behavior followed by the element.

### Reference Issue
Fixes #5503
