### PR TITLE
More fixes for resolveUrl

### DIFF
--- a/lib/utils/resolve-url.js
+++ b/lib/utils/resolve-url.js
@@ -28,9 +28,6 @@ export function resolveUrl(url, baseURI) {
   if (url && ABS_URL.test(url)) {
     return url;
   }
-  if (url === '//') {
-    return url;
-  }
   // Lazy feature detection.
   if (workingURL === undefined) {
     workingURL = false;
@@ -46,7 +43,12 @@ export function resolveUrl(url, baseURI) {
     baseURI = document.baseURI || window.location.href;
   }
   if (workingURL) {
-    return (new URL(url, baseURI)).href;
+    try {
+      return (new URL(url, baseURI)).href;
+    } catch (e) {
+      // Bad url or baseURI structure. Do not attempt to resolve.
+      return url;
+    }
   }
   // Fallback to creating an anchor into a disconnected document.
   if (!resolveDoc) {

--- a/lib/utils/resolve-url.js
+++ b/lib/utils/resolve-url.js
@@ -28,6 +28,9 @@ export function resolveUrl(url, baseURI) {
   if (url && ABS_URL.test(url)) {
     return url;
   }
+  if (url === '//') {
+    return url;
+  }
   // Lazy feature detection.
   if (workingURL === undefined) {
     workingURL = false;

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -194,14 +194,6 @@ suite('ResolveUrl', function() {
     assert.equal(actual, expected);
   });
 
-  test('resolveUrl when called with a garbage url', function () {
-    const el = document.querySelector('x-resolve');
-    const expected = '.../foo.png';
-    const actual =
-        el.resolveUrl('.../foo.png', 'https://example.org/bar');
-    assert.equal(actual, expected);
-  });
-
   test('resolveUrl api with assetpath', function() {
     var el = document.createElement('p-r-ap');
     // Manually calculate expected URL, to avoid dependence on

--- a/test/unit/resolveurl.html
+++ b/test/unit/resolveurl.html
@@ -170,6 +170,38 @@ suite('ResolveUrl', function() {
     assert.equal(actual, expected);
   });
 
+  test('resolveUrl when called with relative url and a bad baseURI', function () {
+    const el = document.querySelector('x-resolve');
+    const expected = 'relative/path.png';
+    const actual =
+        el.resolveUrl('relative/path.png', '/not/a/full/uri');
+    assert.equal(actual, expected);
+  });
+
+  test('resolveUrl when called with a full url and a bad baseURI', function () {
+    const el = document.querySelector('x-resolve');
+    const expected = 'https://example.com/foo.png';
+    const actual =
+        el.resolveUrl('https://example.com/foo.png', '/not/a/full/uri');
+    assert.equal(actual, expected);
+  });
+
+  test('resolveUrl when called with a protocol-relative url and a bad baseURI', function () {
+    const el = document.querySelector('x-resolve');
+    const expected = '//example.com/foo.png';
+    const actual =
+        el.resolveUrl('//example.com/foo.png', '/not/a/full/uri');
+    assert.equal(actual, expected);
+  });
+
+  test('resolveUrl when called with a garbage url', function () {
+    const el = document.querySelector('x-resolve');
+    const expected = '.../foo.png';
+    const actual =
+        el.resolveUrl('.../foo.png', 'https://example.org/bar');
+    assert.equal(actual, expected);
+  });
+
   test('resolveUrl api with assetpath', function() {
     var el = document.createElement('p-r-ap');
     // Manually calculate expected URL, to avoid dependence on


### PR DESCRIPTION
Upstreaming cl/245273850, minus the removal of the explicit check for `//` (for which we return `//`), because unlike the other browsers, Edge does *not* throw on `new URL('//', 'https://example.org/bar')`.