### PR TITLE
Work around Closure Compiler bug to avoid upcoming type error

### DIFF
--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -392,21 +392,31 @@ function addPropagateEffects(target, templateInfo, options, methodHost) {
          * @constructor
          * @extends {DataTemplate}
          */
-        let templatizedBase = options.mutableData ? MutableDataTemplate : DataTemplate;
+        let templatizedBase =
+            options.mutableData ? MutableDataTemplate : DataTemplate;
+
+        // NOTE: due to https://github.com/google/closure-compiler/issues/2928,
+        // combining the next two lines into one assignment causes a spurious
+        // type error.
+        class TemplatizedTemplate extends templatizedBase {}
         /** @private */
-        klass = templateInfo.templatizeTemplateClass =
-          class TemplatizedTemplate extends templatizedBase {};
+        klass = templateInfo.templatizeTemplateClass = TemplatizedTemplate;
       } else {
         /**
          * @constructor
          * @extends {PolymerElement}
          */
         const templatizedBase = target.constructor;
+
         // Create a cached subclass of the base custom element class onto which
         // to put the template-specific propagate effects
+        // NOTE: due to https://github.com/google/closure-compiler/issues/2928,
+        // combining the next two lines into one assignment causes a spurious
+        // type error.
+        class TemplatizedTemplateExtension extends templatizedBase {}
         /** @private */
         klass = templateInfo.templatizeTemplateClass =
-          class TemplatizedTemplateExtension extends templatizedBase {};
+            TemplatizedTemplateExtension;
       }
       // Add template - >instances effects
       // and host <- template effects

--- a/lib/utils/templatize.js
+++ b/lib/utils/templatize.js
@@ -398,8 +398,8 @@ function addPropagateEffects(target, templateInfo, options, methodHost) {
         // NOTE: due to https://github.com/google/closure-compiler/issues/2928,
         // combining the next two lines into one assignment causes a spurious
         // type error.
-        class TemplatizedTemplate extends templatizedBase {}
         /** @private */
+        class TemplatizedTemplate extends templatizedBase {}
         klass = templateInfo.templatizeTemplateClass = TemplatizedTemplate;
       } else {
         /**
@@ -413,8 +413,8 @@ function addPropagateEffects(target, templateInfo, options, methodHost) {
         // NOTE: due to https://github.com/google/closure-compiler/issues/2928,
         // combining the next two lines into one assignment causes a spurious
         // type error.
-        class TemplatizedTemplateExtension extends templatizedBase {}
         /** @private */
+        class TemplatizedTemplateExtension extends templatizedBase {}
         klass = templateInfo.templatizeTemplateClass =
             TemplatizedTemplateExtension;
       }


### PR DESCRIPTION
Fixing a compiler type equality bug uncovers a new error caused by
https://github.com/google/closure-compiler/issues/2928.

  third_party/javascript/polymer/v2/polymer/lib/utils/templatize.js:409: ERROR - [JSC_TYPE_MISMATCH] mismatch in declaration of superclass type
  found   : templatizedBase
  required: templatizedBase
            class TemplatizedTemplateExtension extends templatizedBase {};
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

(The found and required types are actually different classes completely, as the compiler is attaching the wrong type to `TemplatizedTemplateExtension`).