### PR TITLE
Update the polyfills; fix a type generation error.

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -8,6 +8,7 @@
     "index.html"
   ],
   "excludeIdentifiers": [
+    "ElementMixinPatchedBase",
     "templatizedBase"
   ],
   "removeReferences": [

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -104,8 +104,13 @@ export const ElementMixin = dedupingMixin(base => {
   // Optimizations for ShadyDOM's on-demand patching that pre-patches
   // elements to work with ShadyDOM.
   if (window.ShadyDOM && window.ShadyDOM.patchOnDemand) {
-    base = class extends base {};
-    ShadyDOM.patchElementProto(base.prototype);
+    // `ElementMixinPatchedBase` is explicitly ignored in `gen-tsd.json` so
+    // that it doesn't attempt to export a type for it: the type generator
+    // attempts to declare it as extending `base` but no type is generated for
+    // `base`.
+    class ElementMixinPatchedBase extends base {};
+    ShadyDOM.patchElementProto(ElementMixinPatchedBase.prototype);
+    base = ElementMixinPatchedBase;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,14 +1300,14 @@
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
-      "integrity": "sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.3.tgz",
+      "integrity": "sha512-fRuET+UGrH84hG0UF4iHbFqWZKUoan4/ki+iCOJ/vnKltPSHv/ZVbcA6sT/pRreznt8aKEGqN2KdHvgRxn4xjA=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.10.tgz",
-      "integrity": "sha512-5dzhUhP+h0qMiK0IWb7VNb0OGBoXO3AuI6Qi8t9PoKT50s5L1jv0xnwnLq+cFgPuTB8FLTNP8xIDmyoOsKBy9Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.0.tgz",
+      "integrity": "sha512-kEClEz2nu9/i6SvyBJTV4pCc6CyCzMhK7zEeJ6QhiJoulBp4YZ06Zfj2E2HUXfWfHJIjtKriJYMtfhettKEjEg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@polymer/gen-typescript-declarations": "^1.5.1",
     "@polymer/iron-component-page": "^3.0.0-pre.12",
     "@polymer/test-fixture": "^3.0.0-pre.12",
-    "@webcomponents/webcomponentsjs": "^2.2.10",
+    "@webcomponents/webcomponentsjs": "^2.4.0",
     "babel-eslint": "^7.2.3",
     "babel-preset-minify": "^0.2.0",
     "del": "^3.0.0",
@@ -65,7 +65,7 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "@webcomponents/shadycss": "^1.9.1"
+    "@webcomponents/shadycss": "^1.9.3"
   },
   "files": [
     "externs",


### PR DESCRIPTION
`base = class extends base {};` causes a type `declare class base extends base {}` to be emitted but this fails to verify in the next step. Also, I didn't want to ignore everything called `base` so I renamed it.