### PR TITLE
Run resolveUrl for protocol-relative urls

### DIFF
--- a/lib/utils/resolve-url.js
+++ b/lib/utils/resolve-url.js
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import './boot.js';
 
 let CSS_URL_RX = /(url\()([^)]*)(\))/g;
-let ABS_URL = /(^\/)|(^#)|(^[\w-\d]*:)/;
+let ABS_URL = /(^\/[^\/])|(^#)|(^[\w-\d]*:)/;
 let workingURL;
 let resolveDoc;
 /**

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -154,6 +154,15 @@ suite('ResolveUrl', function() {
     assert.equal(actual, expected);
   });
 
+  test('resolveUrl when called with a protocol-relative url', function () {
+    debugger;
+    const el = document.querySelector('x-resolve');
+    const expected = `https://example.com/foo`;
+    const actual =
+        el.resolveUrl('//example.com/foo', 'https://example.org/bar');
+    assert.equal(actual, expected);
+  });
+
   test('resolveUrl api with assetpath', function() {
     var el = document.createElement('p-r-ap');
     // Manually calculate expected URL, to avoid dependence on

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -155,7 +155,6 @@ suite('ResolveUrl', function() {
   });
 
   test('resolveUrl when called with a protocol-relative url', function () {
-    debugger;
     const el = document.querySelector('x-resolve');
     const expected = `https://example.com/foo`;
     const actual =

--- a/test/unit/sub/resolveurl-elements.js
+++ b/test/unit/sub/resolveurl-elements.js
@@ -31,16 +31,16 @@ class PR extends PolymerElement {
       }
     </style>
     <div id="div" class="logo" style\$="background-image: url('[[importPath]]foo.z');"></div>
-    <img id="img" src\$="[[importPath]]foo.z">
-    <a id="a" href\$="[[importPath]]foo.z">Foo</a>
-    <zonk id="import" url\$="[[importPath]]foo.z"></zonk>
-    <zonk id="resolveUrl" url\$="[[resolveUrl('foo.z')]]"></zonk>
-    <zonk id="resolveUrlHash" url\$="[[resolveUrl('#foo')]]"></zonk>
-    <zonk id="resolveUrlAbs" url\$="[[resolveUrl('/foo')]]"></zonk>
-    <zonk id="root" url\$="[[rootPath]]foo.z"></zonk>
-    <a id="rel" href\$="[[importPath]]../foo.z?123">Foo</a>
+    <img id="img" src$="[[importPath]]foo.z">
+    <a id="a" href$="[[importPath]]foo.z">Foo</a>
+    <zonk id="import" url$="[[importPath]]foo.z"></zonk>
+    <zonk id="resolveUrl" url$="[[resolveUrl('foo.z')]]"></zonk>
+    <zonk id="resolveUrlHash" url$="[[resolveUrl('#foo')]]"></zonk>
+    <zonk id="resolveUrlAbs" url$="[[resolveUrl('/foo')]]"></zonk>
+    <zonk id="root" url$="[[rootPath]]foo.z"></zonk>
+    <a id="rel" href$="[[importPath]]../foo.z?123">Foo</a>
     <a id="action" action="foo.z">Foo</a>
-    <form id="formAction" action\$="[[importPath]]foo.z"></form>
+    <form id="formAction" action$="[[importPath]]foo.z"></form>
     <a id="hash" href="#foo.z">Foo</a>
     <a id="absolute" href="/foo.z">Foo</a>
     <a id="protocol" href="data:foo.z">Foo</a>


### PR DESCRIPTION
This part of ABS_URL is trying to match on absolute paths, like `/images/logo.png` not protocol-relative urls like `//example.com/images/logo.png`

Upstreaming cl/245302268