### PR TITLE
Remove use of Object.create on template info (significant perf impact).

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2721,7 +2721,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
           // stamped, and may be stamped more than once (in which case instances
           // of the template info will be in the tree under its parent more than
           // once).
-          const parent = templateInfo.parent || this.__templateInfo;
+          const parent = template._parentTemplateInfo || this.__templateInfo;
           const previous = parent.lastChild;
           parent.lastChild = templateInfo;
           templateInfo.previousSibling = previous;

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2670,21 +2670,21 @@ export const PropertyEffects = dedupingMixin(superClass => {
      * Overview of binding flow:
      *
      * During finalization (`instanceBinding==false`, `wasPreBound==false`):
-     *  `_bindTemplate(false)` called directly during finalization - parses the
-     *  template (for the first time), and then assigns that _prototypical_
+     *  `_bindTemplate(t, false)` called directly during finalization - parses
+     *  the template (for the first time), and then assigns that _prototypical_
      *  template info to `__preboundTemplateInfo` _on the prototype_; note in
      *  this case `wasPreBound` is false; this is the first time we're binding
      *  it, thus we create accessors.
      *
      * During first stamping (`instanceBinding==true`, `wasPreBound==true`):
-     *   `_stampTemplate` calls `_bindTemplate(true)`: the `templateInfo`
+     *   `_stampTemplate` calls `_bindTemplate(t, true)`: the `templateInfo`
      *   returned matches the prebound one, and so this is `wasPreBound == true`
-     *   state; thus we _skip_ creating accessors, but _do_ create a
-     *   sub-instance of the template info to serve as the start of our linked
-     *   list (needs to be an instance, not the prototypical one, so that we can
-     *   add `nodeList` to it to contain the `nodeInfo`-ordered list of instance
-     *   nodes for bindings, and so we can chain runtime-stamped template infos
-     *   off of it). At this point, the call to `_stampTemplate` calls
+     *   state; thus we _skip_ creating accessors, but _do_ create an instance
+     *   of the template info to serve as the start of our linked list (needs to
+     *   be an instance, not the prototypical one, so that we can add `nodeList`
+     *   to it to contain the `nodeInfo`-ordered list of instance nodes for
+     *   bindings, and so we can chain runtime-stamped template infos off of
+     *   it). At this point, the call to `_stampTemplate` calls
      *   `applyTemplateInfo` for each nested `<template>` found during parsing
      *   to hand prototypical `_templateInfo` to them; we also pass the _parent_
      *   `templateInfo` to the `<template>` so that we have the instance-time
@@ -2692,12 +2692,12 @@ export const PropertyEffects = dedupingMixin(superClass => {
      *   runtime-stamped.
      *
      * During subsequent runtime stamping (`instanceBinding==true`,
-     *   `wasPreBound==false`): `_stampTemplate` calls `_bindTemplate(true)` -
-     *   here `templateInfo` is guaranteed to _not_ match the prebound one,
+     *   `wasPreBound==false`): `_stampTemplate` calls `_bindTemplate(t, true)`
+     *   - here `templateInfo` is guaranteed to _not_ match the prebound one,
      *   because it was either a different template altogether, or even if it
-     *   was the same template, the step above created a sub-instance of the
-     *   info; in this case `wasPreBound == false`, so we _do_ create accessors,
-     *   _and_ link a sub-instance into the linked list.
+     *   was the same template, the step above created a instance of the info;
+     *   in this case `wasPreBound == false`, so we _do_ create accessors, _and_
+     *   link a instance into the linked list.
      */
 
     /**
@@ -2748,7 +2748,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
           // template, use the root template (the first stamped one) as the
           // parent. Note, `parent` is the `templateInfo` instance for this
           // template's parent (containing) template, which was set up in
-          // `applyTemplateContent`.  While a given template's `parent` is set
+          // `applyTemplateInfo`.  While a given template's `parent` is set
           // apriori, it is only added to the parent's child list at the point
           // that it is being bound, since a template may or may not ever be
           // stamped, and may be stamped more than once (in which case instances
@@ -2863,7 +2863,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
       // Unlink template info; Note that while the child is unlinked from its
       // parent list, a template's `parent` reference is never removed, since
       // this is is determined by the tree structure and applied at
-      // `applyTemplateContent` time.
+      // `applyTemplateInfo` time.
       let templateInfo = dom.templateInfo;
       const {previousSibling, nextSibling, parent} = templateInfo;
       if (previousSibling) {

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2666,10 +2666,43 @@ export const PropertyEffects = dedupingMixin(superClass => {
 
     // -- binding ----------------------------------------------
 
+    /*
+     * Overview of binding flow:
+     *
+     * During finalization (`instanceBinding==false`, `wasPreBound==false`):
+     *  `_bindTemplate(false)` called directly during finalization - parses the
+     *  template (for the first time), and then assigns that _prototypical_
+     *  template info to `__preboundTemplateInfo` _on the prototype_; note in
+     *  this case `wasPreBound` is false; this is the first time we're binding
+     *  it, thus we create accessors.
+     *
+     * During first stamping (`instanceBinding==true`, `wasPreBound==true`):
+     *   `_stampTemplate` calls `_bindTemplate(true)`: the `templateInfo`
+     *   returned matches the prebound one, and so this is `wasPreBound == true`
+     *   state; thus we _skip_ creating accessors, but _do_ create a
+     *   sub-instance of the template info to serve as the start of our linked
+     *   list (needs to be an instance, not the prototypical one, so that we can
+     *   add `nodeList` to it to contain the `nodeInfo`-ordered list of instance
+     *   nodes for bindings, and so we can chain runtime-stamped template infos
+     *   off of it). At this point, the call to `_stampTemplate` calls
+     *   `applyTemplateInfo` for each nested `<template>` found during parsing
+     *   to hand prototypical `_templateInfo` to them; we also pass the _parent_
+     *   `templateInfo` to the `<template>` so that we have the instance-time
+     *   parent to link the `templateInfo` under in the case it was
+     *   runtime-stamped.
+     *
+     * During subsequent runtime stamping (`instanceBinding==true`,
+     *   `wasPreBound==false`): `_stampTemplate` calls `_bindTemplate(true)` -
+     *   here `templateInfo` is guaranteed to _not_ match the prebound one,
+     *   because it was either a different template altogether, or even if it
+     *   was the same template, the step above created a sub-instance of the
+     *   info; in this case `wasPreBound == false`, so we _do_ create accessors,
+     *   _and_ link a sub-instance into the linked list.
+     */
+
     /**
-     * Equivalent to static `bindTemplate` API but can be called on
-     * an instance to add effects at runtime.  See that method for
-     * full API docs.
+     * Equivalent to static `bindTemplate` API but can be called on an instance
+     * to add effects at runtime.  See that method for full API docs.
      *
      * This method may be called on the prototype (for prototypical template
      * binding, to avoid creating accessors every instance) once per prototype,
@@ -2677,17 +2710,17 @@ export const PropertyEffects = dedupingMixin(superClass => {
      * create and link an instance of the template metadata associated with a
      * particular stamping.
      *
-     * @override
+     * @override 
      * @param {!HTMLTemplateElement} template Template containing binding
-     *   bindings
+     * bindings
      * @param {boolean=} instanceBinding When false (default), performs
-     *   "prototypical" binding of the template and overwrites any previously
-     *   bound template for the class. When true (as passed from
-     *   `_stampTemplate`), the template info is instanced and linked into
-     *   the list of bound templates.
+     * "prototypical" binding of the template and overwrites any previously
+     * bound template for the class. When true (as passed from
+     * `_stampTemplate`), the template info is instanced and linked into the
+     * list of bound templates.
      * @return {!TemplateInfo} Template metadata object; for `runtimeBinding`,
-     *   this is an instance of the prototypical template info
-     * @protected
+     * this is an instance of the prototypical template info
+     * @protected 
      * @suppress {missingProperties} go/missingfnprops
      */
     _bindTemplate(template, instanceBinding) {

--- a/lib/mixins/template-stamp.js
+++ b/lib/mixins/template-stamp.js
@@ -72,7 +72,7 @@ function applyEventListener(inst, node, nodeInfo) {
 }
 
 // push configuration references at configure time
-function applyTemplateContent(inst, node, nodeInfo, parentTemplateInfo) {
+function applyTemplateInfo(inst, node, nodeInfo, parentTemplateInfo) {
   if (nodeInfo.templateInfo) {
     // Give the node an instance of this templateInfo and set its parent
     node._templateInfo = nodeInfo.templateInfo;
@@ -466,7 +466,7 @@ export const TemplateStamp = dedupingMixin(
       for (let i=0, l=nodeInfo.length, info; (i<l) && (info=nodeInfo[i]); i++) {
         let node = nodes[i] = findTemplateNode(dom, info);
         applyIdToMap(this, dom.$, node, info);
-        applyTemplateContent(this, node, info, templateInfo);
+        applyTemplateInfo(this, node, info, templateInfo);
         applyEventListener(this, node, info);
       }
       dom = /** @type {!StampedTemplate} */(dom); // eslint-disable-line no-self-assign

--- a/lib/mixins/template-stamp.js
+++ b/lib/mixins/template-stamp.js
@@ -75,8 +75,8 @@ function applyEventListener(inst, node, nodeInfo) {
 function applyTemplateContent(inst, node, nodeInfo, parentTemplateInfo) {
   if (nodeInfo.templateInfo) {
     // Give the node an instance of this templateInfo and set its parent
-    node._templateInfo = Object.create(nodeInfo.templateInfo);
-    node._templateInfo.parent = parentTemplateInfo;
+    node._templateInfo = nodeInfo.templateInfo;
+    node._parentTemplateInfo = parentTemplateInfo;
   }
 }
 

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -895,7 +895,7 @@ suite('timing', function() {
       document.body.removeChild(el);
     });
 
-    test.only('host properties in sync toggling true-false-true synchronously', function() {
+    test('host properties in sync toggling true-false-true synchronously', function() {
       let el = document.createElement('x-guard-separate-props');
       el.restamp = restamp;
       document.body.appendChild(el);


### PR DESCRIPTION
The only reason `Object.create` was used here was to hand the template info its parent template info; since `templateInfo` is prototypical at this point, this made it an instance.  For whatever reason, this caused a 5-10% performance regression on some benchmarks.  The `<template>` node also acts as an instance that can carry this info, and doing so gets the performance back.