### PR TITLE
Don't import/export from the same file twice

### DIFF
--- a/lib/utils/flush.js
+++ b/lib/utils/flush.js
@@ -11,8 +11,8 @@ import './boot.js';
 /* eslint-disable no-unused-vars */
 import { Debouncer } from '../utils/debounce.js';  // used in type annotations
 /* eslint-enable no-unused-vars */
-import { flushDebouncers } from '../utils/debounce.js';  // used in type annotations
-export { enqueueDebouncer } from '../utils/debounce.js';  // used in type annotations
+import {enqueueDebouncer, flushDebouncers} from '../utils/debounce.js';
+export {enqueueDebouncer};
 
 /**
  * Forces several classes of asynchronously queued tasks to flush:


### PR DESCRIPTION
Quiets down an annoying build warning in some configurations

Downstreamed as cl/254578011
