### PR TITLE
Remove use of TreeWalker for finding nodes in templates.

### DIFF
--- a/lib/mixins/template-stamp.js
+++ b/lib/mixins/template-stamp.js
@@ -11,9 +11,6 @@ import '../utils/boot.js';
 
 import { dedupingMixin } from '../utils/mixin.js';
 
-const walker = document.createTreeWalker(document, NodeFilter.SHOW_ALL,
-    null, false);
-
 // 1.x backwards-compatible auto-wrapper for template type extensions
 // This is a clear layering violation and gives favored-nation status to
 // dom-if and dom-repeat templates.  This is a conceit we're choosing to keep
@@ -48,8 +45,7 @@ function findTemplateNode(root, nodeInfo) {
   if (parent) {
     // note: marginally faster than indexing via childNodes
     // (http://jsperf.com/childnodes-lookup)
-    walker.currentNode = parent;
-    for (let n=walker.firstChild(), i=0; n; n=walker.nextSibling()) {
+    for (let n=parent.firstChild, i=0; n; n=n.nextSibling) {
       if (nodeInfo.parentIndex === i++) {
         return n;
       }
@@ -238,8 +234,7 @@ export const TemplateStamp = dedupingMixin(
         // For ShadyDom optimization, indicating there is an insertion point
         templateInfo.hasInsertionPoint = true;
       }
-      walker.currentNode = element;
-      if (walker.firstChild()) {
+      if (element.firstChild) {
         noted = this._parseTemplateChildNodes(element, templateInfo, nodeInfo) || noted;
       }
       if (element.hasAttributes && element.hasAttributes()) {
@@ -265,8 +260,7 @@ export const TemplateStamp = dedupingMixin(
       if (root.localName === 'script' || root.localName === 'style') {
         return;
       }
-      walker.currentNode = root;
-      for (let node=walker.firstChild(), parentIndex=0, next; node; node=next) {
+      for (let node=root.firstChild, parentIndex=0, next; node; node=next) {
         // Wrap templates
         if (node.localName == 'template') {
           node = wrapTemplateExtension(node);
@@ -275,13 +269,12 @@ export const TemplateStamp = dedupingMixin(
         // text nodes to be inexplicably split =(
         // note that root.normalize() should work but does not so we do this
         // manually.
-        walker.currentNode = node;
-        next = walker.nextSibling();
+        next = node.nextSibling;
         if (node.nodeType === Node.TEXT_NODE) {
           let /** Node */ n = next;
           while (n && (n.nodeType === Node.TEXT_NODE)) {
             node.textContent += n.textContent;
-            next = walker.nextSibling();
+            next = n.nextSibling;
             root.removeChild(n);
             n = next;
           }
@@ -296,8 +289,7 @@ export const TemplateStamp = dedupingMixin(
           childInfo.infoIndex = templateInfo.nodeInfoList.push(/** @type {!NodeInfo} */(childInfo)) - 1;
         }
         // Increment if not removed
-        walker.currentNode = node;
-        if (walker.parentNode()) {
+        if (node.parentNode) {
           parentIndex++;
         }
       }


### PR DESCRIPTION
TreeWalker is slower than normal DOM accessors on Edge/IE. This change was put in place to enhance performance by avoiding ShadyDOM patches, but the recent noPatch mode is a better way to accomplish this.