### PR TITLE
Adds `legacyNoAttributes` setting

### DIFF
--- a/externs/webcomponents-externs.js
+++ b/externs/webcomponents-externs.js
@@ -12,42 +12,48 @@
  */
 /* eslint-disable */
 
-var HTMLImports = {
-  /**
-   * @param {function()} callback
-   */
-  whenReady(callback) {},
-  /**
-   * @param {!Node} element
-   * @return {?HTMLLinkElement|?Document|undefined}
-   */
-  importForElement(element) {}
-};
+var HTMLImports = {};
+
+/**
+ * @param {function()} callback
+ */
+HTMLImports.whenReady = function(callback) {};
+
+/**
+ * @param {!Node} element
+ * @return {?HTMLLinkElement|?Document|undefined}
+ */
+HTMLImports.importForElement = function(element) {};
 
 window.HTMLImports = HTMLImports;
 
-var ShadyDOM = {
-  inUse: false,
-  flush() {},
-  /**
-   * @param {!Node} target
-   * @param {function(Array<MutationRecord>, MutationObserver)} callback
-   * @return {MutationObserver}
-   */
-  observeChildren(target, callback) {},
-  /**
-   * @param {MutationObserver} observer
-   */
-  unobserveChildren(observer) {},
-  /**
-   * @param {Node} node
-   */
-  patch(node) {},
-  /**
-   * @param {!ShadowRoot} shadowroot
-   */
-  flushInitial(shadowroot) {}
-};
+var ShadyDOM = {};
+
+ShadyDOM.inUse;
+
+ShadyDOM.flush = function() {};
+
+/**
+ * @param {!Node} target
+ * @param {function(Array<MutationRecord>, MutationObserver)} callback
+ * @return {MutationObserver}
+ */
+ShadyDOM.observeChildren = function(target, callback) {};
+
+/**
+ * @param {MutationObserver} observer
+ */
+ShadyDOM.unobserveChildren = function(observer) {};
+
+/**
+ * @param {Node} node
+ */
+ShadyDOM.patch = function(node) {};
+
+/**
+ * @param {!ShadowRoot} shadowroot
+ */
+ShadyDOM.flushInitial = function(shadowroot) {};
 
 window.ShadyDOM = ShadyDOM;
 

--- a/externs/webcomponents-externs.js
+++ b/externs/webcomponents-externs.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Externs for webcomponents polyfills
  * @externs
+ * @suppress {duplicate}
  *
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -15,11 +16,12 @@
 var HTMLImports = {};
 
 /**
- * @param {function()} callback
+ * @param {function()=} callback
  */
 HTMLImports.whenReady = function(callback) {};
 
 /**
+ * Returns the import document containing the element.
  * @param {!Node} element
  * @return {?HTMLLinkElement|?Document|undefined}
  */

--- a/externs/webcomponents-externs.js
+++ b/externs/webcomponents-externs.js
@@ -66,3 +66,8 @@ HTMLTemplateElement.decorate = function(template){};
  * @param {function(function())} cb callback
  */
 CustomElementRegistry.prototype.polyfillWrapFlushCallback = function(cb){};
+
+/**
+ * @param {string} cssText
+ */
+CSSStyleSheet.prototype.replaceSync = function(cssText) {};

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -291,7 +291,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
         const a = this.attributes;
         for (let i=0, l=a.length; i < l; i++) {
           const attr = a[i];
-          this.__attributeReaction(attr.name, undefined, attr.value);
+          this.__attributeReaction(attr.name, null, attr.value);
         }
       }
       super.created();
