### PR TITLE
Remove other double import

### DIFF
--- a/lib/utils/flush.js
+++ b/lib/utils/flush.js
@@ -8,9 +8,6 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 import './boot.js';
-/* eslint-disable no-unused-vars */
-import { Debouncer } from '../utils/debounce.js';  // used in type annotations
-/* eslint-enable no-unused-vars */
 import {enqueueDebouncer, flushDebouncers} from '../utils/debounce.js';
 export {enqueueDebouncer};
 


### PR DESCRIPTION

Debouncer is no longer used in the file, even as a type name.