### PR TITLE
Only consider a class "registered" when it is the top-most prototype

### DIFF
--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -302,17 +302,23 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       // only proceed if the generated class' prototype has not been registered.
       const generatedProto = PolymerGenerated.prototype;
       if (!generatedProto.hasOwnProperty('__hasRegisterFinished')) {
-        generatedProto.__hasRegisterFinished = true;
-        // ensure superclass is registered first.
-        super._registered();
-        // copy properties onto the generated class lazily if we're optimizing,
-        if (legacyOptimizations) {
-          copyPropertiesToProto(generatedProto);
-        }
         // make sure legacy lifecycle is called on the *element*'s prototype
         // and not the generated class prototype; if the element has been
         // extended, these are *not* the same.
         const proto = Object.getPrototypeOf(this);
+        // Only set flag when generated prototype itself is registered,
+        // as this element may be extended from, and needs to run `registered`
+        // on all behaviors on the subclass as well.
+        if (proto === generatedProto) {
+          generatedProto.__hasRegisterFinished = true;
+        }
+        // ensure superclass is registered first.
+        super._registered();
+        // copy properties onto the generated class lazily if we're optimizing,
+        if (legacyOptimizations && !Object.hasOwnProperty(generatedProto, '__hasCopiedProperties')) {
+          generatedProto.__hasCopiedProperties = true;
+          copyPropertiesToProto(generatedProto);
+        }
         let list = lifecycle.beforeRegister;
         if (list) {
           for (let i=0; i < list.length; i++) {

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -439,6 +439,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     });
 
+    const inheritedBehavior = {
+      registered() {
+        this.foo = {};
+      }
+    };
+
+    Polymer({
+      is: 'x-base-behavior',
+      behaviors: [inheritedBehavior],
+      hasFoo() {
+        return Boolean(this.foo);
+      }
+    });
+
+    class XInherit extends customElements.get('x-base-behavior') {}
+    customElements.define('x-inherit-behavior', XInherit);
+
 </script>
 
   <test-fixture id="single">
@@ -522,6 +539,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="property-observer-readonly">
     <template>
       <property-observer-readonly></property-observer-readonly>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="sub-behavior">
+    <template>
+      <x-inherit-behavior></x-inherit-behavior>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="sup-behavior">
+    <template>
+      <x-base-behavior></x-base-behavior>
     </template>
   </test-fixture>
 
@@ -788,6 +817,17 @@ suite('templates from behaviors', function() {
   test('template from behavior registered callback', function() {
     var el = fixture('from-behavior-registered');
     assert.ok(el.shadowRoot.querySelector('#behavior-from-registered'));
+  });
+
+});
+
+suite('inherited behaviors', function() {
+
+  test('behaviors are set up correctly on legacy element when subclass boots first', function() {
+    const sub = fixture('sub-behavior');
+    const sup = fixture('sup-behavior');
+    assert(sub.hasFoo(), 'subclass should have registered property defined');
+    assert(sup.hasFoo(), 'superclass should have registered property defined');
   });
 
 });

--- a/test/unit/mixin-behaviors.html
+++ b/test/unit/mixin-behaviors.html
@@ -395,13 +395,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     const Base = mixinBehaviors([{
       registered() {
-        this.usedExtendedProto = this.canUseExtendedProto;
+        this.usedExtendedProto = Boolean(this.canUseExtendedProto);
       }
     }], PolymerElement);
+
+    customElements.define('registered-super', Base);
 
     customElements.define('registered-proto', mixinBehaviors([
       {canUseExtendedProto: true}
     ], Base));
+
 
   </script>
 
@@ -485,6 +488,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="registered-super">
+    <template>
+      <registered-super></registered-super>
+    </template>
+  </test-fixture>
+
   <test-fixture id="extended-observed-attributes">
     <template>
       <extended-observed-attributes b1="b1" e1="e1" b2="b2" e2="e2"></extended-observed-attributes>
@@ -554,7 +563,7 @@ suite('behavior.registered/beforeRegister', function() {
 
   test('extending element with behaviors with registered properly registers', function() {
     var el = fixture('registered-ext');
-    assert.equal(el.registeredCount, 4);
+    assert.equal(el.registeredCount, 7);
     assert.equal(el.registeredBehaviors.length, 3);
     assert.equal(el.registeredBehaviors, el.behaviors);
     assert.deepEqual(el.registeredProps, [true, true, true]);
@@ -569,6 +578,11 @@ suite('behavior.registered/beforeRegister', function() {
   test('registered called on class prototype when extended', function() {
     var el = fixture('registered-proto');
     assert.isTrue(el.usedExtendedProto);
+  });
+
+  test('registered called on super-class prototype when extended', function() {
+    const el = fixture('registered-super');
+    assert.isFalse(el.usedExtendedProto);
   });
 
 });


### PR DESCRIPTION
Fixes #5567
