### PR TITLE
Attempt to sync host properties on every call to _showHideChildren.

### DIFF
--- a/lib/elements/dom-if.js
+++ b/lib/elements/dom-if.js
@@ -464,9 +464,9 @@ class DomIfFast extends DomIfBase {
     if (this.__instance && Boolean(this.__instance.__hidden) !== hidden) {
       this.__instance.__hidden = hidden;
       showHideChildren(hidden, this.__instance.templateInfo.childNodes);
-      if (!hidden) {
-        this.__syncHostProperties();
-      }
+    }
+    if (!hidden) {
+      this.__syncHostProperties();
     }
   }
 }
@@ -615,9 +615,9 @@ class DomIfLegacy extends DomIfBase {
     if (this.__instance && Boolean(this.__instance.__hidden) !== hidden) {
       this.__instance.__hidden = hidden;
       this.__instance._showHideChildren(hidden);
-      if (!hidden) {
-        this.__syncHostProperties();
-      }
+    }
+    if (!hidden) {
+      this.__syncHostProperties();
     }
   }
 }

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -895,6 +895,21 @@ suite('timing', function() {
       document.body.removeChild(el);
     });
 
+    test.only('host properties in sync toggling true-false-true synchronously', function() {
+      let el = document.createElement('x-guard-separate-props');
+      el.restamp = restamp;
+      document.body.appendChild(el);
+      el.a = 'initial';
+      el.b = true;
+      flush();
+      assert.equal(el.shadowRoot.textContent.trim(), 'initial');
+      el.setProperties({b: false, a: 'changed'});
+      el.b = true;
+      flush();
+      assert.equal(el.shadowRoot.textContent.trim(), 'changed');
+      document.body.removeChild(el);
+    });
+
     test('host paths in sync when changed while false', function() {
       let el = document.createElement('x-guard-separate-paths');
       el.restamp = restamp;


### PR DESCRIPTION
Fixes an issue where a `dom-if` that is toggled synchronously true-false-true could fail to sync properties invalidated while false, since the hidden state is only checked at async render timing, and the newly added dirty-check could means nothing happens if the hidden state has been changed back to its previous value at last render.

Since `__syncHostProperties` has its own fast-path if there is nothing to sync, it need not be gated on the hidden dirty-check in `_showHideChildren).