### PR TITLE
[legacy-data-mixin 2.x] Ensure wildcard arguments get undefined treatment. Fixes #5428

### DIFF
--- a/lib/legacy/legacy-data-mixin.html
+++ b/lib/legacy/legacy-data-mixin.html
@@ -99,7 +99,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // undefined or not. Multi-property observers must have all arguments defined
         if (this._legacyUndefinedCheck && vals.length > 1) {
           for (let i=0; i<vals.length; i++) {
-            if (vals[i] === undefined) {
+          if (vals[i] === undefined || 
+              (args[i].wildcard && vals[i].base === undefined)) {
               // Break out of effect's control flow; will be caught in
               // wrapped property effect function below
               const name = args[i].name;

--- a/test/unit/legacy-data.html
+++ b/test/unit/legacy-data.html
@@ -50,13 +50,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             },
             computedMulti: {
               computed: 'computeMulti(computedMultiDep1, computedMultiDep2)'
-            }
+            },
+            wildcardProp: String,
+            wildcardObj: Object
           },
           observers: [
             'staticObserver("staticObserver")',
             'singlePropObserver(singleProp)',
             'multiPropObserver(multiProp1, multiProp2)',
-            'throws(throwProp)'
+            'throws(throwProp)',
+            'wildcardObserver(wildcardProp, wildcardObj.*)'
           ],
           created() {
             this.singlePropObserver = sinon.spy();
@@ -64,6 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.staticObserver = sinon.spy();
             this.computeSingle = sinon.spy((inlineSingleDep) => `[${inlineSingleDep}]`);
             this.computeMulti = sinon.spy((inlineMultiDep1, inlineMultiDep2) => `[${inlineMultiDep1},${inlineMultiDep2}]`);
+            this.wildcardObserver = sinon.spy();
           },
           throws() {
             throw new Error('real error');
@@ -145,6 +149,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="declarative-wildcard-one">
+    <template>
+      <x-data wildcard-prop='prop'></x-data>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="declarative-wildcard-all">
+    <template>
+      <x-data wildcard-prop="prop" wildcard-obj='{"prop": "wildcardObj"}'></x-data>
+    </template>
+  </test-fixture>
+
   <script>
   (function() {
 
@@ -192,6 +208,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const inlineMultiDep2 = 'inlineMultiDep2';
       const inlineMultiIfDep1 = 'inlineMultiIfDep1';
       const inlineMultiIfDep2 = 'inlineMultiIfDep2';
+      const wildcardProp = 'wildcardProp';
+      const wildcardObj = {prop: 'wildcardObj'};
 
       suite('check disabled', () => {
         test('no arguments defined', () => {
@@ -269,6 +287,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setupElement(false, {inlineMultiIfDep1, inlineMultiIfDep2});
           assertEffects({computeMulti: 1});
           assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,inlineMultiIfDep2]');
+        });
+        test('one wildcard argument defined', () => {
+          setupElement(false, {wildcardProp});
+          assertEffects({wildcardObserver: 1});
+        });
+        test('all wildcard arguments defined', () => {
+          setupElement(false, {wildcardProp, wildcardObj});
+          assertEffects({wildcardObserver: 1});
         });
       });
 
@@ -349,6 +375,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertEffects({computeMulti: 1});
           assert.equal(el.$$('#ifChild').computedMulti, '[inlineMultiIfDep1,inlineMultiIfDep2]');
         });
+        test('one wildcard argument defined', () => {
+          setupElement(true, {wildcardProp});
+          assertEffects({warn: 1});
+        });
+        test('all wildcard arguments defined', () => {
+          setupElement(true, {wildcardProp, wildcardObj});
+          assertEffects({wildcardObserver: 1});
+        });
       });
     });
 
@@ -415,6 +449,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           Polymer.flush();
           assertEffects({computeMulti: 1});
           assert.equal(el.$$('#ifChild').computedMulti, '[b,c]');
+        });
+        test('one wildcard argument defined', () => {
+          el = fixture('declarative-wildcard-one');
+          Polymer.flush();
+          assertEffects({warn: 1});
+        });
+        test('all wildcard arguments defined', () => {
+          el = fixture('declarative-wildcard-all');
+          Polymer.flush();
+          assertEffects({wildcardObserver: 1});
         });
       });
     });


### PR DESCRIPTION
When checking the results of `_marshalArgs` for `undefined` values, a wildcard argument would normally always have an object and thus would not trigger a warning even if the underlying base object was `undefined`.  In those cases check wildcard argument's base object for `undefined`, which would match Polymer 1's undefined rule behavior.

### Reference Issue
Fixes #5428.