### PR TITLE
Fix a minification issue with the `__hasRegisterFinished` property.

### DIFF
--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -301,7 +301,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       */
       // only proceed if the generated class' prototype has not been registered.
       const generatedProto = PolymerGenerated.prototype;
-      if (!generatedProto.hasOwnProperty('__hasRegisterFinished')) {
+      if (!generatedProto.hasOwnProperty(JSCompiler_renameProperty('__hasRegisterFinished', generatedProto))) {
         generatedProto.__hasRegisterFinished = true;
         // ensure superclass is registered first.
         super._registered();

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -179,7 +179,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      */
     _initializeProperties() {
       let proto = Object.getPrototypeOf(this);
-      if (!proto.hasOwnProperty('__hasRegisterFinished')) {
+      if (!proto.hasOwnProperty(JSCompiler_renameProperty('__hasRegisterFinished', proto))) {
         this._registered();
         // backstop in case the `_registered` implementation does not set this
         proto.__hasRegisterFinished = true;


### PR DESCRIPTION
Wrap `hasOwnProperty` checks for `__hasRegisterFinished` in `JSCompiler_renameProperty()`.