### PR TITLE
Ensure content was observed before unobserving. Fixes #5524

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - gulp switch
 script:
 - xvfb-run wct
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s default; fi
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@15' -s 'windows 10/microsoftedge@17' -s 'windows 7/internet explorer@10' -s 'windows 8.1/internet explorer@11' -s 'os x 10.10/safari@8' -s 'os x 10.11/safari@9' -s 'macos 10.13/safari@11' -s 'macos 10.13/safari@12' -s 'Linux/chrome@41'; fi
 env:
   global:
   - secure: bfF/o1ewpOxDNqTzWfvlwgRgGfP8OXhSQLLdEwZ6izO9tckMJuSNghk3qBXCEQJwTcUEyXP6EqfzIrRAvDXPa0H3OoinbrooDyV2wIDaVRK++WR2iZIqzqo3hGOdzm4tdrGJZe5av5Rk661Hls8aPfLbjdzcGuYXi8B4wZq2xMI=

--- a/src/lib/dom-api-effective-nodes-observer.html
+++ b/src/lib/dom-api-effective-nodes-observer.html
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _unobserveContentElements: function(elements) {
         for (var i=0, n, h; (i < elements.length) && (n=elements[i]); i++) {
           if (this._isContent(n)) {
-            h = n.__observeNodesMap.get(this);
+            h = n.__observeNodesMap && n.__observeNodesMap.get(this);
             if (h) {
               Polymer.dom(n).unobserveNodes(h);
               n.__observeNodesMap.delete(this);

--- a/test/unit/globals.html
+++ b/test/unit/globals.html
@@ -45,7 +45,10 @@ suite('globals', function() {
     // weird safari + selenium globals
     alert: true,
     confirm: true,
-    prompt: true
+    prompt: true,
+
+    // weird FF globals
+    XULElement: true
   };
 
   test('check global leakage', function() {

--- a/test/unit/polymer-dom-observeNodes.html
+++ b/test/unit/polymer-dom-observeNodes.html
@@ -889,7 +889,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('detach observed element after appending content', function(done) {
       var el = document.createElement('test-detach-host');
       document.body.appendChild(el);
-      Polymer.dom(el).appendChild(new Text('hi'));
+      Polymer.dom(el).appendChild(document.createTextNode('hi'));
       Polymer.Async.run(function() {
         document.body.removeChild(el);
         done();

--- a/test/unit/polymer-dom-observeNodes.html
+++ b/test/unit/polymer-dom-observeNodes.html
@@ -160,7 +160,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </script>
   </dom-module>
 
-
+  <dom-module id="test-detach-child">
+    <template>
+      [x-child: <slot></slot>]
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'test-detach-child',
+        ready() {
+          this._observer = Polymer.dom(this).observeNodes(function() {
+          });
+        },
+        detached() {
+          Polymer.dom(this).unobserveNodes(this._observer);
+        }
+      });
+    });
+    </script>
+  </dom-module>
+  
+  <dom-module id="test-detach-host">
+    <template>
+      [x-host: <test-detach-child><template is="dom-repeat" items="[0]"><slot id="x-child"></slot></template></test-detach-child>]
+    </template>
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'test-detach-host'
+      });
+    });
+    </script>
+  </dom-module>
+    
   <test-content><div>A</div><div>B</div></test-content>
 
   <test-static><div>static A</div><div>static B</div></test-static>
@@ -852,6 +884,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(r1, 5);
       assert.equal(r2, 5);
       assert.equal(r3, 5);
+    });
+
+    test.only('detach observed element after appending content', function(done) {
+      const el = document.createElement('test-detach-host');
+      document.body.appendChild(el);
+      Polymer.dom(el).appendChild(new Text('hi'));
+      Polymer.Async.run(function() {
+        document.body.removeChild(el);
+        done();
+      });
     });
 
   });

--- a/test/unit/polymer-dom-observeNodes.html
+++ b/test/unit/polymer-dom-observeNodes.html
@@ -887,7 +887,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('detach observed element after appending content', function(done) {
-      const el = document.createElement('test-detach-host');
+      var el = document.createElement('test-detach-host');
       document.body.appendChild(el);
       Polymer.dom(el).appendChild(new Text('hi'));
       Polymer.Async.run(function() {

--- a/test/unit/polymer-dom-observeNodes.html
+++ b/test/unit/polymer-dom-observeNodes.html
@@ -168,11 +168,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     HTMLImports.whenReady(function() {
       Polymer({
         is: 'test-detach-child',
-        ready() {
+        ready: function() {
           this._observer = Polymer.dom(this).observeNodes(function() {
           });
         },
-        detached() {
+        detached: function() {
           Polymer.dom(this).unobserveNodes(this._observer);
         }
       });
@@ -886,7 +886,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(r3, 5);
     });
 
-    test.only('detach observed element after appending content', function(done) {
+    test('detach observed element after appending content', function(done) {
       const el = document.createElement('test-detach-host');
       document.body.appendChild(el);
       Polymer.dom(el).appendChild(new Text('hi'));


### PR DESCRIPTION
Since child <content> nodes are observed async, if the node is unobserved before the debouncer runs, child <content> nodes may not have been observed yet.

### Reference Issue
Fixes #5524