### PR TITLE
Ensure telemetry system works with `legacyNoObservedAttributes` setting

### DIFF
--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -168,8 +168,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     static get observedAttributes() {
-      if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
-        this.prototype._legacyForceObservedAttributes = this._legacyForceObservedAttributes;
+      if (legacyNoObservedAttributes && !this.prototype._legacyForceObservedAttributes) {
         // Ensure this element is property registered with the telemetry system.
         if (!this.hasOwnProperty(JSCompiler_renameProperty('__observedAttributes', this))) {
           this.__observedAttributes = [];

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -23,6 +23,7 @@ import { wrap } from '../utils/wrap.js';
 import { scopeSubtree } from '../utils/scope-subtree.js';
 import { legacyOptimizations, legacyNoObservedAttributes } from '../utils/settings.js';
 import { findObservedAttributesGetter } from '../mixins/disable-upgrade-mixin.js';
+import { register } from '../utils/telemetry.js';
 
 const DISABLED_ATTR = 'disable-upgrade';
 
@@ -165,8 +166,16 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     static get observedAttributes() {
-      return legacyNoObservedAttributes ? [] :
-        observedAttributesGetter.call(this).concat(DISABLED_ATTR);
+      if (legacyNoObservedAttributes) {
+        // Ensure this element is property registered with the telemetry system.
+        if (!this.hasOwnProperty(JSCompiler_renameProperty('__observedAttributes', this))) {
+          this.__observedAttributes = [];
+          register(this.prototype);
+        }
+        return this.__observedAttributes;
+      } else {
+        return observedAttributesGetter.call(this).concat(DISABLED_ATTR);
+      }
     }
 
     // NOTE: Inlined for perf from version of DisableUpgradeMixin.

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -104,6 +104,8 @@ export const LegacyElementMixin = dedupingMixin((base) => {
       this.__isUpgradeDisabled;
       /** @type {boolean|undefined} */
       this.__needsAttributesAtConnected;
+      /** @type {boolean|undefined} */
+      this._legacyForceObservedAttributes;
     }
 
     /**
@@ -143,7 +145,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     /** @override */
     setAttribute(name, value) {
-      if (legacyNoObservedAttributes) {
+      if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
         const oldValue = this.getAttribute(name);
         super.setAttribute(name, value);
         // value coerced to String for closure's benefit
@@ -155,7 +157,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     /** @override */
     removeAttribute(name) {
-      if (legacyNoObservedAttributes) {
+      if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
         const oldValue = this.getAttribute(name);
         super.removeAttribute(name);
         this.__attributeReaction(name, oldValue, null);
@@ -166,7 +168,8 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     // NOTE: Inlined for perf from version of DisableUpgradeMixin.
     static get observedAttributes() {
-      if (legacyNoObservedAttributes) {
+      if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
+        this.prototype._legacyForceObservedAttributes = this._legacyForceObservedAttributes;
         // Ensure this element is property registered with the telemetry system.
         if (!this.hasOwnProperty(JSCompiler_renameProperty('__observedAttributes', this))) {
           this.__observedAttributes = [];
@@ -315,7 +318,7 @@ export const LegacyElementMixin = dedupingMixin((base) => {
         this.root = /** @type {HTMLElement} */(this);
         this.created();
         // Pull all attribute values 1x if `legacyNoObservedAttributes` is set.
-        if (legacyNoObservedAttributes) {
+        if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
           if (this.hasAttributes()) {
             this._takeAttributes();
           // Element created from scratch or parser generated

--- a/lib/legacy/polymer-fn.js
+++ b/lib/legacy/polymer-fn.js
@@ -39,6 +39,10 @@ const Polymer = function(info) {
   } else {
     klass = Polymer.Class(info);
   }
+  // Copy opt out for `legacyNoObservedAttributes` from info object to class.
+  if (info._legacyForceObservedAttributes) {
+    klass._legacyForceObservedAttributes = info._legacyForceObservedAttributes;
+  }
   customElements.define(klass.is, /** @type {!HTMLElement} */(klass));
   return klass;
 };

--- a/lib/legacy/polymer-fn.js
+++ b/lib/legacy/polymer-fn.js
@@ -41,7 +41,7 @@ const Polymer = function(info) {
   }
   // Copy opt out for `legacyNoObservedAttributes` from info object to class.
   if (info._legacyForceObservedAttributes) {
-    klass._legacyForceObservedAttributes = info._legacyForceObservedAttributes;
+    klass.prototype._legacyForceObservedAttributes = info._legacyForceObservedAttributes;
   }
   customElements.define(klass.is, /** @type {!HTMLElement} */(klass));
   return klass;

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -117,7 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.ok(def);
       });
 
-      test('native property observeable via `attributeChanged` and reflected to property when `_forceObservedAttributes` is used', () => {
+      test('native properties observeable when `_legacyForceObservedAttributes` set', () => {
         el = document.createElement('x-native-attrs-force');
         document.body.appendChild(el);
         el.tabIndex = 5;

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         properties: {
           tabindex: {reflectToAttribute: true, type: Number}
         },
-        attributeChanged(name, old, value) {
+        attributeChanged() {
           this.attributeChangedCalled = true;
         }
       });

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -117,7 +117,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.ok(def);
       });
 
-      test('native properties observeable when `_legacyForceObservedAttributes` set', () => {
+      test('native properties observeable when `_legacyForceObservedAttributes` set', function() {
+        if (customElements.polyfillWrapFlushCallback) {
+          this.skip();
+        }
         el = document.createElement('x-native-attrs-force');
         document.body.appendChild(el);
         el.tabIndex = 5;

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -118,6 +118,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('native properties observeable when `_legacyForceObservedAttributes` set', function() {
+        // Unsupported when polyfill is in use since it uses `setAttribute`.
         if (customElements.polyfillWrapFlushCallback) {
           this.skip();
         }

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -113,8 +113,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('telemetry collected as expected', () => {
-        const def = registrations.find((def) => def.is === el.localName);
-        assert.ok(def);
+        const defs = registrations.filter((def) => def.is === el.localName);
+        assert.ok(defs[0]);
       });
 
       test('native properties observeable when `_legacyForceObservedAttributes` set', function() {

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           zot: Boolean,
           shouldIf: Boolean,
           camelCase: String,
-          disabled: {type: Boolean, value: 'true'}
+          disabled: {type: Boolean, value: 'true'},
         },
         created() {
           this.wasCreated = true;
@@ -72,6 +72,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         attributeChanged(name, old, value) {
           this.wasCreatedInAttributeChanged = this.wasCreated;
           this.attrInfo = {name, old, value};
+        }
+      });
+
+      Polymer({
+        is: 'x-native-attrs-force',
+        _legacyForceObservedAttributes: true,
+        properties: {
+          tabindex: {reflectToAttribute: true, type: Number}
+        },
+        attributeChanged(name, old, value) {
+          this.attributeChangedCalled = true;
         }
       });
     </script>
@@ -104,6 +115,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('telemetry collected as expected', () => {
         const def = registrations.find((def) => def.is === el.localName);
         assert.ok(def);
+      });
+
+      test('native property observeable via `attributeChanged` and reflected to property when `_forceObservedAttributes` is used', () => {
+        el = document.createElement('x-native-attrs-force');
+        document.body.appendChild(el);
+        el.tabIndex = 5;
+        assert.ok(el.attributeChangedCalled);
+        assert.equal(el.tabindex, 5);
+        document.body.removeChild(el);
       });
 
       test('static attributes', () => {

--- a/test/unit/legacy-noattributes.html
+++ b/test/unit/legacy-noattributes.html
@@ -92,12 +92,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script type="module">
     import {flush} from '../../lib/utils/flush.js';
     import {wrap} from '../../lib/utils/wrap.js';
+    import {registrations} from '../../lib/utils/telemetry.js';
 
     suite('legacyNoObservedAttributes', () => {
 
       let el;
       setup(() => {
         el = fixture('declarative');
+      });
+
+      test('telemetry collected as expected', () => {
+        const def = registrations.find((def) => def.is === el.localName);
+        assert.ok(def);
       });
 
       test('static attributes', () => {


### PR DESCRIPTION
Addresses internal issue found with using telemetry system with the `legacyNoObservedAttributes` setting.
