### PR TITLE
Additional debouncer fixes

### DIFF
--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -35,8 +35,8 @@ export class Debouncer {
     this._callback = callback;
     this._timer = this._asyncModule.run(() => {
       this._timer = null;
-      this._callback();
       debouncerQueue.delete(this);
+      this._callback();
     });
   }
   /**

--- a/lib/utils/debounce.js
+++ b/lib/utils/debounce.js
@@ -161,6 +161,5 @@ export const flushDebouncers = function() {
       });
     }
   });
-  debouncerQueue = new Set();
   return didFlush;
 };

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -62,7 +62,7 @@ suite('enqueueDebouncer & flush', function() {
     setTimeout(() => {
       assert.isTrue(cb.calledOnce);
       done();
-    })
+    });
   });
 
   const testEnqueue = (shouldFlush, done) => {

--- a/test/unit/debounce.html
+++ b/test/unit/debounce.html
@@ -38,7 +38,7 @@ Polymer({is: 'x-basic'});
 
 suite('enqueueDebouncer & flush', function() {
 
-  // NOTE: This is a regression test; the bug it fixed only occured if the
+  // NOTE: This is a regression test; the bug it fixed only occurred if the
   // debouncer was flushed before any microtasks run, hence it should be
   // first in this file
   test('re-enqueue canceled debouncer', function() {
@@ -53,6 +53,16 @@ suite('enqueueDebouncer & flush', function() {
     enqueueDebouncer(db);
     flush();
     assert.isTrue(cb.calledOnce);
+  });
+
+  test('flushDebouncers from enqueued debouncer', function(done) {
+    const cb = sinon.spy(() => flush());
+    let db = Debouncer.debounce(null, microTask, cb);
+    enqueueDebouncer(db);
+    setTimeout(() => {
+      assert.isTrue(cb.calledOnce);
+      done();
+    })
   });
 
   const testEnqueue = (shouldFlush, done) => {
@@ -87,6 +97,21 @@ suite('enqueueDebouncer & flush', function() {
 
   test('flushed', function(done) {
     testEnqueue(true, done);
+  });
+
+  test('reentrant flush', function() {
+    const cb2 = sinon.spy();
+    let db2;
+    const cb1 = sinon.spy(() => {
+      flush();
+      db2 = Debouncer.debounce(null, microTask, cb2);
+      enqueueDebouncer(db2);
+    });
+    const db1 = Debouncer.debounce(null, microTask, cb1);
+    enqueueDebouncer(db1);
+    flush();
+    assert.isTrue(cb1.calledOnce);
+    assert.isTrue(cb2.calledOnce);
   });
 
 });


### PR DESCRIPTION
Additional updates to #5499 and #5508 based on internal testing:
* Don't clear set at the end for `flushDebouncers` reentrancy robustness (they will be deleted from queue when they run, so queue should always be empty when `forEach` returns.
* Remove debouncer from queue before running debouncer callback, to protect against callback calling `flush()`

### Reference Issue
Fixes #5250 
