### PR TITLE
Avoid upgrading template if no hostProps, for better perf.

### DIFF
--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -360,6 +360,9 @@ function createTemplatizerClass(template, templateInfo, options) {
 }
 
 /**
+ * Adds propagate effects from the template to the template instance for
+ * properties that the host binds to the template using the `_host_` prefix.
+ * 
  * @suppress {missingProperties} class.prototype is not defined for some reason
  */
 function addPropagateEffects(template, templateInfo, options) {
@@ -423,6 +426,8 @@ function addNotifyEffects(klass, template, templateInfo, options) {
   }
   if (options.forwardHostProp && template.__dataHost) {
     for (let hprop in hostProps) {
+      // As we're iterating hostProps in this function, note whether
+      // there were any, for an optimization in addPropagateEffects
       if (!templateInfo.hasHostProps) {
         templateInfo.hasHostProps = true;
       }

--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -364,11 +364,7 @@ function createTemplatizerClass(template, templateInfo, options) {
  */
 function addPropagateEffects(template, templateInfo, options) {
   let userForwardHostProp = options.forwardHostProp;
-  const hasHostProps = templateInfo.hasHostProps ||
-    (templateInfo.hasHostProps = 
-      Boolean(templateInfo.hostProps && 
-        Object.keys(templateInfo.hostProps).length));
-  if (userForwardHostProp && hasHostProps) {
+  if (userForwardHostProp && templateInfo.hasHostProps) {
     // Provide data API and property effects on memoized template class
     let klass = templateInfo.templatizeTemplateClass;
     if (!klass) {
@@ -427,6 +423,9 @@ function addNotifyEffects(klass, template, templateInfo, options) {
   }
   if (options.forwardHostProp && template.__dataHost) {
     for (let hprop in hostProps) {
+      if (!templateInfo.hasHostProps) {
+        templateInfo.hasHostProps = true;
+      }
       klass.prototype._addPropertyEffect(hprop,
         klass.prototype.PROPERTY_EFFECT_TYPES.NOTIFY,
         {fn: createNotifyHostPropEffect()});

--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -364,7 +364,11 @@ function createTemplatizerClass(template, templateInfo, options) {
  */
 function addPropagateEffects(template, templateInfo, options) {
   let userForwardHostProp = options.forwardHostProp;
-  if (userForwardHostProp) {
+  const hasHostProps = templateInfo.hasHostProps ||
+    (templateInfo.hasHostProps = 
+      Boolean(templateInfo.hostProps && 
+        Object.keys(templateInfo.hostProps).length));
+  if (userForwardHostProp && hasHostProps) {
     // Provide data API and property effects on memoized template class
     let klass = templateInfo.templatizeTemplateClass;
     if (!klass) {


### PR DESCRIPTION
When e.g. a `dom-repeat` only binds to local instance properties (like `item` or `index`), it is unnecessary to "upgrade" the associated `<template>` as a PropertyEffects client, since there will be no host properties to forward to it.  This condition can be detected based on the count of host properties in the template.