### PR TITLE
Fix `localTarget` when `ShadyDOM.noPatch` is in use

### DIFF
--- a/lib/legacy/polymer.dom.js
+++ b/lib/legacy/polymer.dom.js
@@ -408,9 +408,20 @@ if (window['ShadyDOM'] && window['ShadyDOM']['inUse'] && window['ShadyDOM']['noP
 
   Object.defineProperties(EventApi.prototype, {
 
+    // Returns the "lowest" node in the same root as the event's currentTarget.
+    // When in `noPatch` mode, this must be calculated by walking the event's
+    // path.
     localTarget: {
       get() {
-        return this.event.currentTarget;
+        const current = this.event.currentTarget;
+        const currentRoot = current && dom(current).getOwnerRoot();
+        const p$ = this.path;
+        for (let i = 0; i < p$.length; i++) {
+          const e = p$[i];
+          if (dom(e).getOwnerRoot() === currentRoot) {
+            return e;
+          }
+        }
       },
       configurable: true
     },

--- a/test/unit/polymer-dom-nopatch.html
+++ b/test/unit/polymer-dom-nopatch.html
@@ -47,7 +47,9 @@ Polymer({
 
   <dom-module id="x-event-scoped">
     <template>
-      <div id="scoped"></div>
+      <div id="container">
+        <div id="scoped"></div>
+      </div>
     </template>
     <script type="module">
 import { Polymer } from '../../polymer-legacy.js';
@@ -189,7 +191,7 @@ suite('distribution', function() {
 
 suite('events', function() {
 
-  test('localTarget, rootTarget, path', function(done) {
+  test('localTarget, rootTarget, path', function() {
     // skip if noPatch is not available
     if (!window.ShadyDOM.wrap) {
       this.skip();
@@ -207,7 +209,20 @@ suite('events', function() {
       nodes.push(window);
       const path = dom(e).path;
       assert.deepEqual(path, nodes);
-      done();
+    });
+    ShadyDOM.flush();
+    el.fireComposed();
+  });
+
+  test('localTarget when target node and event listener node are distinct', function() {
+    // skip if noPatch is not available
+    if (!window.ShadyDOM.wrap) {
+      this.skip();
+    }
+    var el = fixture('scoped');
+    el.$.container.addEventListener('composed', function(e) {
+      assert.equal(dom(e).rootTarget, el.$.scoped);
+      assert.equal(dom(e).localTarget, el.$.scoped);
     });
     ShadyDOM.flush();
     el.fireComposed();


### PR DESCRIPTION
Fixes #5526.

Return the "lowest" element in the same root as the node listening for the event (currentTarget).