### PR TITLE
FIx closure annotation

### DIFF
--- a/externs/polymer-dom-api-externs.js
+++ b/externs/polymer-dom-api-externs.js
@@ -14,7 +14,7 @@
  *
  * @interface
  */
-let PolymerDomApi = function() {};
+var PolymerDomApi = function() {};
 
 /**
  * @param {?Node} node


### PR DESCRIPTION
Closure was unhappy with the change from `var` to `let` so reverting it.
