### PR TITLE
Check directly for // in resolveUrl because it isn't a valid URL

### DIFF
--- a/lib/utils/resolve-url.js
+++ b/lib/utils/resolve-url.js
@@ -28,6 +28,9 @@ export function resolveUrl(url, baseURI) {
   if (url && ABS_URL.test(url)) {
     return url;
   }
+  if (url === '//') {
+    return url;
+  }
   // Lazy feature detection.
   if (workingURL === undefined) {
     workingURL = false;

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -162,6 +162,14 @@ suite('ResolveUrl', function() {
     assert.equal(actual, expected);
   });
 
+  test('resolveUrl when called with //', function () {
+    const el = document.querySelector('x-resolve');
+    const expected = '//';
+    const actual =
+        el.resolveUrl('//', 'https://example.org/bar');
+    assert.equal(actual, expected);
+  });
+
   test('resolveUrl api with assetpath', function() {
     var el = document.createElement('p-r-ap');
     // Manually calculate expected URL, to avoid dependence on


### PR DESCRIPTION
Upstreaming cl/245302268