### PR TITLE
Don't set display: none under legacyOptimizations. Fixes #5541.

### DIFF
--- a/lib/elements/dom-bind.js
+++ b/lib/elements/dom-bind.js
@@ -14,6 +14,7 @@ import { OptionalMutableData } from '../mixins/mutable-data.js';
 import { GestureEventListeners } from '../mixins/gesture-event-listeners.js';
 import { strictTemplatePolicy } from '../utils/settings.js';
 import { wrap } from '../utils/wrap.js';
+import { legacyOptimizations } from '../utils/settings.js';
 
 /**
  * @constructor
@@ -75,7 +76,9 @@ export class DomBind extends domBindBase {
    * @return {void}
    */
   connectedCallback() {
-    this.style.display = 'none';
+    if (!legacyOptimizations) {
+      this.style.display = 'none';
+    }
     this.render();
   }
 

--- a/lib/elements/dom-if.js
+++ b/lib/elements/dom-if.js
@@ -15,6 +15,7 @@ import { enqueueDebouncer, flush } from '../utils/flush.js';
 import { microTask } from '../utils/async.js';
 import { root } from '../utils/path.js';
 import { wrap } from '../utils/wrap.js';
+import { legacyOptimizations } from '../utils/settings.js';
 
 /**
  * The `<dom-if>` element will stamp a light-dom `<template>` child when
@@ -134,7 +135,9 @@ export class DomIf extends PolymerElement {
    */
   connectedCallback() {
     super.connectedCallback();
-    this.style.display = 'none';
+    if (!legacyOptimizations) {
+      this.style.display = 'none';
+    }
     if (this.if) {
       this.__debounceRender();
     }

--- a/lib/elements/dom-repeat.js
+++ b/lib/elements/dom-repeat.js
@@ -16,6 +16,7 @@ import { OptionalMutableData } from '../mixins/mutable-data.js';
 import { matches, translate } from '../utils/path.js';
 import { timeOut, microTask } from '../utils/async.js';
 import { wrap } from '../utils/wrap.js';
+import { legacyOptimizations } from '../utils/settings.js';
 
 /**
  * @constructor
@@ -320,7 +321,9 @@ export class DomRepeat extends domRepeatBase {
    */
   connectedCallback() {
     super.connectedCallback();
-    this.style.display = 'none';
+    if (!legacyOptimizations) {
+      this.style.display = 'none';
+    }
     // only perform attachment if the element was previously detached.
     if (this.__isDetached) {
       this.__isDetached = false;


### PR DESCRIPTION
Elide setting style on template elements if `legacyOptimizations` is on.

### Reference Issue
Fixes #5541.
