### PR TITLE
Only import each file once

### DIFF
--- a/lib/elements/dom-if.js
+++ b/lib/elements/dom-if.js
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 import { PolymerElement } from '../../polymer-element.js';
 
-import { templatize } from '../utils/templatize.js';
 import { Debouncer } from '../utils/debounce.js';
 import { enqueueDebouncer, flush } from '../utils/flush.js';
 import { microTask } from '../utils/async.js';
@@ -17,7 +16,7 @@ import { root } from '../utils/path.js';
 import { wrap } from '../utils/wrap.js';
 import { hideElementsGlobally } from '../utils/hide-template-controls.js';
 import { fastDomIf, strictTemplatePolicy } from '../utils/settings.js';
-import { showHideChildren } from '../utils/templatize.js';
+import { showHideChildren, templatize } from '../utils/templatize.js';
 
 /**
  * @customElement


### PR DESCRIPTION
Easier on the reader, and silences a lint warning