### PR TITLE
Fix 1.x tests.

### DIFF
--- a/test/unit/preserve-style-include/styling-scoped.html
+++ b/test/unit/preserve-style-include/styling-scoped.html
@@ -71,7 +71,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 suite('scoped-styling', function() {
 
   suiteSetup(function() {
-    if (!Polymer.Settings.useNativeShadow) {
+    if (!Polymer.Settings.useNativeShadow || !Polymer.Settings.useNativeCSSProperties) {
       this.skip();
     }
   });

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -941,6 +941,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // an element doesn't always accurately reflect values from recently
     // changed CSS variables. Reading the element's `offsetWidth` causes a
     // style recalc which seems to update them.
+    // https://bugs.webkit.org/show_bug.cgi?id=170708
     element.offsetWidth;
     name = name || 'border-top-width';
     var computed = element.getComputedStyleValue && !pseudo ?

--- a/test/unit/styling-cross-scope-var.html
+++ b/test/unit/styling-cross-scope-var.html
@@ -937,6 +937,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('scoped-styling-var', function() {
 
   function assertComputed(element, value, pseudo, name) {
+    // Safari 12 seems to have a bug where the result of `getComputedStyle` for
+    // an element doesn't always accurately reflect values from recently
+    // changed CSS variables. Reading the element's `offsetWidth` causes a
+    // style recalc which seems to update them.
+    element.offsetWidth;
     name = name || 'border-top-width';
     var computed = element.getComputedStyleValue && !pseudo ?
       element.getComputedStyleValue(name) :


### PR DESCRIPTION
Also skips the `preserveStyleIncludes` tests when its not used because native CSS variables aren't supported.