### PR TITLE
Remove use of TreeWalker for finding nodes in templates.

### DIFF
--- a/lib/mixins/template-stamp.html
+++ b/lib/mixins/template-stamp.html
@@ -16,9 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   'use strict';
 
-  const walker = document.createTreeWalker(document, NodeFilter.SHOW_ALL,
-      null, false);
-
   // 1.x backwards-compatible auto-wrapper for template type extensions
   // This is a clear layering violation and gives favored-nation status to
   // dom-if and dom-repeat templates.  This is a conceit we're choosing to keep
@@ -53,8 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     if (parent) {
       // note: marginally faster than indexing via childNodes
       // (http://jsperf.com/childnodes-lookup)
-      walker.currentNode = parent;
-      for (let n=walker.firstChild(), i=0; n; n=walker.nextSibling()) {
+      for (let n=parent.firstChild, i=0; n; n=n.nextSibling) {
         if (nodeInfo.parentIndex === i++) {
           return n;
         }
@@ -244,8 +240,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // For ShadyDom optimization, indicating there is an insertion point
           templateInfo.hasInsertionPoint = true;
         }
-        walker.currentNode = element;
-        if (walker.firstChild()) {
+        if (element.firstChild) {
           noted = this._parseTemplateChildNodes(element, templateInfo, nodeInfo) || noted;
         }
         if (element.hasAttributes && element.hasAttributes()) {
@@ -271,8 +266,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (root.localName === 'script' || root.localName === 'style') {
           return;
         }
-        walker.currentNode = root;
-        for (let node=walker.firstChild(), parentIndex=0, next; node; node=next) {
+        for (let node=root.firstChild, parentIndex=0, next; node; node=next) {
           // Wrap templates
           if (node.localName == 'template') {
             node = wrapTemplateExtension(node);
@@ -281,13 +275,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // text nodes to be inexplicably split =(
           // note that root.normalize() should work but does not so we do this
           // manually.
-          walker.currentNode = node;
-          next = walker.nextSibling();
+          next = node.nextSibling;
           if (node.nodeType === Node.TEXT_NODE) {
             let /** Node */ n = next;
             while (n && (n.nodeType === Node.TEXT_NODE)) {
               node.textContent += n.textContent;
-              next = walker.nextSibling();
+              next = n.nextSibling;
               root.removeChild(n);
               n = next;
             }
@@ -302,8 +295,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             childInfo.infoIndex = templateInfo.nodeInfoList.push(/** @type {!NodeInfo} */(childInfo)) - 1;
           }
           // Increment if not removed
-          walker.currentNode = node;
-          if (walker.parentNode()) {
+          if (node.parentNode) {
             parentIndex++;
           }
         }

--- a/types/lib/elements/array-selector.d.ts
+++ b/types/lib/elements/array-selector.d.ts
@@ -155,7 +155,10 @@ declare namespace Polymer {
    *       </template>
    *     </dom-repeat>
    *
-   *     <array-selector id="selector" items="{{employees}}" selected="{{selected}}" multi toggle></array-selector>
+   *     <array-selector id="selector"
+   *                     items="{{employees}}"
+   *                     selected="{{selected}}"
+   *                     multi toggle></array-selector>
    *
    *     <div> Selected employees: </div>
    *     <dom-repeat items="{{selected}}">
@@ -187,7 +190,7 @@ declare namespace Polymer {
    *    };
    *  }
    *  toggleSelection(e) {
-   *    let item = this.$.employeeList.itemForElement(e.target);
+   *    const item = this.$.employeeList.itemForElement(e.target);
    *    this.$.selector.select(item);
    *  }
    * }

--- a/types/lib/elements/dom-module.d.ts
+++ b/types/lib/elements/dom-module.d.ts
@@ -69,7 +69,7 @@ declare namespace Polymer {
      * @param value Current value of attribute.
      * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace?: string|null): void;
 
     /**
      * Registers the dom-module at a given id. This method should only be called

--- a/types/lib/elements/dom-repeat.d.ts
+++ b/types/lib/elements/dom-repeat.d.ts
@@ -73,15 +73,14 @@ declare namespace Polymer {
    * instances, which will update via the normal structured data notification system.
    *
    * Mutations to the `items` array itself should be made using the Array
-   * mutation API's on `Polymer.Base` (`push`, `pop`, `splice`, `shift`,
-   * `unshift`), and template instances will be kept in sync with the data in the
-   * array.
+   * mutation API's on the PropertyEffects mixin (`push`, `pop`, `splice`,
+   * `shift`, `unshift`), and template instances will be kept in sync with the
+   * data in the array.
    *
    * Events caught by event handlers within the `dom-repeat` template will be
    * decorated with a `model` property, which represents the binding scope for
-   * each template instance.  The model is an instance of Polymer.Base, and should
-   * be used to manipulate data on the instance, for example
-   * `event.model.set('item.checked', true);`.
+   * each template instance.  The model should be used to manipulate data on the
+   * instance, for example `event.model.set('item.checked', true);`.
    *
    * Alternatively, the model for a template instance for an element stamped by
    * a `dom-repeat` can be obtained using the `modelForElement` API on the

--- a/types/lib/legacy/class.d.ts
+++ b/types/lib/legacy/class.d.ts
@@ -17,19 +17,6 @@ declare namespace Polymer {
 
 
   /**
-   * Applies a "legacy" behavior or array of behaviors to the provided class.
-   *
-   * Note: this method will automatically also apply the `Polymer.LegacyElementMixin`
-   * to ensure that any legacy behaviors can rely on legacy Polymer API on
-   * the underlying element.
-   *
-   * @returns Returns a new Element class extended by the
-   * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
-   */
-  function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): {new(): T};
-
-
-  /**
    * Generates a class that extends `Polymer.LegacyElement` based on the
    * provided info object.  Metadata objects on the `info` object
    * (`properties`, `observers`, `listeners`, `behaviors`, `is`) are used

--- a/types/lib/legacy/legacy-data-mixin.d.ts
+++ b/types/lib/legacy/legacy-data-mixin.d.ts
@@ -42,52 +42,20 @@ declare namespace Polymer {
 
   interface LegacyDataMixinConstructor {
     new(...args: any[]): LegacyDataMixin;
-
-    /**
-     * Overrides `Polyer.PropertyEffects` to wrap effect functions to
-     * catch `UndefinedArgumentError`s and warn.
-     *
-     * @param templateInfo Template metadata to add effect to
-     * @param prop Property that should trigger the effect
-     * @param effect Effect metadata object
-     */
-    _addTemplatePropertyEffect(templateInfo: object|null, prop: string, effect?: object|null): void;
   }
 
   interface LegacyDataMixin {
-    readonly _legacyUndefinedCheck: any;
-
-    /**
-     * Overrides `Polyer.PropertyEffects` to wrap effect functions to
-     * catch `UndefinedArgumentError`s and warn.
-     *
-     * @param property Property that should trigger the effect
-     * @param type Effect type, from this.PROPERTY_EFFECT_TYPES
-     * @param effect Effect metadata object
-     */
-    _addPropertyEffect(property: string, type: string, effect?: object|null): void;
   }
 }
 
-declare class LegacyDataMixin extends superClass {
+declare function TemplatizeMixin<T extends new (...args: any[]) => {}>(base: T): T & TemplatizeMixinConstructor;
 
-  /**
-   * Overrides `Polyer.PropertyEffects` to wrap effect functions to
-   * catch `UndefinedArgumentError`s and warn.
-   *
-   * @param templateInfo Template metadata to add effect to
-   * @param prop Property that should trigger the effect
-   * @param effect Effect metadata object
-   */
-  static _addTemplatePropertyEffect(templateInfo: object|null, prop: string, effect?: object|null): void;
+interface TemplatizeMixinConstructor {
+  new(...args: any[]): TemplatizeMixin;
+}
 
-  /**
-   * Overrides `Polyer.PropertyEffects` to wrap effect functions to
-   * catch `UndefinedArgumentError`s and warn.
-   *
-   * @param property Property that should trigger the effect
-   * @param type Effect type, from this.PROPERTY_EFFECT_TYPES
-   * @param effect Effect metadata object
-   */
-  _addPropertyEffect(property: string, type: string, effect?: object|null): void;
+interface TemplatizeMixin {
+}
+
+declare class legacyBase extends HTMLElement {
 }

--- a/types/lib/legacy/legacy-element-mixin.d.ts
+++ b/types/lib/legacy/legacy-element-mixin.d.ts
@@ -20,6 +20,10 @@
 /// <reference path="../utils/render-status.d.ts" />
 /// <reference path="../utils/unresolved.d.ts" />
 /// <reference path="polymer.dom.d.ts" />
+/// <reference path="../utils/gestures.d.ts" />
+/// <reference path="../utils/debounce.d.ts" />
+/// <reference path="../utils/async.d.ts" />
+/// <reference path="../utils/path.d.ts" />
 
 declare namespace Polymer {
 
@@ -38,7 +42,7 @@ declare namespace Polymer {
 
   interface LegacyElementMixin extends Polymer.ElementMixin, Polymer.PropertyEffects, Polymer.TemplateStamp, Polymer.PropertyAccessors, Polymer.PropertiesChanged, Polymer.PropertiesMixin, Polymer.GestureEventListeners {
     isAttached: boolean;
-    _debouncers: {[key: string]: Function|null};
+    _debouncers: {[key: string]: Function|null}|null;
 
     /**
      * Return the element whose local dom within which this element
@@ -70,7 +74,7 @@ declare namespace Polymer {
      * @param value Current value of attribute.
      * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace?: string|null): void;
 
     /**
      * Provides an implementation of `connectedCallback`
@@ -264,7 +268,7 @@ declare namespace Polymer {
      * @param eventName Name of event to listen for.
      * @param methodName Name of handler method on `this` to call.
      */
-    listen(node: _Element|null, eventName: string, methodName: string): void;
+    listen(node: EventTarget|null, eventName: string, methodName: string): void;
 
     /**
      * Convenience method to remove an event listener from a given element,
@@ -275,7 +279,7 @@ declare namespace Polymer {
      * @param methodName Name of handler method on `this` to not call
      *        anymore.
      */
-    unlisten(node: _Element|null, eventName: string, methodName: string): void;
+    unlisten(node: EventTarget|null, eventName: string, methodName: string): void;
 
     /**
      * Override scrolling behavior to all direction, one direction, or none.
@@ -365,7 +369,8 @@ declare namespace Polymer {
      * to children that are insertion points.
      *
      * @param selector Selector to run.
-     * @returns List of effective child nodes that match selector.
+     * @returns List of effective child nodes that match
+     *     selector.
      */
     queryAllEffectiveChildren(selector: string): Node[];
 
@@ -455,7 +460,7 @@ declare namespace Polymer {
      * `flush()` immediately invokes the debounced callback if the debouncer
      * is active.
      */
-    debounce(jobName: string, callback: () => void, wait: number): object;
+    debounce(jobName: string, callback: () => void, wait?: number): object;
 
     /**
      * Returns whether a named debouncer is active.
@@ -485,7 +490,8 @@ declare namespace Polymer {
      * By default (if no waitTime is specified), async callbacks are run at
      * microtask timing, which will occur before paint.
      *
-     * @param callback The callback function to run, bound to `this`.
+     * @param callback The callback function to run, bound to
+     *     `this`.
      * @param waitTime Time to wait before calling the
      *   `callback`.  If unspecified or 0, the callback will be run at microtask
      *   timing (before paint).
@@ -546,9 +552,9 @@ declare namespace Polymer {
      * @param name HTML attribute name
      * @param bool Boolean to force the attribute on or off.
      *    When unspecified, the state of the attribute will be reversed.
-     * @param node Node to target.  Defaults to `this`.
+     * @returns true if the attribute now exists
      */
-    toggleAttribute(name: string, bool?: boolean, node?: _Element|null): void;
+    toggleAttribute(name: string, bool?: boolean): boolean;
 
     /**
      * Toggles a CSS class on or off.
@@ -591,7 +597,8 @@ declare namespace Polymer {
      * If the array is passed directly, **no change
      * notification is generated**.
      *
-     * @param arrayOrPath Path to array from which to remove the item
+     * @param arrayOrPath Path to array from
+     *     which to remove the item
      *   (or the array itself).
      * @param item Item to remove.
      * @returns Array containing item removed.

--- a/types/lib/legacy/polymer-fn.d.ts
+++ b/types/lib/legacy/polymer-fn.d.ts
@@ -19,7 +19,8 @@
  * elements.
  *
  * This method is equivalent to
- * `customElements.define(info.is, Polymer.Class(info));`
+ *
+ *     customElements.define(info.is, Polymer.Class(info));
  *
  * See `Polymer.Class` for details on valid legacy metadata format for `info`.
  *

--- a/types/lib/legacy/polymer.dom.d.ts
+++ b/types/lib/legacy/polymer.dom.d.ts
@@ -39,117 +39,6 @@ declare namespace Polymer {
     function matchesSelector(node: Node, selector: string): boolean;
   }
 
-  /**
-   * Node API wrapper class returned from `Polymer.dom.(target)` when
-   * `target` is a `Node`.
-   */
-  class DomApi {
-
-    /**
-     * For shadow roots, returns the currently focused element within this
-     * shadow root.
-     */
-    readonly activeElement: Node|null|undefined;
-
-    /**
-     * @param node Node for which to create a Polymer.dom helper object.
-     */
-    constructor(node: Node|null);
-
-    /**
-     * Returns an instance of `Polymer.FlattenedNodesObserver` that
-     * listens for node changes on this element.
-     *
-     * @param callback Called when direct or distributed children
-     *   of this element changes
-     * @returns Observer instance
-     */
-    observeNodes(callback: (p0: _Element, p1: {target: _Element, addedNodes: _Element[], removedNodes: _Element[]}) => void): Polymer.FlattenedNodesObserver;
-
-    /**
-     * Disconnects an observer previously created via `observeNodes`
-     *
-     * @param observerHandle Observer instance
-     *   to disconnect.
-     */
-    unobserveNodes(observerHandle: Polymer.FlattenedNodesObserver): void;
-
-    /**
-     * Provided as a backwards-compatible API only.  This method does nothing.
-     */
-    notifyObserver(): void;
-
-    /**
-     * Returns true if the provided node is contained with this element's
-     * light-DOM children or shadow root, including any nested shadow roots
-     * of children therein.
-     *
-     * @param node Node to test
-     * @returns Returns true if the given `node` is contained within
-     *   this element's light or shadow DOM.
-     */
-    deepContains(node: Node|null): boolean;
-
-    /**
-     * Returns the root node of this node.  Equivalent to `getRoodNode()`.
-     *
-     * @returns Top most element in the dom tree in which the node
-     * exists. If the node is connected to a document this is either a
-     * shadowRoot or the document; otherwise, it may be the node
-     * itself or a node or document fragment containing it.
-     */
-    getOwnerRoot(): Node|null;
-
-    /**
-     * For slot elements, returns the nodes assigned to the slot; otherwise
-     * an empty array. It is equivalent to `<slot>.addignedNodes({flatten:true})`.
-     *
-     * @returns Array of assigned nodes
-     */
-    getDistributedNodes(): Node[];
-
-    /**
-     * Returns an array of all slots this element was distributed to.
-     *
-     * @returns Description
-     */
-    getDestinationInsertionPoints(): HTMLSlotElement[];
-
-    /**
-     * Calls `importNode` on the `ownerDocument` for this node.
-     *
-     * @param node Node to import
-     * @param deep True if the node should be cloned deeply during
-     *   import
-     * @returns Clone of given node imported to this owner document
-     */
-    importNode(node: Node, deep: boolean): Node|null;
-
-    /**
-     * @returns Returns a flattened list of all child nodes and
-     * nodes assigned to child slots.
-     */
-    getEffectiveChildNodes(): Node[];
-
-    /**
-     * Returns a filtered list of flattened child elements for this element based
-     * on the given selector.
-     *
-     * @param selector Selector to filter nodes against
-     * @returns List of flattened child elements
-     */
-    queryDistributedElements(selector: string): HTMLElement[];
-    cloneNode(deep?: boolean): Node;
-    appendChild(node: Node): Node;
-    insertBefore(newChild: Node, refChild: Node|null): Node;
-    removeChild(node: Node): Node;
-    replaceChild(oldChild: Node, newChild: Node): Node;
-    setAttribute(name: string, value: string): void;
-    removeAttribute(name: string): void;
-    querySelector(selector: string): _Element|null;
-    querySelectorAll(selector: string): NodeListOf<_Element>;
-  }
-
 
   /**
    * Legacy DOM and Event manipulation API wrapper factory used to abstract
@@ -162,7 +51,132 @@ declare namespace Polymer {
    *
    * @returns Wrapper providing either node API or event API
    */
-  function dom(obj?: Node|Event|null): DomApi|EventApi;
+  function dom(obj?: Node|Event|DomApiNative|EventApi|null): DomApiNative|EventApi;
+}
+
+/**
+ * Node API wrapper class returned from `Polymer.dom.(target)` when
+ * `target` is a `Node`.
+ */
+declare class DomApiNative {
+
+  /**
+   * For shadow roots, returns the currently focused element within this
+   * shadow root.
+   */
+  readonly activeElement: Node|null|undefined;
+  parentNode: Node|null;
+  firstChild: Node|null;
+  lastChild: Node|null;
+  nextSibling: Node|null;
+  previousSibling: Node|null;
+  firstElementChild: HTMLElement|null;
+  lastElementChild: HTMLElement|null;
+  nextElementSibling: HTMLElement|null;
+  previousElementSibling: HTMLElement|null;
+  childNodes: Node[];
+  children: HTMLElement[];
+  classList: DOMTokenList|null;
+  textContent: string;
+  innerHTML: string;
+
+  /**
+   * @param node Node for which to create a Polymer.dom helper object.
+   */
+  constructor(node: Node|null);
+
+  /**
+   * Returns an instance of `Polymer.FlattenedNodesObserver` that
+   * listens for node changes on this element.
+   *
+   * @param callback Called when direct or distributed children
+   *   of this element changes
+   * @returns Observer instance
+   */
+  observeNodes(callback: (p0: {target: HTMLElement, addedNodes: _Element[], removedNodes: _Element[]}) => void): Polymer.DomApi.ObserveHandle;
+
+  /**
+   * Disconnects an observer previously created via `observeNodes`
+   *
+   * @param observerHandle Observer instance
+   *   to disconnect.
+   */
+  unobserveNodes(observerHandle: Polymer.DomApi.ObserveHandle): void;
+
+  /**
+   * Provided as a backwards-compatible API only.  This method does nothing.
+   */
+  notifyObserver(): void;
+
+  /**
+   * Returns true if the provided node is contained with this element's
+   * light-DOM children or shadow root, including any nested shadow roots
+   * of children therein.
+   *
+   * @param node Node to test
+   * @returns Returns true if the given `node` is contained within
+   *   this element's light or shadow DOM.
+   */
+  deepContains(node: Node|null): boolean;
+
+  /**
+   * Returns the root node of this node.  Equivalent to `getRoodNode()`.
+   *
+   * @returns Top most element in the dom tree in which the node
+   * exists. If the node is connected to a document this is either a
+   * shadowRoot or the document; otherwise, it may be the node
+   * itself or a node or document fragment containing it.
+   */
+  getOwnerRoot(): Node|null;
+
+  /**
+   * For slot elements, returns the nodes assigned to the slot; otherwise
+   * an empty array. It is equivalent to `<slot>.addignedNodes({flatten:true})`.
+   *
+   * @returns Array of assigned nodes
+   */
+  getDistributedNodes(): Node[];
+
+  /**
+   * Returns an array of all slots this element was distributed to.
+   *
+   * @returns Description
+   */
+  getDestinationInsertionPoints(): HTMLSlotElement[];
+
+  /**
+   * Calls `importNode` on the `ownerDocument` for this node.
+   *
+   * @param node Node to import
+   * @param deep True if the node should be cloned deeply during
+   *   import
+   * @returns Clone of given node imported to this owner document
+   */
+  importNode(node: Node, deep: boolean): Node|null;
+
+  /**
+   * @returns Returns a flattened list of all child nodes and
+   * nodes assigned to child slots.
+   */
+  getEffectiveChildNodes(): Node[];
+
+  /**
+   * Returns a filtered list of flattened child elements for this element based
+   * on the given selector.
+   *
+   * @param selector Selector to filter nodes against
+   * @returns List of flattened child elements
+   */
+  queryDistributedElements(selector: string): HTMLElement[];
+  cloneNode(deep?: boolean): Node;
+  appendChild(node: Node): Node;
+  insertBefore(newChild: Node, refChild: Node|null): Node;
+  removeChild(node: Node): Node;
+  replaceChild(oldChild: Node, newChild: Node): Node;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  querySelector(selector: string): _Element|null;
+  querySelectorAll(selector: string): NodeListOf<_Element>;
 }
 
 /**
@@ -186,8 +200,4 @@ declare class EventApi {
    */
   readonly path: EventTarget[];
   constructor(event: any);
-}
-
-declare class Wrapper extends ShadyDOM.Wrapper {
-  prop: any;
 }

--- a/types/lib/mixins/dir-mixin.d.ts
+++ b/types/lib/mixins/dir-mixin.d.ts
@@ -13,23 +13,27 @@
 // tslint:disable:no-any describes the API as best we are able today
 
 /// <reference path="property-accessors.d.ts" />
+/// <reference path="../utils/mixin.d.ts" />
 
 declare namespace Polymer {
 
 
   /**
-   * Element class mixin that allows elements to use the `:dir` CSS Selector to have
-   * text direction specific styling.
+   * Element class mixin that allows elements to use the `:dir` CSS Selector to
+   * have text direction specific styling.
    *
-   * With this mixin, any stylesheet provided in the template will transform `:dir` into
-   * `:host([dir])` and sync direction with the page via the element's `dir` attribute.
+   * With this mixin, any stylesheet provided in the template will transform
+   * `:dir` into `:host([dir])` and sync direction with the page via the
+   * element's `dir` attribute.
    *
-   * Elements can opt out of the global page text direction by setting the `dir` attribute
-   * directly in `ready()` or in HTML.
+   * Elements can opt out of the global page text direction by setting the `dir`
+   * attribute directly in `ready()` or in HTML.
    *
    * Caveats:
-   * - Applications must set `<html dir="ltr">` or `<html dir="rtl">` to sync direction
-   * - Automatic left-to-right or right-to-left styling is sync'd with the `<html>` element only.
+   * - Applications must set `<html dir="ltr">` or `<html dir="rtl">` to sync
+   *   direction
+   * - Automatic left-to-right or right-to-left styling is sync'd with the
+   *   `<html>` element only.
    * - Changing `dir` at runtime is supported.
    * - Opting out of the global direction styling is permanent
    */
@@ -37,7 +41,13 @@ declare namespace Polymer {
 
   interface DirMixinConstructor {
     new(...args: any[]): DirMixin;
-    _processStyleText(cssText: any, baseURI: any): any;
+
+    /**
+     * @param cssText .
+     * @param baseURI .
+     * @returns .
+     */
+    _processStyleText(cssText: string, baseURI: string): string;
 
     /**
      * Replace `:dir` in the given CSS text

--- a/types/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/types/lib/mixins/disable-upgrade-mixin.d.ts
@@ -13,6 +13,7 @@
 // tslint:disable:no-any describes the API as best we are able today
 
 /// <reference path="element-mixin.d.ts" />
+/// <reference path="../utils/mixin.d.ts" />
 
 declare namespace Polymer {
 
@@ -46,7 +47,14 @@ declare namespace Polymer {
   interface DisableUpgradeMixin extends Polymer.ElementMixin, Polymer.PropertyEffects, Polymer.TemplateStamp, Polymer.PropertyAccessors, Polymer.PropertiesChanged, Polymer.PropertiesMixin {
     _initializeProperties(): void;
     _enableProperties(): void;
-    attributeChangedCallback(name: any, old: any, value: any, namespace: any): void;
+
+    /**
+     * @param name Attribute name.
+     * @param old The previous value for the attribute.
+     * @param value The new value for the attribute.
+     * @param namespace The XML namespace for the attribute.
+     */
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace?: string|null): undefined;
     connectedCallback(): void;
     disconnectedCallback(): void;
   }

--- a/types/lib/mixins/element-mixin.d.ts
+++ b/types/lib/mixins/element-mixin.d.ts
@@ -86,18 +86,35 @@ declare namespace Polymer {
     new(...args: any[]): ElementMixin;
 
     /**
-     * Overrides `PropertyAccessors` to add map of dynamic functions on
+     * Overrides `PropertyEffects` to add map of dynamic functions on
      * template info, for consumption by `PropertyEffects` template binding
      * code. This map determines which method templates should have accessors
      * created for them.
+     *
+     * @param template Template
+     * @param templateInfo Template metadata for current template
+     * @param nodeInfo Node metadata for current template.
+     * @returns .
      */
-    _parseTemplateContent(template: any, templateInfo: any, nodeInfo: any): any;
+    _parseTemplateContent(template: HTMLTemplateElement, templateInfo: TemplateInfo, nodeInfo: NodeInfo): boolean;
 
     /**
      * Override of PropertiesChanged createProperties to create accessors
      * and property effects for all of the properties.
+     *
+     * @param props .
      */
-    createProperties(props: any): void;
+    createProperties(props: object): void;
+
+    /**
+     * Overrides `PropertyEffects` to warn on use of undeclared properties in
+     * template.
+     *
+     * @param templateInfo Template metadata to add effect to
+     * @param prop Property that should trigger the effect
+     * @param effect Effect metadata object
+     */
+    _addTemplatePropertyEffect(templateInfo: object|null, prop: string, effect?: object|null): void;
 
     /**
      * Override of PropertiesMixin _finalizeClass to create observers and

--- a/types/lib/mixins/gesture-event-listeners.d.ts
+++ b/types/lib/mixins/gesture-event-listeners.d.ts
@@ -43,7 +43,7 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to add
      */
-    _addEventListenerToNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
+    _addEventListenerToNode(node: EventTarget, eventName: string, handler: (p0: Event) => void): void;
 
     /**
      * Remove the event listener to the node if it is a gestures event.
@@ -52,6 +52,6 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to remove
      */
-    _removeEventListenerFromNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
+    _removeEventListenerFromNode(node: EventTarget, eventName: string, handler: (p0: Event) => void): void;
   }
 }

--- a/types/lib/mixins/properties-changed.d.ts
+++ b/types/lib/mixins/properties-changed.d.ts
@@ -64,6 +64,7 @@ declare namespace Polymer {
   }
 
   interface PropertiesChanged {
+    __dataEnabled: any;
 
     /**
      * Creates a setter/getter pair for the named property with its own
@@ -199,7 +200,7 @@ declare namespace Polymer {
      *   in `changedProps`
      * @returns true if changedProps is truthy
      */
-    _shouldPropertiesChange(currentProps: object, changedProps: object, oldProps: object): boolean;
+    _shouldPropertiesChange(currentProps: object, changedProps: object|null, oldProps: object|null): boolean;
 
     /**
      * Callback called when any properties with accessors created via
@@ -211,7 +212,7 @@ declare namespace Polymer {
      * @param oldProps Bag of previous values for each property
      *   in `changedProps`
      */
-    _propertiesChanged(currentProps: object, changedProps: object, oldProps: object): void;
+    _propertiesChanged(currentProps: object, changedProps: object|null, oldProps: object|null): void;
 
     /**
      * Method called to determine whether a property value should be
@@ -241,7 +242,7 @@ declare namespace Polymer {
      * @param value New attribute value
      * @param namespace Attribute namespace.
      */
-    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
+    attributeChangedCallback(name: string, old: string|null, value: string|null, namespace?: string|null): void;
 
     /**
      * Deserializes an attribute to its associated property.

--- a/types/lib/mixins/properties-mixin.d.ts
+++ b/types/lib/mixins/properties-mixin.d.ts
@@ -13,8 +13,8 @@
 // tslint:disable:no-any describes the API as best we are able today
 
 /// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/telemetry.d.ts" />
 /// <reference path="../utils/mixin.d.ts" />
+/// <reference path="../utils/telemetry.d.ts" />
 /// <reference path="properties-changed.d.ts" />
 
 declare namespace Polymer {

--- a/types/lib/mixins/property-accessors.d.ts
+++ b/types/lib/mixins/property-accessors.d.ts
@@ -27,16 +27,18 @@ declare namespace Polymer {
    *
    * For basic usage of this mixin:
    *
-   * -   Declare attributes to observe via the standard `static get observedAttributes()`. Use
-   *     `dash-case` attribute names to represent `camelCase` property names.
+   * -   Declare attributes to observe via the standard `static get
+   *     observedAttributes()`. Use `dash-case` attribute names to represent
+   *     `camelCase` property names.
    * -   Implement the `_propertiesChanged` callback on the class.
-   * -   Call `MyClass.createPropertiesForAttributes()` **once** on the class to generate
-   *     property accessors for each observed attribute. This must be called before the first
-   *     instance is created, for example, by calling it before calling `customElements.define`.
-   *     It can also be called lazily from the element's `constructor`, as long as it's guarded so
-   *     that the call is only made once, when the first instance is created.
-   * -   Call `this._enableProperties()` in the element's `connectedCallback` to enable
-   *     the accessors.
+   * -   Call `MyClass.createPropertiesForAttributes()` **once** on the class to
+   *     generate property accessors for each observed attribute. This must be
+   *     called before the first instance is created, for example, by calling it
+   *     before calling `customElements.define`. It can also be called lazily from
+   *     the element's `constructor`, as long as it's guarded so that the call is
+   *     only made once, when the first instance is created.
+   * -   Call `this._enableProperties()` in the element's `connectedCallback` to
+   *     enable the accessors.
    *
    * Any `observedAttributes` will automatically be
    * deserialized via `attributeChangedCallback` and set to the associated
@@ -95,7 +97,8 @@ declare namespace Polymer {
      * Overrides PropertiesChanged implemention to serialize objects as JSON.
      *
      * @param value Property value to serialize.
-     * @returns String serialized from the provided property value.
+     * @returns String serialized from the provided property
+     *     value.
      */
     _serializeValue(value: any): string|undefined;
 

--- a/types/lib/mixins/property-effects.d.ts
+++ b/types/lib/mixins/property-effects.d.ts
@@ -18,6 +18,7 @@
 /// <reference path="../utils/case-map.d.ts" />
 /// <reference path="property-accessors.d.ts" />
 /// <reference path="template-stamp.d.ts" />
+/// <reference path="../utils/settings.d.ts" />
 
 declare namespace Polymer {
 
@@ -282,8 +283,8 @@ declare namespace Polymer {
      * Called to evaluate a previously parsed binding part based on a set of
      * one or more changed dependencies.
      *
-     * @param inst Element that should be used as scope for
-     *   binding dependencies
+     * @param inst Element that should be used as
+     *     scope for binding dependencies
      * @param part Binding part metadata
      * @param path Property/path that triggered this effect
      * @param props Bag of current property changes
@@ -291,7 +292,7 @@ declare namespace Polymer {
      * @param hasPaths True with `props` contains one or more paths
      * @returns Value the binding part evaluated to
      */
-    _evaluateBinding(inst: this|null, part: BindingPart|null, path: string, props: object|null, oldProps: object|null, hasPaths: boolean): any;
+    _evaluateBinding(inst: Polymer.PropertyEffects, part: BindingPart|null, path: string, props: object|null, oldProps: object|null, hasPaths: boolean): any;
   }
 
   interface PropertyEffects extends Polymer.TemplateStamp, Polymer.PropertyAccessors, Polymer.PropertiesChanged {
@@ -404,7 +405,7 @@ declare namespace Polymer {
      * @param oldProps Bag of previous values for each property
      *   in `changedProps`
      */
-    _propertiesChanged(currentProps: object, changedProps: object, oldProps: object): void;
+    _propertiesChanged(currentProps: object, changedProps: object|null, oldProps: object|null): void;
 
     /**
      * Overrides `Polymer.PropertyAccessors` implementation to provide a
@@ -441,7 +442,8 @@ declare namespace Polymer {
      *
      * @param property Property name
      * @param type Effect type, from this.PROPERTY_EFFECT_TYPES
-     * @returns True if the prototype/instance has an effect of this type
+     * @returns True if the prototype/instance has an effect of this
+     *     type
      */
     _hasPropertyEffect(property: string, type?: string): boolean;
 
@@ -450,7 +452,8 @@ declare namespace Polymer {
      * accessor for the given property.
      *
      * @param property Property name
-     * @returns True if the prototype/instance has an effect of this type
+     * @returns True if the prototype/instance has an effect of this
+     *     type
      */
     _hasReadOnlyEffect(property: string): boolean;
 
@@ -459,16 +462,18 @@ declare namespace Polymer {
      * property effect for the given property.
      *
      * @param property Property name
-     * @returns True if the prototype/instance has an effect of this type
+     * @returns True if the prototype/instance has an effect of this
+     *     type
      */
     _hasNotifyEffect(property: string): boolean;
 
     /**
-     * Returns whether the current prototype/instance has a "reflect to attribute"
-     * property effect for the given property.
+     * Returns whether the current prototype/instance has a "reflect to
+     * attribute" property effect for the given property.
      *
      * @param property Property name
-     * @returns True if the prototype/instance has an effect of this type
+     * @returns True if the prototype/instance has an effect of this
+     *     type
      */
     _hasReflectEffect(property: string): boolean;
 
@@ -477,7 +482,8 @@ declare namespace Polymer {
      * property effect for the given property.
      *
      * @param property Property name
-     * @returns True if the prototype/instance has an effect of this type
+     * @returns True if the prototype/instance has an effect of this
+     *     type
      */
     _hasComputedEffect(property: string): boolean;
 
@@ -607,8 +613,10 @@ declare namespace Polymer {
      *     this.items.splice(1, 1, {name: 'Sam'});
      *     this.items.push({name: 'Bob'});
      *     this.notifySplices('items', [
-     *       { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },
-     *       { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}
+     *       { index: 1, removed: [{name: 'Todd'}], addedCount: 1,
+     *         object: this.items, type: 'splice' },
+     *       { index: 3, removed: [], addedCount: 1,
+     *         object: this.items, type: 'splice'}
      *     ]);
      *
      * @param path Path that should be notified.
@@ -713,7 +721,7 @@ declare namespace Polymer {
      * @param items Items to insert into array.
      * @returns Array of removed items.
      */
-    splice(path: string|Array<string|number>, start: number, deleteCount: number, ...items: any[]): any[]|null;
+    splice(path: string|Array<string|number>, start: number, deleteCount?: number, ...items: any[]): any[]|null;
 
     /**
      * Removes an item from the beginning of array at the path specified.
@@ -774,7 +782,8 @@ declare namespace Polymer {
      * full API docs.
      *
      * @param property Property name
-     * @param method Function or name of observer method to call
+     * @param method Function or name of observer method
+     *     to call
      * @param dynamicFn Whether the method name should be included as
      *   a dependency to the effect.
      */

--- a/types/lib/mixins/template-stamp.d.ts
+++ b/types/lib/mixins/template-stamp.d.ts
@@ -239,7 +239,7 @@ declare namespace Polymer {
      *   to `node`)
      * @returns Generated handler function
      */
-    _addMethodEventListenerToNode(node: Node, eventName: string, methodName: string, context?: any): Function|null;
+    _addMethodEventListenerToNode(node: EventTarget, eventName: string, methodName: string, context?: any): Function|null;
 
     /**
      * Override point for adding custom or simulated event handling.
@@ -248,7 +248,7 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to add
      */
-    _addEventListenerToNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
+    _addEventListenerToNode(node: EventTarget, eventName: string, handler: (p0: Event) => void): void;
 
     /**
      * Override point for adding custom or simulated event handling.
@@ -257,6 +257,6 @@ declare namespace Polymer {
      * @param eventName Name of event
      * @param handler Listener function to remove
      */
-    _removeEventListenerFromNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
+    _removeEventListenerFromNode(node: EventTarget, eventName: string, handler: (p0: Event) => void): void;
   }
 }

--- a/types/lib/utils/flattened-nodes-observer.d.ts
+++ b/types/lib/utils/flattened-nodes-observer.d.ts
@@ -59,25 +59,14 @@ declare namespace Polymer {
   class FlattenedNodesObserver {
 
     /**
-     * @param target Node on which to listen for changes.
-     * @param callback Function called when there are additions
-     * or removals from the target's list of flattened nodes.
+     * eslint-disable-next-line
      */
-    constructor(target: _Element|null, callback: ((p0: _Element, p1: {target: _Element, addedNodes: _Element[], removedNodes: _Element[]}) => void)|null);
+    constructor(target: any, callback: any);
 
     /**
-     * Returns the list of flattened nodes for the given `node`.
-     * This list consists of a node's children and, for any children
-     * that are `<slot>` elements, the expanded flattened list of `assignedNodes`.
-     * For example, if the observed node has children `<a></a><slot></slot><b></b>`
-     * and the `<slot>` has one `<div>` assigned to it, then the flattened
-     * nodes list is `<a></a><div></div><b></b>`. If the `<slot>` has other
-     * `<slot>` elements assigned to it, these are flattened as well.
-     *
-     * @param node The node for which to return the list of flattened nodes.
-     * @returns The list of flattened nodes for the given `node`.
+     * eslint-disable-next-line
      */
-    static getFlattenedNodes(node: HTMLElement|HTMLSlotElement|null): any[]|null;
+    static getFlattenedNodes(node: any): any;
 
     /**
      * Activates an observer. This method is automatically called when

--- a/types/lib/utils/html-tag.d.ts
+++ b/types/lib/utils/html-tag.d.ts
@@ -83,7 +83,9 @@ declare namespace Polymer {
    *         ${super.template}
    *       `;
    *     }
-   *     static get styleTemplate() { return Polymer.htmlLiteral`.shadowed { background: gray; }`; }
+   *     static get styleTemplate() {
+   *        return Polymer.htmlLiteral`.shadowed { background: gray; }`;
+   *     }
    *
    * @returns Constructed literal string
    */

--- a/types/lib/utils/settings.d.ts
+++ b/types/lib/utils/settings.d.ts
@@ -48,4 +48,11 @@ declare namespace Polymer {
    * optimizations when only legacy Polymer() style elements are used.
    */
   function setLegacyOptimizations(useLegacyOptimizations: boolean): void;
+
+
+  /**
+   * Sets `syncInitialRender` globally for all elements. Enables
+   * synchronous initial rendering. This matches the behavior of Polymer 1.
+   */
+  function setSyncInitialRender(useSyncInitialRender: boolean): void;
 }

--- a/types/lib/utils/templatize.d.ts
+++ b/types/lib/utils/templatize.d.ts
@@ -15,10 +15,12 @@
 /// <reference path="boot.d.ts" />
 /// <reference path="../mixins/property-effects.d.ts" />
 /// <reference path="../mixins/mutable-data.d.ts" />
+/// <reference path="settings.d.ts" />
 
 declare class TemplateInstanceBase extends
   Polymer.PropertyEffects(
   Object) {
+  root: StampedTemplate;
 
   /**
    * Find the parent model of this template instance.  The parent model
@@ -78,6 +80,12 @@ declare class TemplateInstanceBase extends
    * @returns Always true.
    */
   dispatchEvent(event: Event|null): boolean;
+}
+
+declare class templatizerBase extends TemplateInstanceBase {
+}
+
+declare class templatizedBase extends HTMLTemplateElementExtension {
 }
 
 declare namespace Polymer {
@@ -213,4 +221,7 @@ declare namespace Polymer {
      */
     function modelForElement(template: HTMLTemplateElement|null, node?: Node|null): TemplateInstanceBase|null;
   }
+}
+
+declare class baseClass extends TemplateInstanceBase {
 }


### PR DESCRIPTION
TreeWalker is slower than normal DOM accessors on Edge/IE. This change was put in place to enhance performance by avoiding ShadyDOM patches, but the recent noPatch mode is a better way to accomplish this.