### PR TITLE
Add module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.0",
   "description": "The Polymer library makes it easy to create your own web components. Give your element some markup and properties, and then use it on a site. Polymer provides features like dynamic templates and data binding to reduce the amount of boilerplate you need to write",
   "main": "polymer-element.js",
+  "module": "polymer-element.js",
   "directories": {
     "doc": "docs",
     "test": "test"


### PR DESCRIPTION
https://unpkg.com/@polymer/polymer@3.3.0?module fails to load saying that the package is not an ES module. Adding `module` field should allow it to load (see: https://github.com/mjackson/unpkg/blob/4bb6cf424a6f7e803fc98c13662ee4d04bfe4af2/modules/middleware/validateFilename.js#L7)
