### PR TITLE
Ensure parent is linked to child templateInfo. Fixes fastDomIf unstamping issue.

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2866,7 +2866,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
       // parent list, a template's `parent` reference is never removed, since
       // this is is determined by the tree structure and applied at
       // `applyTemplateInfo` time.
-      let templateInfo = dom.templateInfo;
+      const templateInfo = dom.templateInfo;
       const {previousSibling, nextSibling, parent} = templateInfo;
       if (previousSibling) {
         previousSibling.nextSibling = nextSibling;
@@ -2878,6 +2878,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
       } else if (parent) {
         parent.lastChild = previousSibling;
       }
+      templateInfo.nextSibling = templateInfo.previousSibling = null;
       // Remove stamped nodes
       let nodes = templateInfo.childNodes;
       for (let i=0; i<nodes.length; i++) {

--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -2756,6 +2756,7 @@ export const PropertyEffects = dedupingMixin(superClass => {
           // once).
           const parent = template._parentTemplateInfo || this.__templateInfo;
           const previous = parent.lastChild;
+          templateInfo.parent = parent;
           parent.lastChild = templateInfo;
           templateInfo.previousSibling = previous;
           if (previous) {

--- a/test/unit/dom-if-elements.js
+++ b/test/unit/dom-if-elements.js
@@ -126,8 +126,14 @@ Polymer({
       <x-foo prop="{{prop1}}"></x-foo>
       <template is="dom-if" id="if-2" if="{{shouldStamp2}}">
         <x-foo prop="{{prop2}}"></x-foo>
-        <template is="dom-if" id="if-3" if="{{shouldStamp3}}">
+        <template is="dom-if" id="if-3" if="{{shouldStamp3}}" restamp>
           <x-foo prop="{{prop3}}"></x-foo>
+        </template>
+        <template is="dom-if" id="if-4" if="{{shouldStamp4}}" restamp>
+          <x-foo prop="{{prop4}}"></x-foo>
+        </template>
+        <template is="dom-if" id="if-5" if="{{shouldStamp5}}" restamp>
+          <x-foo prop="{{prop5}}"></x-foo>
         </template>
       </template>
     </template>
@@ -144,6 +150,12 @@ Polymer({
     },
     prop3: {
       value: 'prop3'
+    },
+    prop4: {
+      value: 'prop4'
+    },
+    prop5: {
+      value: 'prop5'
     },
     item: {
       value: function() { return {prop: 'outerItem'}; }

--- a/test/unit/dom-if-elements.js
+++ b/test/unit/dom-if-elements.js
@@ -126,14 +126,14 @@ Polymer({
       <x-foo prop="{{prop1}}"></x-foo>
       <template is="dom-if" id="if-2" if="{{shouldStamp2}}">
         <x-foo prop="{{prop2}}"></x-foo>
-        <template is="dom-if" id="if-3" if="{{shouldStamp3}}" restamp>
-          <x-foo prop="{{prop3}}"></x-foo>
+        <template is="dom-if" id="if-3-1" if="{{shouldStamp3_1}}" restamp>
+          <x-foo prop="{{prop3_1}}"></x-foo>
         </template>
-        <template is="dom-if" id="if-4" if="{{shouldStamp4}}" restamp>
-          <x-foo prop="{{prop4}}"></x-foo>
+        <template is="dom-if" id="if-4-2" if="{{shouldStamp3_2}}" restamp>
+          <x-foo prop="{{prop3_2}}"></x-foo>
         </template>
-        <template is="dom-if" id="if-5" if="{{shouldStamp5}}" restamp>
-          <x-foo prop="{{prop5}}"></x-foo>
+        <template is="dom-if" id="if-5-3" if="{{shouldStamp3_3}}" restamp>
+          <x-foo prop="{{prop3_3}}"></x-foo>
         </template>
       </template>
     </template>
@@ -148,14 +148,14 @@ Polymer({
     prop2: {
       value: 'prop2'
     },
-    prop3: {
-      value: 'prop3'
+    prop3_1: {
+      value: 'prop3_1'
     },
-    prop4: {
-      value: 'prop4'
+    prop3_2: {
+      value: 'prop3_2'
     },
-    prop5: {
-      value: 'prop5'
+    prop3_3: {
+      value: 'prop3_3'
     },
     item: {
       value: function() { return {prop: 'outerItem'}; }

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -178,87 +178,87 @@ suite('nested individually-controlled dom-if', function() {
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
   });
 
-  test('show 3', function() {
-    individual.shouldStamp3 = true;
+  test('show 3-1', function() {
+    individual.shouldStamp3_1 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 3, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[2].prop, 'prop3_1');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3-1 display wrong');
   });
 
-  test('show 4', function() {
-    individual.shouldStamp4 = true;
+  test('show 3-2', function() {
+    individual.shouldStamp3_2 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 4, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
-    assert.equal(stamped[3].prop, 'prop4');
+    assert.equal(stamped[2].prop, 'prop3_1');
+    assert.equal(stamped[3].prop, 'prop3_2');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
-    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 4 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3-1 display wrong');
+    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 3-2 display wrong');
   });
 
-  test('remove 4', function() {
-    individual.shouldStamp4 = false;
+  test('remove 3-2', function() {
+    individual.shouldStamp3_2 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 3, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[2].prop, 'prop3_1');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3-1 display wrong');
   });
 
-  test('show 5', function() {
-    individual.shouldStamp5 = true;
+  test('show 3-3', function() {
+    individual.shouldStamp3_3 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 4, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
-    assert.equal(stamped[3].prop, 'prop5');
+    assert.equal(stamped[2].prop, 'prop3_1');
+    assert.equal(stamped[3].prop, 'prop3_3');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
-    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 5 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3-1 display wrong');
+    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 3-3 display wrong');
   });
 
-  test('update 5', function() {
-    individual.prop5 = 'prop5*';
+  test('update 3-3', function() {
+    individual.prop3_3 = 'prop3_3*';
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 4, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
-    assert.equal(stamped[3].prop, 'prop5*');
+    assert.equal(stamped[2].prop, 'prop3_1');
+    assert.equal(stamped[3].prop, 'prop3_3*');
   });
 
-  test('remove 5', function() {
-    individual.shouldStamp5 = false;
+  test('remove 3-3', function() {
+    individual.shouldStamp3_3 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 3, 'total stamped count incorrect');
     assert.equal(stamped[0].prop, 'prop1');
     assert.equal(stamped[1].prop, 'prop2');
-    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[2].prop, 'prop3_1');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3-1 display wrong');
   });
 
   test('remove 3', function() {
-    individual.shouldStamp3 = false;
+    individual.shouldStamp3_1 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 2, 'total stamped count incorrect');
@@ -305,7 +305,7 @@ suite('nested individually-controlled dom-if', function() {
   });
 
   test('show 3', function() {
-    individual.shouldStamp3 = true;
+    individual.shouldStamp3_1 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 3, 'total stamped count incorrect');

--- a/test/unit/dom-if.html
+++ b/test/unit/dom-if.html
@@ -191,54 +191,117 @@ suite('nested individually-controlled dom-if', function() {
     assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
   });
 
-  test('hide 3', function() {
-    individual.shouldStamp3 = false;
+  test('show 4', function() {
+    individual.shouldStamp4 = true;
+    individual.render();
+    let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
+    assert.equal(stamped.length, 4, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[3].prop, 'prop4');
+    assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
+    assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 4 display wrong');
+  });
+
+  test('remove 4', function() {
+    individual.shouldStamp4 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
     assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(stamped[2].prop, 'prop3');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'none', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+  });
+
+  test('show 5', function() {
+    individual.shouldStamp5 = true;
+    individual.render();
+    let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
+    assert.equal(stamped.length, 4, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[3].prop, 'prop5');
+    assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
+    assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+    assert.equal(getComputedStyle(stamped[3]).display, 'inline', 'stamped 5 display wrong');
+  });
+
+  test('update 5', function() {
+    individual.prop5 = 'prop5*';
+    let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
+    assert.equal(stamped.length, 4, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(stamped[3].prop, 'prop5*');
+  });
+
+  test('remove 5', function() {
+    individual.shouldStamp5 = false;
+    individual.render();
+    let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
+    assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(stamped[2].prop, 'prop3');
+    assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
+    assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
+    assert.equal(getComputedStyle(stamped[2]).display, 'inline', 'stamped 3 display wrong');
+  });
+
+  test('remove 3', function() {
+    individual.shouldStamp3 = false;
+    individual.render();
+    let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
+    assert.equal(stamped.length, 2, 'total stamped count incorrect');
+    assert.equal(stamped[0].prop, 'prop1');
+    assert.equal(stamped[1].prop, 'prop2');
+    assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
+    assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
   });
 
   test('hide 2', function() {
     individual.shouldStamp2 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
-    assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped.length, 2, 'total stamped count incorrect');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'none', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'none', 'stamped 3 display wrong');
   });
 
   test('hide 1', function() {
     individual.shouldStamp1 = false;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
-    assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped.length, 2, 'total stamped count incorrect');
     assert.equal(getComputedStyle(stamped[0]).display, 'none', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'none', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'none', 'stamped 3 display wrong');
   });
 
   test('show 1', function() {
     individual.shouldStamp1 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
-    assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped.length, 2, 'total stamped count incorrect');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'none', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'none', 'stamped 3 display wrong');
   });
 
   test('show 2', function() {
     individual.shouldStamp2 = true;
     individual.render();
     let stamped = individual.shadowRoot.querySelectorAll('*:not(template):not(dom-if):not(span)');
-    assert.equal(stamped.length, 3, 'total stamped count incorrect');
+    assert.equal(stamped.length, 2, 'total stamped count incorrect');
     assert.equal(getComputedStyle(stamped[0]).display, 'inline', 'stamped 1 display wrong');
     assert.equal(getComputedStyle(stamped[1]).display, 'inline', 'stamped 2 display wrong');
-    assert.equal(getComputedStyle(stamped[2]).display, 'none', 'stamped 3 display wrong');
   });
 
   test('show 3', function() {

--- a/test/unit/property-effects-template.html
+++ b/test/unit/property-effects-template.html
@@ -741,7 +741,9 @@ suite('nested runtime template stamping', () => {
   const spans = new Set();
   const accumulatedContent = () => {
     Array.from(el.shadowRoot.querySelectorAll('span')).forEach(s => spans.add(s));
-    return Array.from(spans).map(e => e.textContent);
+    const content = [];
+    spans.forEach(e => content.push(e.textContent));
+    return content;
   };
 
   setup(() => {

--- a/test/unit/property-effects-template.html
+++ b/test/unit/property-effects-template.html
@@ -162,6 +162,30 @@ customElements.define('x-runtime', XRuntime);
 </script>
 </dom-module>
 
+<script type="module">
+  import { PolymerElement, html } from '../../polymer-element.js';
+  customElements.define('x-runtime-nested', class extends PolymerElement {
+    static get template() {
+      return html`<template id="t1">
+        <span>t1-[[prop1]]</span>
+        <template id="t2">
+          <span>t2-[[prop2]]</span>
+          <template id="t3">
+            <span>t3-[[prop3]]</span>
+          </template>
+        </template>
+      </template>`;
+    }
+    static get properties() {
+      return {
+        prop1: { value: 'prop1'},
+        prop2: { value: 'prop2'},
+        prop3: { value: 'prop3'}
+      };
+    }
+  });
+</script>
+
 <template id="custom-template">
   <x-special name="el1" special="attr1" binding="[[prop]]" on-event="handler"></x-special>
   <div name="el2" special="attr2">
@@ -705,6 +729,85 @@ suite('runtime template stamping', function() {
     assert.isTrue(dom.querySelector('x-element').readied);
   });
 
+});
+
+suite('nested runtime template stamping', () => {
+
+  let el;
+
+  // Accumulates any spans that are stamped into a single ordered set; once
+  // added, a span is never removed, so we can test that updates stop happening
+  // when bound DOM is removed
+  const spans = new Set();
+  const accumulatedContent = () => {
+    Array.from(el.shadowRoot.querySelectorAll('span')).forEach(s => spans.add(s));
+    return Array.from(spans).map(e => e.textContent);
+  };
+
+  setup(() => {
+    el = document.createElement('x-runtime-nested');
+    document.body.appendChild(el);
+  });
+  teardown(() => {
+    document.body.removeChild(el);
+  });
+
+  test('nested stamping', () => {
+    // Stamp 1
+    const dom1 = el._stampTemplate(el.shadowRoot.querySelector('#t1'));
+    el.shadowRoot.appendChild(dom1);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1']);
+    // Stamp 2
+    const dom2 = el._stampTemplate(el.shadowRoot.querySelector('#t2'));
+    el.shadowRoot.appendChild(dom2);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1', 't2-prop2']);
+    // Stamp 3-1
+    const dom3_1 = el._stampTemplate(el.shadowRoot.querySelector('#t3'));
+    el.shadowRoot.appendChild(dom3_1);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1', 't2-prop2', 't3-prop3']);
+    // Stamp 3_2
+    const dom3_2 = el._stampTemplate(el.shadowRoot.querySelector('#t3'));
+    el.shadowRoot.appendChild(dom3_2);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1', 't2-prop2', 't3-prop3', 't3-prop3']);
+    // Stamp 3_3
+    const dom3_3 = el._stampTemplate(el.shadowRoot.querySelector('#t3'));
+    el.shadowRoot.appendChild(dom3_3);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1', 't2-prop2', 't3-prop3', 't3-prop3', 't3-prop3']);
+    // Modify all
+    el.setProperties({
+      prop1: el.prop1 + '*',
+      prop2: el.prop2 + '*',
+      prop3: el.prop3 + '*'
+    });
+    assert.deepEqual(accumulatedContent(), ['t1-prop1*', 't2-prop2*', 't3-prop3*', 't3-prop3*', 't3-prop3*']);
+    // Remove 3-1 & modify all
+    el._removeBoundDom(dom3_1);
+    el.setProperties({
+      prop1: el.prop1 + '*',
+      prop2: el.prop2 + '*',
+      prop3: el.prop3 + '*'
+    });
+    assert.deepEqual(accumulatedContent(), ['t1-prop1**', 't2-prop2**', 't3-prop3*', 't3-prop3**', 't3-prop3**']);
+    // Remove 3-3 & modify all
+    el._removeBoundDom(dom3_3);
+    el.setProperties({
+      prop1: el.prop1 + '*',
+      prop2: el.prop2 + '*',
+      prop3: el.prop3 + '*'
+    });
+    assert.deepEqual(accumulatedContent(), ['t1-prop1***', 't2-prop2***', 't3-prop3*', 't3-prop3***', 't3-prop3**']);
+    // Stamp 3-4
+    const dom3_4 = el._stampTemplate(el.shadowRoot.querySelector('#t3'));
+    el.shadowRoot.appendChild(dom3_4);
+    assert.deepEqual(accumulatedContent(), ['t1-prop1***', 't2-prop2***', 't3-prop3*', 't3-prop3***', 't3-prop3**', 't3-prop3***']);
+    // Modify all
+    el.setProperties({
+      prop1: el.prop1 + '*',
+      prop2: el.prop2 + '*',
+      prop3: el.prop3 + '*'
+    });
+    assert.deepEqual(accumulatedContent(), ['t1-prop1****', 't2-prop2****', 't3-prop3*', 't3-prop3****', 't3-prop3**', 't3-prop3****']);
+  });
 });
 
 suite('template parsing hooks', () => {


### PR DESCRIPTION
`_stampTemplate` was failing to link the `parent` field of the `templateInfo` linked tree. This resulted in the `lastChild` not being correctly unlinked if it was unstamped, causing subsequent children to be linked off of the removed `lastChild`. Since the host iterates the tree from `firstChild`, it would never see the added templates and their effects (updates subsequent to first render) would not be run.