### PR TITLE
Remove Google+ links in README.md and CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Beyond GitHub, we try to have a variety of different lines of communication open
 
 * [Blog](https://blog.polymer-project.org/)
 * [Twitter](https://twitter.com/polymer)
-* [Google+ Community](https://plus.sandbox.google.com/u/0/communities/115626364525706131031?cfem=1)
 * [Mailing list](https://groups.google.com/forum/#!forum/polymer-dev)
 * [Slack channel](https://bit.ly/polymerslack)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Beyond GitHub, we try to have a variety of different lines of communication avai
 
 * [Blog](https://blog.polymer-project.org/)
 * [Twitter](https://twitter.com/polymer)
-* [Google+ community](https://plus.google.com/communities/115626364525706131031)
 * [Mailing list](https://groups.google.com/forum/#!forum/polymer-dev)
 * [Slack channel](https://bit.ly/polymerslack)
 


### PR DESCRIPTION
Maybe it is smart to not merge this until the 2nd of April, when Google+ actually shuts down.
### Reference Issue
Fixes #5510
