### PR TITLE
Adds support for binding to slots' `name` attribute.

### DIFF
--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -305,7 +305,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var name$Value = slot.getAttribute('name$');
       if (name$Value) {
         // See the comment on `_select$Attr`.
-        const select$Attr = this._select$Attr.cloneNode();
+        var select$Attr = this._select$Attr.cloneNode();
         select$Attr.value = '[slot=\'' + name$Value + '\']';
         content.attributes.setNamedItem(select$Attr);
       }

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -273,6 +273,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    _select$Attr: (function () {
+      var div = document.createElement('div');
+      div.innerHTML = "<div select$>";
+      return div.childNodes[0].attributes.getNamedItem("select$");
+    })(),
+
     _replaceSlotWithContent: function(slot) {
       var content = slot.ownerDocument.createElement('content');
       while (slot.firstChild) {
@@ -280,12 +286,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       var attrs = slot.attributes;
       for (var i=0; i<attrs.length; i++) {
-        var attr = attrs[i];
-        content.setAttribute(attr.name, attr.value);
+        content.attributes.setNamedItem(attrs[i].cloneNode());
       }
       var name = slot.getAttribute('name');
       if (name) {
         content.setAttribute('select', '[slot=\'' + name + '\']');
+      }
+      var name$Value = slot.getAttribute('name$');
+      if (name$Value) {
+        const select$Attr = this._select$Attr.cloneNode();
+        select$Attr.value = '[slot=\'' + name$Value + '\']';
+        content.attributes.setNamedItem(select$Attr);
       }
       slot.parentNode.replaceChild(content, slot);
       return content;

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -296,6 +296,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       var attrs = slot.attributes;
       for (var i=0; i<attrs.length; i++) {
+        // Attribute nodes are cloned and inserted into `attributes` in this
+        // way, rather than through `getAttribute` and `setAttribute`, because
+        // `setAttribute` accepts only a subset of names that the HTML parser
+        // might have actually added to the source node. This means of copying
+        // works for attributes with any name.
         content.attributes.setNamedItem(attrs[i].cloneNode());
       }
       var name = slot.getAttribute('name');

--- a/src/lib/annotations/annotations.html
+++ b/src/lib/annotations/annotations.html
@@ -273,10 +273,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    // In attribute names, some characters (e.g. '$') are considered valid by
+    // the HTML parser even though they are considered invalid by the DOM,
+    // which references the XML spec's definition of a valid attribute name.
+    // When `_replaceSlotWithContent` finds an attribute named 'name$', it
+    // needs to replace it with an attribute named 'select$', however the DOM
+    // prevents this attribute from being created directly due to XML's
+    // narrower valid attribute name definition. To work around this, the HTML
+    // parser is used to create an element with an attribute named 'select$'
+    // and this single attribute node is cloned whenever
+    // `_replaceSlotWithContent` needs to create a new 'select$' attribute.
     _select$Attr: (function () {
       var div = document.createElement('div');
-      div.innerHTML = "<div select$>";
-      return div.childNodes[0].attributes.getNamedItem("select$");
+      div.innerHTML = '<div select$>';
+      return div.childNodes[0].attributes.getNamedItem('select$');
     })(),
 
     _replaceSlotWithContent: function(slot) {
@@ -294,6 +304,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       var name$Value = slot.getAttribute('name$');
       if (name$Value) {
+        // See the comment on `_select$Attr`.
         const select$Attr = this._select$Attr.cloneNode();
         select$Attr.value = '[slot=\'' + name$Value + '\']';
         content.attributes.setNamedItem(select$Attr);

--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -412,7 +412,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _maybeDistributeForAttributeChange: function(element, name) {
-      // If this is a 'content' attribute on a 'select' element inside a shady
+      // If this is a 'select' attribute on a 'content' element inside a shady
       // root, then this change affects the root's host's distribution instead
       // of the parent element's distribution.
       if (name === 'select' && element.localName === 'content') {

--- a/src/lib/dom-api-shady.html
+++ b/src/lib/dom-api-shady.html
@@ -403,11 +403,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     setAttribute: function(name, value) {
       this.node.setAttribute(name, value);
-      this._maybeDistributeParent();
+      this._maybeDistributeForAttributeChange(this.node, name);
     },
 
     removeAttribute: function(name) {
       this.node.removeAttribute(name);
+      this._maybeDistributeForAttributeChange(this.node, name);
+    },
+
+    _maybeDistributeForAttributeChange: function(element, name) {
+      // If this is a 'content' attribute on a 'select' element inside a shady
+      // root, then this change affects the root's host's distribution instead
+      // of the parent element's distribution.
+      if (name === 'select' && element.localName === 'content') {
+        var ownerRoot = this.getOwnerRoot();
+        if (ownerRoot && this._nodeNeedsDistribution(ownerRoot.host)) {
+          this._lazyDistribute(ownerRoot.host);
+          return;
+        }
+      }
       this._maybeDistributeParent();
     },
 

--- a/test/unit/polymer-dom-content.html
+++ b/test/unit/polymer-dom-content.html
@@ -42,6 +42,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 </dom-module>
 
+<dom-module id="x-dist-slot-name-binding">
+  <template>
+    <slot id="slot" name$="[[slotName]]"></slot>
+  </template>
+  <script>
+  HTMLImports.whenReady(function() {
+    Polymer({
+      is: 'x-dist-slot-name-binding',
+      properties: {
+        slotName: {
+          type: String,
+          value: 'A'
+        }
+      }
+    });
+  });
+  </script>
+</dom-module>
+
 <dom-module id="x-dist-simple">
   <template>
     <content id="content"></content>
@@ -386,6 +405,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(Polymer.dom(dist.$.fooIP).getDistributedNodes()[1], null);
       assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[0].textContent, 'fallback for default');
       assert.equal(Polymer.dom(dist.$.defaultIP).getDistributedNodes()[1], null);
+      document.body.removeChild(dist);
+    });
+
+    test('bindings to slot names are converted to select attributes (auto <slot> to <content>)', function() {
+      var dist = document.createElement('x-dist-slot-name-binding');
+      document.body.appendChild(dist);
+      Polymer.dom.flush();
+      assert.equal(dist.slotName, 'A');
+      assert.equal(dist.$.slot.localName, 'content');
+      assert.equal(dist.$.slot.getAttribute('select'), '[slot=\'A\']');
+      assert.equal(Polymer.dom(dist.$.slot).getDistributedNodes().length, 0);
+      // Insert nodes with slot names 'A' and 'B'.
+      var divA = document.createElement('div');
+      divA.setAttribute('slot', 'A');
+      divA.textContent = 'DIV A';
+      Polymer.dom(dist).appendChild(divA);
+      var divB = document.createElement('div');
+      divB.setAttribute('slot', 'B');
+      divB.textContent = 'DIV B';
+      Polymer.dom(dist).appendChild(divB);
+      Polymer.dom.flush();
+      // Only the node with slot name 'A' should be assigned to the slot.
+      assert.equal(Polymer.dom(dist.$.slot).getDistributedNodes().length, 1);
+      assert.equal(Polymer.dom(dist.$.slot).getDistributedNodes()[0], divA);
+      // Update the bound variable so that the slot name becomes 'B'.
+      dist.slotName = 'B';
+      Polymer.dom.flush();
+      // Only the node with slot name 'B' should be assigned to the slot.
+      assert.equal(dist.$.slot.localName, 'content');
+      assert.equal(dist.$.slot.getAttribute('select'), '[slot=\'B\']');
+      assert.equal(Polymer.dom(dist.$.slot).getDistributedNodes().length, 1);
+      assert.equal(Polymer.dom(dist.$.slot).getDistributedNodes()[0], divB);
       document.body.removeChild(dist);
     });
 


### PR DESCRIPTION
Previously bindings to the `name` attribute of slots were not supported because, when slots were converted to content elements, the `name$` attribute was not converted to `select$` in the same way the `name` attribute was converted to `select`. Also, changes to a content element's `select` attribute did not trigger redistribution of its root's host element.

Fixes #5539.