### PR TITLE
Remove TimvdLippe from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Code owners for Polymer
-* @sorvell @kevinpschaaf @TimvdLippe @azakus
+* @sorvell @kevinpschaaf @azakus


### PR DESCRIPTION
I am no longer an active maintainer of the Polymer repository, but I am still receiving review requests for PRs. While I could review PRs, it would be better for active maintainers to review community PRs. I am still available for reviews where my domain knowledge would be required, but I don't think I should be added a reviewer to every PR.