@@ -309,6 +309,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    /** @override */
     setAttribute(name, value) {
       if (legacyNoObservedAttributes) {
         const oldValue = this.getAttribute(name);
@@ -319,6 +320,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    /** @override */
     removeAttribute(name) {
       if (legacyNoObservedAttributes) {
         const oldValue = this.getAttribute(name);
@@ -472,6 +474,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
     }
 
     // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+    /** @override */
     static get observedAttributes() {
       return legacyNoObservedAttributes ? [] :
         observedAttributesGetter.call(this).concat(DISABLED_ATTR);

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -10,10 +10,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import { LegacyElementMixin } from './legacy-element-mixin.js';
 import { legacyOptimizations, legacyNoObservedAttributes } from '../utils/settings.js';
+import { findObservedAttributesGetter } from '../mixins/disable-upgrade-mixin.js';
 import { wrap } from '../utils/wrap.js';
 
 const DISABLED_ATTR = 'disable-upgrade';
-let observedAttributesGetter;
 
 const lifecycleProps = {
   attached: true,
@@ -179,6 +179,9 @@ function mergeProperties(target, source) {
   }
 }
 
+const LegacyElement = LegacyElementMixin(HTMLElement);
+const observedAttributesGetter = findObservedAttributesGetter(LegacyElement);
+
 /* Note about construction and extension of legacy classes.
   [Changed in Q4 2018 to optimize performance.]
 
@@ -210,22 +213,6 @@ function mergeProperties(target, source) {
  * @private
  */
 function GenerateClassFromInfo(info, Base, behaviors) {
-
-  // Work around for closure bug #126934458. Using `super` in a property
-  // getter does not work so instead we search the Base prototype for an
-  // implementation of observedAttributes so that we can override and call
-  // the `super` getter. Note, this is done one time ever because we assume
-  // that `Base` is always comes from `Polymer.LegacyElementMixn`.
-  if (!observedAttributesGetter) {
-    let ctor = Base;
-    while (ctor && !observedAttributesGetter) {
-      const desc = Object.getOwnPropertyDescriptor(ctor, 'observedAttributes');
-      if (desc) {
-        observedAttributesGetter = desc.get;
-      }
-      ctor = Object.getPrototypeOf(ctor.prototype).constructor;
-    }
-  }
 
   // manages behavior and lifecycle processing (filled in after class definition)
   let behaviorList;
@@ -477,20 +464,20 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
-    // NOTE: Below is an inlined version of DisableUpgradeMixin. It is inlined
-    // as a performance optimization to avoid the need to place the mixin on
-    // top of every legacy element.
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     constructor() {
       super();
       /** @type {boolean|undefined} */
       this.__isUpgradeDisabled;
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     static get observedAttributes() {
       return legacyNoObservedAttributes ? [] :
         observedAttributesGetter.call(this).concat(DISABLED_ATTR);
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     // Prevent element from initializing properties when it's upgrade disabled.
     /** @override */
     _initializeProperties() {
@@ -501,6 +488,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     // Prevent element from enabling properties when it's upgrade disabled.
     // Normally overriding connectedCallback would be enough, but dom-* elements
     /** @override */
@@ -510,6 +498,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     // If the element starts upgrade-disabled and a property is set for
     // which an accessor exists, the default should not be applied.
     // This additional check is needed because defaults are applied via
@@ -521,6 +510,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
         !(this.__isUpgradeDisabled && this._isPropertyPending(property));
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     /**
      * @override
      * @param {string} name Attribute name.
@@ -546,6 +536,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     // Prevent element from connecting when it's upgrade disabled.
     // This prevents user code in `attached` from being called.
     /** @override */
@@ -555,6 +546,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     // Prevent element from disconnecting when it's upgrade disabled.
     // This avoids allowing user code `detached` from being called without a
     // paired call to `attached`.
@@ -598,8 +590,6 @@ function GenerateClassFromInfo(info, Base, behaviors) {
 
   return PolymerGenerated;
 }
-
-const LegacyElement = LegacyElementMixin(HTMLElement);
 
 /**
  * Generates a class that extends `LegacyElement` based on the

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -9,11 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { LegacyElementMixin } from './legacy-element-mixin.js';
-import { legacyOptimizations, legacyNoObservedAttributes } from '../utils/settings.js';
-import { findObservedAttributesGetter } from '../mixins/disable-upgrade-mixin.js';
-import { wrap } from '../utils/wrap.js';
-
-const DISABLED_ATTR = 'disable-upgrade';
+import { legacyOptimizations } from '../utils/settings.js';
 
 const lifecycleProps = {
   attached: true,
@@ -180,7 +176,6 @@ function mergeProperties(target, source) {
 }
 
 const LegacyElement = LegacyElementMixin(HTMLElement);
-const observedAttributesGetter = findObservedAttributesGetter(LegacyElement);
 
 /* Note about construction and extension of legacy classes.
   [Changed in Q4 2018 to optimize performance.]
@@ -286,56 +281,12 @@ function GenerateClassFromInfo(info, Base, behaviors) {
      * @return {void}
      */
     created() {
-      // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
-      if (legacyNoObservedAttributes && this.hasAttributes()) {
-        const a = this.attributes;
-        for (let i=0, l=a.length; i < l; i++) {
-          const attr = a[i];
-          this.__attributeReaction(attr.name, null, attr.value);
-        }
-      }
       super.created();
       const list = lifecycle.created;
       if (list) {
         for (let i=0; i < list.length; i++) {
           list[i].call(this);
         }
-      }
-    }
-
-    /**
-     * Processes an attribute reaction when the `legacyNoObservedAttributes`
-     * setting is in use.
-     * @param {string} name Name of attribute that changed
-     * @param {?string} old Old attribute value
-     * @param {?string} value New attribute value
-     * @return {void}
-     */
-    __attributeReaction(name, old, value) {
-      if ((this.__dataAttributes && this.__dataAttributes[name]) || name === DISABLED_ATTR) {
-        this.attributeChangedCallback(name, old, value);
-      }
-    }
-
-    /** @override */
-    setAttribute(name, value) {
-      if (legacyNoObservedAttributes) {
-        const oldValue = this.getAttribute(name);
-        super.setAttribute(name, value);
-        this.__attributeReaction(name, oldValue, value);
-      } else {
-        super.setAttribute(name, value);
-      }
-    }
-
-    /** @override */
-    removeAttribute(name) {
-      if (legacyNoObservedAttributes) {
-        const oldValue = this.getAttribute(name);
-        super.removeAttribute(name);
-        this.__attributeReaction(name, oldValue, null);
-      } else {
-        super.removeAttribute(name);
       }
     }
 
@@ -473,101 +424,6 @@ function GenerateClassFromInfo(info, Base, behaviors) {
         }
       }
     }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    constructor() {
-      super();
-      /** @type {boolean|undefined} */
-      this.__isUpgradeDisabled;
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    /** @override */
-    static get observedAttributes() {
-      return legacyNoObservedAttributes ? [] :
-        observedAttributesGetter.call(this).concat(DISABLED_ATTR);
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    // Prevent element from initializing properties when it's upgrade disabled.
-    /** @override */
-    _initializeProperties() {
-      if (this.hasAttribute(DISABLED_ATTR)) {
-        this.__isUpgradeDisabled = true;
-      } else {
-        super._initializeProperties();
-      }
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    // Prevent element from enabling properties when it's upgrade disabled.
-    // Normally overriding connectedCallback would be enough, but dom-* elements
-    /** @override */
-    _enableProperties() {
-      if (!this.__isUpgradeDisabled) {
-        super._enableProperties();
-      }
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    // If the element starts upgrade-disabled and a property is set for
-    // which an accessor exists, the default should not be applied.
-    // This additional check is needed because defaults are applied via
-    // `_initializeProperties` which is called after initial properties
-    // have been set when the element starts upgrade-disabled.
-    /** @override */
-    _canApplyPropertyDefault(property) {
-      return super._canApplyPropertyDefault(property) &&
-        !(this.__isUpgradeDisabled && this._isPropertyPending(property));
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    /**
-     * @override
-     * @param {string} name Attribute name.
-     * @param {?string} old The previous value for the attribute.
-     * @param {?string} value The new value for the attribute.
-     * @param {?string} namespace The XML namespace for the attribute.
-     * @return {void}
-     */
-    attributeChangedCallback(name, old, value, namespace) {
-      if (name == DISABLED_ATTR) {
-        // When disable-upgrade is removed, intialize properties and
-        // provoke connectedCallback if the element is already connected.
-        if (this.__isUpgradeDisabled && value == null) {
-          super._initializeProperties();
-          this.__isUpgradeDisabled = false;
-          if (wrap(this).isConnected) {
-            super.connectedCallback();
-          }
-        }
-      } else {
-        super.attributeChangedCallback(
-            name, old, value, /** @type {null|string} */ (namespace));
-      }
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    // Prevent element from connecting when it's upgrade disabled.
-    // This prevents user code in `attached` from being called.
-    /** @override */
-    connectedCallback() {
-      if (!this.__isUpgradeDisabled) {
-        super.connectedCallback();
-      }
-    }
-
-    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-    // Prevent element from disconnecting when it's upgrade disabled.
-    // This avoids allowing user code `detached` from being called without a
-    // paired call to `attached`.
-    /** @override */
-    disconnectedCallback() {
-      if (!this.__isUpgradeDisabled) {
-        super.disconnectedCallback();
-      }
-    }
-
   }
 
   // apply behaviors, note actual copying is done lazily at first instance creation

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -303,9 +303,17 @@ function GenerateClassFromInfo(info, Base, behaviors) {
       }
     }
 
-    __attributeReaction(name, oldValue, value) {
+    /**
+     * Processes an attribute reaction when the `legacyNoObservedAttributes`
+     * setting is in use.
+     * @param {string} name Name of attribute that changed
+     * @param {?string} old Old attribute value
+     * @param {?string} value New attribute value
+     * @return {void}
+     */
+    __attributeReaction(name, old, value) {
       if ((this.__dataAttributes && this.__dataAttributes[name]) || name === DISABLED_ATTR) {
-        this.attributeChangedCallback(name, oldValue, value);
+        this.attributeChangedCallback(name, old, value);
       }
     }
 

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -9,8 +9,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { LegacyElementMixin } from './legacy-element-mixin.js';
-import { legacyOptimizations } from '../utils/settings.js';
-import { DisableUpgradeMixin } from '../mixins/disable-upgrade-mixin.js';
+import { legacyOptimizations, legacyNoObservedAttributes } from '../utils/settings.js';
+import { wrap } from '../utils/wrap.js';
+
+const DISABLED_ATTR = 'disable-upgrade';
+let observedAttributesGetter;
 
 const lifecycleProps = {
   attached: true,
@@ -208,6 +211,22 @@ function mergeProperties(target, source) {
  */
 function GenerateClassFromInfo(info, Base, behaviors) {
 
+  // Work around for closure bug #126934458. Using `super` in a property
+  // getter does not work so instead we search the Base prototype for an
+  // implementation of observedAttributes so that we can override and call
+  // the `super` getter. Note, this is done one time ever because we assume
+  // that `Base` is always comes from `Polymer.LegacyElementMixn`.
+  if (!observedAttributesGetter) {
+    let ctor = Base;
+    while (ctor && !observedAttributesGetter) {
+      const desc = Object.getOwnPropertyDescriptor(ctor, 'observedAttributes');
+      if (desc) {
+        observedAttributesGetter = desc.get;
+      }
+      ctor = Object.getPrototypeOf(ctor.prototype).constructor;
+    }
+  }
+
   // manages behavior and lifecycle processing (filled in after class definition)
   let behaviorList;
   const lifecycle = {};
@@ -280,12 +299,46 @@ function GenerateClassFromInfo(info, Base, behaviors) {
      * @return {void}
      */
     created() {
+      // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
+      if (legacyNoObservedAttributes && this.hasAttributes()) {
+        const a = this.attributes;
+        for (let i=0, l=a.length; i < l; i++) {
+          const attr = a[i];
+          this.__attributeReaction(attr.name, undefined, attr.value)
+        }
+      }
       super.created();
       const list = lifecycle.created;
       if (list) {
         for (let i=0; i < list.length; i++) {
           list[i].call(this);
         }
+      }
+    }
+
+    __attributeReaction(name, oldValue, value) {
+      if ((this.__dataAttributes && this.__dataAttributes[name]) || name === DISABLED_ATTR) {
+        this.attributeChangedCallback(name, oldValue, value);
+      }
+    }
+
+    setAttribute(name, value) {
+      if (legacyNoObservedAttributes) {
+        const oldValue = this.getAttribute(name);
+        super.setAttribute(name, value);
+        this.__attributeReaction(name, oldValue, value);
+      } else {
+        super.setAttribute(name, value);
+      }
+    }
+
+    removeAttribute(name) {
+      if (legacyNoObservedAttributes) {
+        const oldValue = this.getAttribute(name);
+        super.removeAttribute(name);
+        this.__attributeReaction(name, oldValue, null);
+      } else {
+        super.removeAttribute(name);
       }
     }
 
@@ -423,6 +476,95 @@ function GenerateClassFromInfo(info, Base, behaviors) {
         }
       }
     }
+
+    // NOTE: Below is an inlined version of DisableUpgradeMixin. It is inlined
+    // as a performance optimization to avoid the need to place the mixin on
+    // top of every legacy element.
+    constructor() {
+      super();
+      /** @type {boolean|undefined} */
+      this.__isUpgradeDisabled;
+    }
+
+    static get observedAttributes() {
+      return legacyNoObservedAttributes ? [] :
+        observedAttributesGetter.call(this).concat(DISABLED_ATTR);
+    }
+
+    // Prevent element from initializing properties when it's upgrade disabled.
+    /** @override */
+    _initializeProperties() {
+      if (this.hasAttribute(DISABLED_ATTR)) {
+        this.__isUpgradeDisabled = true;
+      } else {
+        super._initializeProperties();
+      }
+    }
+
+    // Prevent element from enabling properties when it's upgrade disabled.
+    // Normally overriding connectedCallback would be enough, but dom-* elements
+    /** @override */
+    _enableProperties() {
+      if (!this.__isUpgradeDisabled) {
+        super._enableProperties();
+      }
+    }
+
+    // If the element starts upgrade-disabled and a property is set for
+    // which an accessor exists, the default should not be applied.
+    // This additional check is needed because defaults are applied via
+    // `_initializeProperties` which is called after initial properties
+    // have been set when the element starts upgrade-disabled.
+    /** @override */
+    _canApplyPropertyDefault(property) {
+      return super._canApplyPropertyDefault(property) &&
+        !(this.__isUpgradeDisabled && this._isPropertyPending(property));
+    }
+
+    /**
+     * @override
+     * @param {string} name Attribute name.
+     * @param {?string} old The previous value for the attribute.
+     * @param {?string} value The new value for the attribute.
+     * @param {?string} namespace The XML namespace for the attribute.
+     * @return {void}
+     */
+    attributeChangedCallback(name, old, value, namespace) {
+      if (name == DISABLED_ATTR) {
+        // When disable-upgrade is removed, intialize properties and
+        // provoke connectedCallback if the element is already connected.
+        if (this.__isUpgradeDisabled && value == null) {
+          super._initializeProperties();
+          this.__isUpgradeDisabled = false;
+          if (wrap(this).isConnected) {
+            super.connectedCallback();
+          }
+        }
+      } else {
+        super.attributeChangedCallback(
+            name, old, value, /** @type {null|string} */ (namespace));
+      }
+    }
+
+    // Prevent element from connecting when it's upgrade disabled.
+    // This prevents user code in `attached` from being called.
+    /** @override */
+    connectedCallback() {
+      if (!this.__isUpgradeDisabled) {
+        super.connectedCallback();
+      }
+    }
+
+    // Prevent element from disconnecting when it's upgrade disabled.
+    // This avoids allowing user code `detached` from being called without a
+    // paired call to `attached`.
+    /** @override */
+    disconnectedCallback() {
+      if (!this.__isUpgradeDisabled) {
+        super.disconnectedCallback();
+      }
+    }
+
   }
 
   // apply behaviors, note actual copying is done lazily at first instance creation
@@ -456,6 +598,8 @@ function GenerateClassFromInfo(info, Base, behaviors) {
 
   return PolymerGenerated;
 }
+
+const LegacyElement = LegacyElementMixin(HTMLElement);
 
 /**
  * Generates a class that extends `LegacyElement` based on the
@@ -531,13 +675,10 @@ export const Class = function(info, mixin) {
   if (!info) {
     console.warn('Polymer.Class requires `info` argument');
   }
-  let klass = mixin ? mixin(LegacyElementMixin(HTMLElement)) :
-      LegacyElementMixin(HTMLElement);
+  let klass = mixin ? mixin(LegacyElement) :
+      LegacyElement;
   klass = GenerateClassFromInfo(info, klass, info.behaviors);
   // decorate klass with registration info
   klass.is = klass.prototype.is = info.is;
-  if (legacyOptimizations) {
-    klass = DisableUpgradeMixin(klass);
-  }
   return klass;
 };

--- a/lib/legacy/class.js
+++ b/lib/legacy/class.js
@@ -304,7 +304,7 @@ function GenerateClassFromInfo(info, Base, behaviors) {
         const a = this.attributes;
         for (let i=0, l=a.length; i < l; i++) {
           const attr = a[i];
-          this.__attributeReaction(attr.name, undefined, attr.value)
+          this.__attributeReaction(attr.name, undefined, attr.value);
         }
       }
       super.created();

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -122,16 +122,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @override
      * @return {void}
      */
-    created() {
-      // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
-      if (legacyNoObservedAttributes && this.hasAttributes()) {
-        const a = this.attributes;
-        for (let i=0, l=a.length; i < l; i++) {
-          const attr = a[i];
-          this.__attributeReaction(attr.name, null, attr.value);
-        }
-      }
-    }
+    created() {}
 
     /**
      * Processes an attribute reaction when the `legacyNoObservedAttributes`
@@ -310,6 +301,14 @@ export const LegacyElementMixin = dedupingMixin((base) => {
         super._initializeProperties();
         this.root = /** @type {HTMLElement} */(this);
         this.created();
+        // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
+        if (legacyNoObservedAttributes && this.hasAttributes()) {
+          const a = this.attributes;
+          for (let i=0, l=a.length; i < l; i++) {
+            const attr = a[i];
+            this.__attributeReaction(attr.name, null, attr.value);
+          }
+        }
         // Ensure listeners are applied immediately so that they are
         // added before declarative event listeners. This allows an element to
         // decorate itself via an event prior to any declarative listeners

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -21,6 +21,10 @@ import { timeOut, microTask } from '../utils/async.js';
 import { get } from '../utils/path.js';
 import { wrap } from '../utils/wrap.js';
 import { scopeSubtree } from '../utils/scope-subtree.js';
+import { legacyNoObservedAttributes } from '../utils/settings.js';
+import { findObservedAttributesGetter } from '../mixins/disable-upgrade-mixin.js';
+
+const DISABLED_ATTR = 'disable-upgrade';
 
 let styleInterface = window.ShadyCSS;
 
@@ -64,6 +68,8 @@ export const LegacyElementMixin = dedupingMixin((base) => {
   const legacyElementBase = builtCSS ? GesturesElement :
     DirMixin(GesturesElement);
 
+  const observedAttributesGetter = findObservedAttributesGetter(legacyElementBase);
+
   /**
    * Map of simple names to touch action names
    * @dict
@@ -92,6 +98,9 @@ export const LegacyElementMixin = dedupingMixin((base) => {
       this.__boundListeners;
       /** @type {?Object<string, ?Function>} */
       this._debouncers;
+      // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+      /** @type {boolean|undefined} */
+      this.__isUpgradeDisabled;
     }
 
     /**
@@ -113,7 +122,82 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @override
      * @return {void}
      */
-    created() {}
+    created() {
+      // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
+      if (legacyNoObservedAttributes && this.hasAttributes()) {
+        const a = this.attributes;
+        for (let i=0, l=a.length; i < l; i++) {
+          const attr = a[i];
+          this.__attributeReaction(attr.name, null, attr.value);
+        }
+      }
+    }
+
+    /**
+     * Processes an attribute reaction when the `legacyNoObservedAttributes`
+     * setting is in use.
+     * @param {string} name Name of attribute that changed
+     * @param {?string} old Old attribute value
+     * @param {?string} value New attribute value
+     * @return {void}
+     */
+    __attributeReaction(name, old, value) {
+      if ((this.__dataAttributes && this.__dataAttributes[name]) || name === DISABLED_ATTR) {
+        this.attributeChangedCallback(name, old, value, null);
+      }
+    }
+
+    /** @override */
+    setAttribute(name, value) {
+      if (legacyNoObservedAttributes) {
+        const oldValue = this.getAttribute(name);
+        super.setAttribute(name, value);
+        // value coerced to String for closure's benefit
+        this.__attributeReaction(name, oldValue, String(value));
+      } else {
+        super.setAttribute(name, value);
+      }
+    }
+
+    /** @override */
+    removeAttribute(name) {
+      if (legacyNoObservedAttributes) {
+        const oldValue = this.getAttribute(name);
+        super.removeAttribute(name);
+        this.__attributeReaction(name, oldValue, null);
+      } else {
+        super.removeAttribute(name);
+      }
+    }
+
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+    /** @override */
+    static get observedAttributes() {
+      return legacyNoObservedAttributes ? [] :
+        observedAttributesGetter.call(this).concat(DISABLED_ATTR);
+    }
+
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+    // Prevent element from enabling properties when it's upgrade disabled.
+    // Normally overriding connectedCallback would be enough, but dom-* elements
+    /** @override */
+    _enableProperties() {
+      if (!this.__isUpgradeDisabled) {
+        super._enableProperties();
+      }
+    }
+
+    // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+    // If the element starts upgrade-disabled and a property is set for
+    // which an accessor exists, the default should not be applied.
+    // This additional check is needed because defaults are applied via
+    // `_initializeProperties` which is called after initial properties
+    // have been set when the element starts upgrade-disabled.
+    /** @override */
+    _canApplyPropertyDefault(property) {
+      return super._canApplyPropertyDefault(property) &&
+        !(this.__isUpgradeDisabled && this._isPropertyPending(property));
+    }
 
     /**
      * Provides an implementation of `connectedCallback`
@@ -122,9 +206,12 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @override
      */
     connectedCallback() {
-      super.connectedCallback();
-      this.isAttached = true;
-      this.attached();
+      // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+      if (!this.__isUpgradeDisabled) {
+        super.connectedCallback();
+        this.isAttached = true;
+        this.attached();
+      }
     }
 
     /**
@@ -142,9 +229,12 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @override
      */
     disconnectedCallback() {
-      super.disconnectedCallback();
-      this.isAttached = false;
-      this.detached();
+      // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+      if (!this.__isUpgradeDisabled) {
+        super.disconnectedCallback();
+        this.isAttached = false;
+        this.detached();
+      }
     }
 
     /**
@@ -167,8 +257,21 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      */
     attributeChangedCallback(name, old, value, namespace) {
       if (old !== value) {
-        super.attributeChangedCallback(name, old, value, namespace);
-        this.attributeChanged(name, old, value);
+        // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+        if (name == DISABLED_ATTR) {
+          // When disable-upgrade is removed, intialize properties and
+          // provoke connectedCallback if the element is already connected.
+          if (this.__isUpgradeDisabled && value == null) {
+            this._initializeProperties();
+            this.__isUpgradeDisabled = false;
+            if (wrap(this).isConnected) {
+              this.connectedCallback();
+            }
+          }
+        } else {
+          super.attributeChangedCallback(name, old, value, namespace);
+          this.attributeChanged(name, old, value);
+        }
       }
     }
 
@@ -193,20 +296,25 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      * @suppress {invalidCasts}
      */
     _initializeProperties() {
-      let proto = Object.getPrototypeOf(this);
-      if (!proto.hasOwnProperty(JSCompiler_renameProperty('__hasRegisterFinished', proto))) {
-        this._registered();
-        // backstop in case the `_registered` implementation does not set this
-        proto.__hasRegisterFinished = true;
+      // NOTE: Inlined for perf from version of DisableUpgradeMixin.
+      if (this.hasAttribute(DISABLED_ATTR)) {
+        this.__isUpgradeDisabled = true;
+      } else {
+        let proto = Object.getPrototypeOf(this);
+        if (!proto.hasOwnProperty(JSCompiler_renameProperty('__hasRegisterFinished', proto))) {
+          this._registered();
+          // backstop in case the `_registered` implementation does not set this
+          proto.__hasRegisterFinished = true;
+        }
+        super._initializeProperties();
+        this.root = /** @type {HTMLElement} */(this);
+        this.created();
+        // Ensure listeners are applied immediately so that they are
+        // added before declarative event listeners. This allows an element to
+        // decorate itself via an event prior to any declarative listeners
+        // seeing the event. Note, this ensures compatibility with 1.x ordering.
+        this._applyListeners();
       }
-      super._initializeProperties();
-      this.root = /** @type {HTMLElement} */(this);
-      this.created();
-      // Ensure listeners are applied immediately so that they are
-      // added before declarative event listeners. This allows an element to
-      // decorate itself via an event prior to any declarative listeners
-      // seeing the event. Note, this ensures compatibility with 1.x ordering.
-      this._applyListeners();
     }
 
     /**

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -21,7 +21,7 @@ import { timeOut, microTask } from '../utils/async.js';
 import { get } from '../utils/path.js';
 import { wrap } from '../utils/wrap.js';
 import { scopeSubtree } from '../utils/scope-subtree.js';
-import { legacyNoObservedAttributes } from '../utils/settings.js';
+import { legacyOptimizations, legacyNoObservedAttributes } from '../utils/settings.js';
 import { findObservedAttributesGetter } from '../mixins/disable-upgrade-mixin.js';
 
 const DISABLED_ATTR = 'disable-upgrade';
@@ -297,7 +297,8 @@ export const LegacyElementMixin = dedupingMixin((base) => {
      */
     _initializeProperties() {
       // NOTE: Inlined for perf from version of DisableUpgradeMixin.
-      if (this.hasAttribute(DISABLED_ATTR)) {
+      // Only auto-use disable-upgrade if legacyOptimizations is set.
+      if (legacyOptimizations && this.hasAttribute(DISABLED_ATTR)) {
         this.__isUpgradeDisabled = true;
       } else {
         let proto = Object.getPrototypeOf(this);

--- a/lib/mixins/disable-upgrade-mixin.js
+++ b/lib/mixins/disable-upgrade-mixin.js
@@ -15,7 +15,16 @@ import { wrap } from '../utils/wrap.js';
 
 const DISABLED_ATTR = 'disable-upgrade';
 
-let observedAttributesGetter;
+export const findObservedAttributesGetter = (ctor) => {
+  while (ctor) {
+    const desc = Object.getOwnPropertyDescriptor(ctor, 'observedAttributes');
+    if (desc) {
+      return desc.get;
+    }
+    ctor = Object.getPrototypeOf(ctor.prototype).constructor;
+  }
+  return () => [];
+};
 
 /**
  * Element class mixin that allows the element to boot up in a non-enabled
@@ -58,16 +67,7 @@ export const DisableUpgradeMixin = dedupingMixin((base) => {
   // implementation of observedAttributes so that we can override and call
   // the `super` getter. Note, this is done one time ever because we assume
   // that `Base` is always comes from `Polymer.LegacyElementMixn`.
-  if (!observedAttributesGetter) {
-    let ctor = superClass;
-    while (ctor && !observedAttributesGetter) {
-      const desc = Object.getOwnPropertyDescriptor(ctor, 'observedAttributes');
-      if (desc) {
-        observedAttributesGetter = desc.get;
-      }
-      ctor = Object.getPrototypeOf(ctor.prototype).constructor;
-    }
-  }
+  let observedAttributesGetter = findObservedAttributesGetter(superClass);
 
   /**
    * @polymer

--- a/lib/utils/mixin.js
+++ b/lib/utils/mixin.js
@@ -52,13 +52,13 @@ export const dedupingMixin = function(mixin) {
     if (!extended) {
       extended = /** @type {!Function} */(mixin)(base);
       map.set(base, extended);
+      // copy inherited mixin set from the extended class, or the base class
+      // NOTE: we avoid use of Set here because some browser (IE11)
+      // cannot extend a base Set via the constructor.
+      let mixinSet = Object.create(/** @type {!MixinFunction} */(extended).__mixinSet || baseSet || null);
+      mixinSet[mixinDedupeId] = true;
+      /** @type {!MixinFunction} */(extended).__mixinSet = mixinSet;
     }
-    // copy inherited mixin set from the extended class, or the base class
-    // NOTE: we avoid use of Set here because some browser (IE11)
-    // cannot extend a base Set via the constructor.
-    let mixinSet = Object.create(/** @type {!MixinFunction} */(extended).__mixinSet || baseSet || null);
-    mixinSet[mixinDedupeId] = true;
-    /** @type {!MixinFunction} */(extended).__mixinSet = mixinSet;
     return extended;
   }
 

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -312,3 +312,21 @@ export let suppressTemplateNotifications =
 export const setSuppressTemplateNotifications = function(suppress) {
   suppressTemplateNotifications = suppress;
 };
+
+/**
+ * Setting to disable use of dynamic attributes. This is an optimization
+ * to avoid setting `observedAttributes`. Instead attributes are read
+ * once at create time.
+ */
+export let legacyNoObservedAttributes =
+  window.Polymer && window.Polymer.legacyNoObservedAttributes || false;
+
+/**
+ * Sets `legacyNoObservedAttributes` globally, to disable `observedAttributes`.
+ *
+ * @param {boolean} disables `observedAttributes`
+ * @return {void}
+ */
+export const setLegacyNoObservedAttributes = function(noAttributes) {
+  legacyNoObservedAttributes = noAttributes;
+};

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -316,7 +316,7 @@ export const setSuppressTemplateNotifications = function(suppress) {
 /**
  * Setting to disable use of dynamic attributes. This is an optimization
  * to avoid setting `observedAttributes`. Instead attributes are read
- * once at create time.
+ * once at create time and set/removeAttribute are patched.
  */
 export let legacyNoObservedAttributes =
   window.Polymer && window.Polymer.legacyNoObservedAttributes || false;
@@ -324,9 +324,9 @@ export let legacyNoObservedAttributes =
 /**
  * Sets `legacyNoObservedAttributes` globally, to disable `observedAttributes`.
  *
- * @param {boolean} disables `observedAttributes`
+ * @param {boolean} noObservedAttributes enable or disable `legacyNoObservedAttributes`
  * @return {void}
  */
-export const setLegacyNoObservedAttributes = function(noAttributes) {
-  legacyNoObservedAttributes = noAttributes;
+export const setLegacyNoObservedAttributes = function(noObservedAttributes) {
+  legacyNoObservedAttributes = noObservedAttributes;
 };

--- a/test/runner.html
+++ b/test/runner.html
@@ -96,6 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'unit/html-tag.html',
       'unit/legacy-data.html',
       'unit/legacy-undefined.html',
+      'unit/legacy-noattributes.html',
       // 'unit/multi-style.html'
       'unit/class-properties.html',
       'unit/styling-scoped-nopatch.html'

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -15,8 +15,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="wct-browser-config.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script type="module">
-    import {setLegacyNoObservedAttributes} from '../../lib/utils/settings.js';
+    import {setLegacyNoObservedAttributes, setLegacyOptimizations} from '../../lib/utils/settings.js';
     setLegacyNoObservedAttributes(true);
+    setLegacyOptimizations(true);
   </script>
 </head>
 <body>

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -77,8 +77,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     import {flush} from '../../lib/utils/flush.js';
     import {wrap} from '../../lib/utils/wrap.js';
 
-    let el = window.configured;
-
     suite('legacyNoObservedAttributes', () => {
 
       let el;

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -32,7 +32,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         properties: {
           foo: {type: String, value: 'default'},
           bar: {type: String, value: 'default'},
-          zot: {type: Boolean, value: false, reflectToAttribute: true}
+          zot: {type: Boolean, value: false, reflectToAttribute: true},
+          camelCase: String
         },
         ready() {
           this.isEnabled = true;
@@ -43,12 +44,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <dom-module id="x-attrs">
     <template>
-      <x-child id="child1" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]"></x-child>
-      <x-child id="child2" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" disable-upgrade></x-child>
-      <x-child id="child3" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" disable-upgrade$="[[disabled]]"></x-child>
+      <x-child id="child1" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" camel-case="camelCase"></x-child>
+      <x-child id="child2" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" camel-case="[[camelCase]]" disable-upgrade></x-child>
+      <x-child id="child3" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" camel-case="[[camelCase]]" disable-upgrade$="[[disabled]]"></x-child>
       <div id="ifContainer">
         <dom-if if="[[shouldIf]]">
-          <template><x-child foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]"></x-child></template>
+          <template><x-child foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" camel-case="[[camelCase]]"></x-child></template>
         </dom-if>
       </div>
     </template>
@@ -61,6 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           bar: {type: String, value: 'bar'},
           zot: Boolean,
           shouldIf: Boolean,
+          camelCase: String,
           disabled: {type: Boolean, value: 'true'}
         }
       });
@@ -69,7 +71,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="declarative">
     <template>
-      <x-attrs id="configured" foo="foo" bar="bar"></x-attrs>
+      <x-attrs id="configured" foo="foo" bar="bar" camel-case="camelCase"></x-attrs>
     </template>
   </test-fixture>
 
@@ -89,6 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.$.child1.getAttribute('foo'), 'x-attrs.foo');
         assert.equal(el.$.child1.foo, "x-attrs.foo");
         assert.equal(el.$.child1.$.content.textContent, 'x-attrs.foo');
+        assert.equal(el.camelCase, 'camelCase');
       });
 
       test('static attribute bindings', () => {
@@ -96,6 +99,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.$.child1.bar, 'bar');
         assert.equal(el.$.child1.getAttribute('zot'), null);
         assert.equal(el.$.child1.zot, false);
+        assert.equal(el.$.child1.camelCase, 'camelCase');
       });
 
       test('dynamic attribute bindings', () => {
@@ -114,6 +118,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(child.getAttribute('foo'), 'x-attrs.foo');
         assert.equal(child.foo, "x-attrs.foo");
         assert.equal(child.$.content.textContent, 'x-attrs.foo');
+        assert.equal(child.camelCase, 'camelCase');
         //
         assert.equal(child.getAttribute('bar'), 'bar');
         assert.equal(child.bar, 'bar');
@@ -132,12 +137,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.notOk(el.$.child2.isEnabled);
         el.$.child2.removeAttribute('disable-upgrade');
         assert.isTrue(el.$.child2.isEnabled);
+        assert.equal(el.$.child2.camelCase, 'camelCase');
       });
 
       test('disable-upgrade binding', () => {
         assert.notOk(el.$.child3.isEnabled);
         el.disabled = false;
         assert.isTrue(el.$.child3.isEnabled);
+        assert.equal(el.$.child3.camelCase, 'camelCase');
       });
 
 

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -64,6 +64,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           shouldIf: Boolean,
           camelCase: String,
           disabled: {type: Boolean, value: 'true'}
+        },
+        attributeChanged(name, old, value) {
+          this.attrInfo = {name, old, value};
         }
       });
     </script>
@@ -71,7 +74,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="declarative">
     <template>
-      <x-attrs id="configured" foo="foo" bar="bar" camel-case="camelCase"></x-attrs>
+      <x-attrs foo="foo" bar="bar" camel-case="camelCase"></x-attrs>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="one-attr">
+    <template>
+      <x-attrs foo="foo"></x-attrs>
     </template>
   </test-fixture>
 
@@ -93,6 +102,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.$.child1.$.content.textContent, 'x-attrs.foo');
         assert.equal(el.camelCase, 'camelCase');
       });
+
+      test('attributeChanged gets expected arguments', () => {
+        el = fixture('one-attr');
+        assert.deepEqual(el.attrInfo, {name: 'foo', old: null, value: 'foo'});
+        el.setAttribute('zot', '');
+        assert.deepEqual(el.attrInfo, {name: 'zot', old: null, value: ''});
+        el.setAttribute('zot', 'foo');
+        assert.deepEqual(el.attrInfo, {name: 'zot', old: '', value: 'foo'});
+        el.removeAttribute('zot', 'foo');
+        assert.deepEqual(el.attrInfo, {name: 'zot', old: 'foo', value: null});
+        el.setAttribute('zot', 'bar');
+        assert.deepEqual(el.attrInfo, {name: 'zot', old: null, value: 'bar'});
+        el.setAttribute('foo', 'foo2');
+        assert.deepEqual(el.attrInfo, {name: 'foo', old: 'foo', value: 'foo2'});
+      })
 
       test('static attribute bindings', () => {
         assert.equal(el.$.child1.getAttribute('bar'), 'bar');

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="wct-browser-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+  <script type="module">
+    import {setLegacyNoObservedAttributes} from '../../lib/utils/settings.js';
+    setLegacyNoObservedAttributes(true);
+  </script>
+</head>
+<body>
+
+  <dom-module id="x-child">
+    <template>
+      <div id="content">[[foo]]</div>
+    </template>
+    <script type="module">
+      import {Polymer} from '../../polymer-legacy.js';
+      Polymer({
+        is: 'x-child',
+        properties: {
+          foo: {type: String, value: 'default'},
+          bar: {type: String, value: 'default'},
+          zot: {type: Boolean, value: false, reflectToAttribute: true}
+        },
+        ready() {
+          this.isEnabled = true;
+        }
+      });
+    </script>
+  </dom-module>
+
+  <dom-module id="x-attrs">
+    <template>
+      <x-child id="child1" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]"></x-child>
+      <x-child id="child2" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" disable-upgrade></x-child>
+      <x-child id="child3" foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]" disable-upgrade$="[[disabled]]"></x-child>
+      <div id="ifContainer">
+        <dom-if if="[[shouldIf]]">
+          <template><x-child foo="x-attrs.foo" bar$="[[bar]]" zot$="[[zot]]"></x-child></template>
+        </dom-if>
+      </div>
+    </template>
+    <script type="module">
+      import {Polymer} from '../../polymer-legacy.js';
+      Polymer({
+        is: 'x-attrs',
+        properties: {
+          foo: String,
+          bar: {type: String, value: 'bar'},
+          zot: Boolean,
+          shouldIf: Boolean,
+          disabled: {type: Boolean, value: 'true'}
+        }
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="declarative">
+    <template>
+      <x-attrs id="configured" foo="foo" bar="bar"></x-attrs>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+    import {flush} from '../../lib/utils/flush.js';
+    import {wrap} from '../../lib/utils/wrap.js';
+
+    let el = window.configured;
+
+    suite('legacyNoObservedAttributes', () => {
+
+      let el;
+      setup(() => {
+        el = fixture('declarative');
+      });
+
+      test('static attributes', () => {
+        assert.equal(el.foo, 'foo');
+        assert.equal(el.$.child1.getAttribute('foo'), 'x-attrs.foo');
+        assert.equal(el.$.child1.foo, "x-attrs.foo");
+        assert.equal(el.$.child1.$.content.textContent, 'x-attrs.foo');
+      });
+
+      test('static attribute bindings', () => {
+        assert.equal(el.$.child1.getAttribute('bar'), 'bar');
+        assert.equal(el.$.child1.bar, 'bar');
+        assert.equal(el.$.child1.getAttribute('zot'), null);
+        assert.equal(el.$.child1.zot, false);
+      });
+
+      test('dynamic attribute bindings', () => {
+        el.bar = 'bar-modified';
+        assert.equal(el.$.child1.getAttribute('bar'), 'bar-modified');
+        assert.equal(el.$.child1.bar, 'bar-modified');
+        el.zot = true;
+        assert.equal(el.$.child1.getAttribute('zot'), '');
+        assert.equal(el.$.child1.zot, true);
+      });
+
+      test('attributes inside dom-if', () => {
+        el.shouldIf = true;
+        flush();
+        const child = wrap(el.$.ifContainer).querySelector('x-child');
+        assert.equal(child.getAttribute('foo'), 'x-attrs.foo');
+        assert.equal(child.foo, "x-attrs.foo");
+        assert.equal(child.$.content.textContent, 'x-attrs.foo');
+        //
+        assert.equal(child.getAttribute('bar'), 'bar');
+        assert.equal(child.bar, 'bar');
+        assert.equal(child.getAttribute('zot'), null);
+        assert.equal(child.zot, false);
+        //
+        el.bar = 'bar-modified';
+        assert.equal(child.getAttribute('bar'), 'bar-modified');
+        assert.equal(child.bar, 'bar-modified');
+        el.zot = true;
+        assert.equal(child.getAttribute('zot'), '');
+        assert.equal(child.zot, true);
+      });
+
+      test('disable-upgrade static', () => {
+        assert.notOk(el.$.child2.isEnabled);
+        el.$.child2.removeAttribute('disable-upgrade');
+        assert.isTrue(el.$.child2.isEnabled);
+      });
+
+      test('disable-upgrade binding', () => {
+        assert.notOk(el.$.child3.isEnabled);
+        el.disabled = false;
+        assert.isTrue(el.$.child3.isEnabled);
+      });
+
+
+    });
+
+  </script>
+</body>
+</html>

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -66,7 +66,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           camelCase: String,
           disabled: {type: Boolean, value: 'true'}
         },
+        created() {
+          this.wasCreated = true;
+        },
         attributeChanged(name, old, value) {
+          this.wasCreatedInAttributeChanged = this.wasCreated;
           this.attrInfo = {name, old, value};
         }
       });
@@ -102,6 +106,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(el.$.child1.foo, "x-attrs.foo");
         assert.equal(el.$.child1.$.content.textContent, 'x-attrs.foo');
         assert.equal(el.camelCase, 'camelCase');
+      });
+
+      test('created called before attributeChanged', () => {
+        assert.isTrue(el.wasCreatedInAttributeChanged);
       });
 
       test('attributeChanged gets expected arguments', () => {

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -116,7 +116,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.deepEqual(el.attrInfo, {name: 'zot', old: null, value: 'bar'});
         el.setAttribute('foo', 'foo2');
         assert.deepEqual(el.attrInfo, {name: 'foo', old: 'foo', value: 'foo2'});
-      })
+      });
 
       test('static attribute bindings', () => {
         assert.equal(el.$.child1.getAttribute('bar'), 'bar');


### PR DESCRIPTION
Applies a number of optimizations that speed up defining a legacy element. These optimizations are mostly beneficial when a large number of elements are defined that are not used for initial render.

* Fixes an issue with `dedupingMixin` that was causing info to be cached on the resulting class even when no mixin should be applied.
* In Polymer.Class, avoids using `LegacyElementMixin(HTMLElement)` in favor of a cached `LegacyElement`.
* Copies `DisableUpgradeMixin` into Polymer's legacy class generation. This avoids the need to mix this on top of all legacy elements.
* Adds `legacyNoAttributes` setting which avoids setting `observedAttributes` and instead (1) applies the values of all attributes at create time, (2) patches set/removeAttribute so that they call attributeChangedCallback. This is faster since it avoids the work Polymer needs to do to calculate `observedAttributes`.
