### PR TITLE
Read the CSS build type at the first instance creation rather than at registration time.

### DIFF
--- a/src/standard/styling.html
+++ b/src/standard/styling.html
@@ -55,10 +55,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!nativeShadow) {
           this._scopeStyle = styleUtil.applyStylePlaceHolder(this.is);
         }
-        this.__cssBuild = styleUtil.cssBuildTypeForModule(this.is);
       },
 
       _prepShimStyles: function() {
+        this.__cssBuild = styleUtil.cssBuildTypeForModule(this.is);
         if (this._template) {
           // We can avoid *all* shimming if native properties are used
           // and there is a shadow css build and we are using native shadow.


### PR DESCRIPTION
If dom-modules are not upgraded by the time the component is registered, then the style transformer will not know what type of CSS build has happened, if any. This PR delays reading this information until the first instance is created, in case the dom-module for that element has loaded in the mean time.