### PR TITLE
Fixes for several related dom-repeat chunking issues. Fixes #5631.

### DIFF
--- a/lib/elements/dom-repeat.js
+++ b/lib/elements/dom-repeat.js
@@ -247,13 +247,13 @@ export class DomRepeat extends domRepeatBase {
       /**
        * Defines an initial count of template instances to render after setting
        * the `items` array, before the next paint, and puts the `dom-repeat`
-       * into "chunking mode".  The remaining items will be created and rendered
-       * incrementally at each animation frame therof until all instances have
+       * into "chunking mode".  The remaining items (and any future items as a
+       * result of pushing onto the array) will be created and rendered
+       * incrementally at each animation frame thereof until all instances have
        * been rendered.
        */
       initialCount: {
-        type: Number,
-        observer: '__initializeChunking'
+        type: Number
       },
 
       /**
@@ -285,6 +285,25 @@ export class DomRepeat extends domRepeatBase {
        */
       notifyDomChange: {
         type: Boolean
+      },
+
+      /**
+       * When chunking is enabled via `initialCount` and the `items` array is
+       * set to a new array, this flag controls whether the previously rendered
+       * instances are reused or not.
+       *
+       * When `true`, any previously rendered template instances are updated in
+       * place to their new item values synchronously in one shot, and then any
+       * further items (if any) are chunked out.  When `false`, the list is
+       * returned back to its `initialCount` (any instances over the initial
+       * count are discarded) and the remainder of the list is chunked back in.
+       * Set this to `true` to avoid re-creating the list and losing scroll
+       * position, although note that when changing the list to completely
+       * different data the render thread will be blocked until all existing
+       * instances are updated to their new data.
+       */
+      reuseChunkedInstances: {
+        type: Boolean
       }
 
     };
@@ -303,7 +322,10 @@ export class DomRepeat extends domRepeatBase {
     this.__renderDebouncer = null;
     this.__itemsIdxToInstIdx = {};
     this.__chunkCount = null;
-    this.__lastChunkTime = null;
+    this.__renderStartTime = null;
+    this.__restartChunking = true;
+    this.__shouldMeasureChunk = false;
+    this.__shouldContinueChunking = false;
     this.__sortFn = null;
     this.__filterFn = null;
     this.__observePaths = null;
@@ -445,36 +467,58 @@ export class DomRepeat extends domRepeatBase {
     return Math.ceil(1000/rate);
   }
 
-  __initializeChunking() {
-    if (this.initialCount) {
-      this.__limit = this.initialCount;
-      this.__chunkCount = this.initialCount;
-      this.__lastChunkTime = performance.now();
+  __updateLimitAndScheduleNextChunk(filteredItemCount) {
+    let newCount;
+    if (this.__restartChunking) {
+      this.__restartChunking = false;
+      // Limit next render to the initial count
+      this.__limit = Math.min(filteredItemCount, this.initialCount);
+      // Subtract off any existing instances to determine the number of
+      // instances that will be created
+      newCount = Math.max(this.__limit - this.__instances.length, 0);
+      // Initialize the chunk size with how many items we're creating
+      this.__chunkCount = newCount || 1;
+    } else {
+      // The number of new instances that will be created is based on the
+      // existing instances, the new list size, and the maximum chunk size
+      newCount = Math.min(
+        Math.max(filteredItemCount - this.__instances.length, 0), 
+        this.__chunkCount);
+      // Increase the limit based on how many new items we're making
+      this.__limit = Math.min(this.__limit + newCount, filteredItemCount);
+    }
+    // Schedule a rAF task to measure the total time to render the chunk
+    // (including layout/paint plus any other thread contention), throttle the
+    // chunk size accordingly, and schedule another render if there is more to
+    // chunk
+    this.__shouldMeasureChunk = newCount === this.__chunkCount;
+    this.__shouldContinueChunking = this.__limit < filteredItemCount;
+    this.__renderStartTime = performance.now();
+    if (this.__shouldMeasureChunk || this.__shouldContinueChunking) {
+      this.__debounceRender(this.__continueChunkingAfterRaf);
     }
   }
 
-  __tryRenderChunk() {
-    // Debounced so that multiple calls through `_render` between animation
-    // frames only queue one new rAF (e.g. array mutation & chunked render)
-    if (this.items && this.__limit < this.items.length) {
-      this.__debounceRender(this.__requestRenderChunk);
-    }
+  __continueChunkingAfterRaf() {
+    requestAnimationFrame(() => this.__continueChunking());
   }
 
-  __requestRenderChunk() {
-    requestAnimationFrame(()=>this.__renderChunk());
-  }
-
-  __renderChunk() {
+  __continueChunking() {
     // Simple auto chunkSize throttling algorithm based on feedback loop:
-    // measure actual time between frames and scale chunk count by ratio
-    // of target/actual frame time
-    let currChunkTime = performance.now();
-    let ratio = this._targetFrameTime / (currChunkTime - this.__lastChunkTime);
-    this.__chunkCount = Math.round(this.__chunkCount * ratio) || 1;
-    this.__limit += this.__chunkCount;
-    this.__lastChunkTime = currChunkTime;
-    this.__debounceRender(this.__render);
+    // measure actual time between frames and scale chunk count by ratio of
+    // target/actual frame time.  Only modify chunk size if our measurement
+    // reflects the cost of a creating a full chunk's worth of instances; this
+    // avoids scaling up the chunk size if we e.g. quickly re-rendered instances
+    // in place
+    if (this.__shouldMeasureChunk) {
+      const renderTime = performance.now() - this.__renderStartTime;
+      const ratio = this._targetFrameTime / renderTime;
+      this.__chunkCount = Math.round(this.__chunkCount * ratio) || 1;
+    }
+    // Enqueue a new render if we haven't reached the full size of the list
+    if (this.__shouldContinueChunking) {
+      this.__debounceRender(this.__render);
+    }
   }
 
   __observeChanged() {
@@ -491,7 +535,9 @@ export class DomRepeat extends domRepeatBase {
     if (!this.__handleItemPath(change.path, change.value)) {
       // Otherwise, the array was reset ('items') or spliced ('items.splices'),
       // so queue a full refresh
-      this.__initializeChunking();
+      if (change.path === 'items' && !this.reuseChunkedInstances) {
+        this.__restartChunking = true;
+      }
       this.__debounceRender(this.__render);
     }
   }
@@ -561,8 +607,6 @@ export class DomRepeat extends domRepeatBase {
         composed: true
       }));
     }
-    // Check to see if we need to render more items
-    this.__tryRenderChunk();
   }
 
   __applyFullRefresh() {
@@ -579,6 +623,11 @@ export class DomRepeat extends domRepeatBase {
     // Apply user sort
     if (this.__sortFn) {
       isntIdxToItemsIdx.sort((a, b) => this.__sortFn(items[a], items[b]));
+    }
+    // If we're chunking, increase the limit if there are new instances to
+    // create and schedule the next chunk
+    if (this.initialCount) {
+      this.__updateLimitAndScheduleNextChunk(isntIdxToItemsIdx.length);
     }
     // items->inst map kept for item path forwarding
     const itemsIdxToInstIdx = this.__itemsIdxToInstIdx = {};

--- a/lib/elements/dom-repeat.js
+++ b/lib/elements/dom-repeat.js
@@ -318,12 +318,11 @@ export class DomRepeat extends domRepeatBase {
     super();
     this.__instances = [];
     this.__limit = Infinity;
-    this.__pool = [];
     this.__renderDebouncer = null;
     this.__itemsIdxToInstIdx = {};
     this.__chunkCount = null;
     this.__renderStartTime = null;
-    this.__restartChunking = true;
+    this.__itemsArrayChanged = false;
     this.__shouldMeasureChunk = false;
     this.__shouldContinueChunking = false;
     this.__sortFn = null;
@@ -467,79 +466,9 @@ export class DomRepeat extends domRepeatBase {
     return Math.ceil(1000/rate);
   }
 
-  __updateLimitAndScheduleNextChunk(filteredItemCount) {
-    let newCount;
-    if (this.__restartChunking) {
-      this.__restartChunking = false;
-      // Limit next render to the initial count
-      this.__limit = Math.min(filteredItemCount, this.initialCount);
-      // Subtract off any existing instances to determine the number of
-      // instances that will be created
-      newCount = Math.max(this.__limit - this.__instances.length, 0);
-      // Initialize the chunk size with how many items we're creating
-      this.__chunkCount = newCount || 1;
-    } else {
-      // The number of new instances that will be created is based on the
-      // existing instances, the new list size, and the maximum chunk size
-      newCount = Math.min(
-        Math.max(filteredItemCount - this.__instances.length, 0), 
-        this.__chunkCount);
-      // Increase the limit based on how many new items we're making
-      this.__limit = Math.min(this.__limit + newCount, filteredItemCount);
-    }
-    // Schedule a rAF task to measure the total time to render the chunk
-    // (including layout/paint plus any other thread contention), throttle the
-    // chunk size accordingly, and schedule another render if there is more to
-    // chunk
-    this.__shouldMeasureChunk = newCount === this.__chunkCount;
-    this.__shouldContinueChunking = this.__limit < filteredItemCount;
-    this.__renderStartTime = performance.now();
-    if (this.__shouldMeasureChunk || this.__shouldContinueChunking) {
-      this.__debounceRender(this.__continueChunkingAfterRaf);
-    }
-  }
-
-  __continueChunkingAfterRaf() {
-    requestAnimationFrame(() => this.__continueChunking());
-  }
-
-  __continueChunking() {
-    // Simple auto chunkSize throttling algorithm based on feedback loop:
-    // measure actual time between frames and scale chunk count by ratio of
-    // target/actual frame time.  Only modify chunk size if our measurement
-    // reflects the cost of a creating a full chunk's worth of instances; this
-    // avoids scaling up the chunk size if we e.g. quickly re-rendered instances
-    // in place
-    if (this.__shouldMeasureChunk) {
-      const renderTime = performance.now() - this.__renderStartTime;
-      const ratio = this._targetFrameTime / renderTime;
-      this.__chunkCount = Math.round(this.__chunkCount * ratio) || 1;
-    }
-    // Enqueue a new render if we haven't reached the full size of the list
-    if (this.__shouldContinueChunking) {
-      this.__debounceRender(this.__render);
-    }
-  }
-
   __observeChanged() {
     this.__observePaths = this.observe &&
       this.observe.replace('.*', '.').split(' ');
-  }
-
-  __itemsChanged(change) {
-    if (this.items && !Array.isArray(this.items)) {
-      console.warn('dom-repeat expected array for `items`, found', this.items);
-    }
-    // If path was to an item (e.g. 'items.3' or 'items.3.foo'), forward the
-    // path to that instance synchronously (returns false for non-item paths)
-    if (!this.__handleItemPath(change.path, change.value)) {
-      // Otherwise, the array was reset ('items') or spliced ('items.splices'),
-      // so queue a full refresh
-      if (change.path === 'items' && !this.reuseChunkedInstances) {
-        this.__restartChunking = true;
-      }
-      this.__debounceRender(this.__render);
-    }
   }
 
   __handleObservedPaths(path) {
@@ -557,6 +486,23 @@ export class DomRepeat extends domRepeatBase {
           }
         }
       }
+    }
+  }
+
+  __itemsChanged(change) {
+    if (this.items && !Array.isArray(this.items)) {
+      console.warn('dom-repeat expected array for `items`, found', this.items);
+    }
+    // If path was to an item (e.g. 'items.3' or 'items.3.foo'), forward the
+    // path to that instance synchronously (returns false for non-item paths)
+    if (!this.__handleItemPath(change.path, change.value)) {
+      // Otherwise, the array was reset ('items') or spliced ('items.splices'),
+      // so queue a render.  Restart chunking when the items changed (for
+      // backward compatibility), unless `reuseChunkedInstances` option is set
+      if (change.path === 'items') {
+        this.__itemsArrayChanged = true;
+      }
+      this.__debounceRender(this.__render);
     }
   }
 
@@ -591,15 +537,23 @@ export class DomRepeat extends domRepeatBase {
       // No template found yet
       return;
     }
-    this.__applyFullRefresh();
-    // Reset the pool
-    // TODO(kschaaf): Reuse pool across turns and nested templates
-    // Now that objects/arrays are re-evaluated when set, we can safely
-    // reuse pooled instances across turns, however we still need to decide
-    // semantics regarding how long to hold, how many to hold, etc.
-    this.__pool.length = 0;
+    let items = this.items || [];
+    // Sort and filter the items into a mapping array from instance->item
+    const isntIdxToItemsIdx = this.__sortAndFilterItems(items);
+    // If we're chunking, increase the limit if there are new instances to
+    // create and schedule the next chunk
+    if (this.initialCount) {
+      this.__updateLimit(isntIdxToItemsIdx.length);
+    }
+    // Create, update, and/or remove instances
+    this.__updateInstances(items, isntIdxToItemsIdx);
     // Set rendered item count
     this._setRenderedItemCount(this.__instances.length);
+    // If we're chunking, schedule a rAF task to measure/continue chunking
+    if (this.initialCount &&
+       (this.__shouldMeasureChunk || this.__shouldContinueChunking)) {
+      this.__debounceRender(this.__continueChunkingAfterRaf);
+    }
     // Notify users
     if (!suppressTemplateNotifications || this.notifyDomChange) {
       this.dispatchEvent(new CustomEvent('dom-change', {
@@ -609,8 +563,8 @@ export class DomRepeat extends domRepeatBase {
     }
   }
 
-  __applyFullRefresh() {
-    let items = this.items || [];
+  __sortAndFilterItems(items) {
+    // Generate array maping the instance index to the items array index
     let isntIdxToItemsIdx = new Array(items.length);
     for (let i=0; i<items.length; i++) {
       isntIdxToItemsIdx[i] = i;
@@ -624,11 +578,60 @@ export class DomRepeat extends domRepeatBase {
     if (this.__sortFn) {
       isntIdxToItemsIdx.sort((a, b) => this.__sortFn(items[a], items[b]));
     }
-    // If we're chunking, increase the limit if there are new instances to
-    // create and schedule the next chunk
-    if (this.initialCount) {
-      this.__updateLimitAndScheduleNextChunk(isntIdxToItemsIdx.length);
+    return isntIdxToItemsIdx;
+  }
+
+  __updateLimit(filteredItemCount) {
+    let newCount;
+    if (!this.__chunkCount ||
+       (this.__itemsArrayChanged && !this.reuseChunkedInstances)) {
+      // Limit next render to the initial count
+      this.__limit = Math.min(filteredItemCount, this.initialCount);
+      // Subtract off any existing instances to determine the number of
+      // instances that will be created
+      newCount = Math.max(this.__limit - this.__instances.length, 0);
+      // Initialize the chunk size with how many items we're creating
+      this.__chunkCount = newCount || 1;
+    } else {
+      // The number of new instances that will be created is based on the
+      // existing instances, the new list size, and the maximum chunk size
+      newCount = Math.min(
+        Math.max(filteredItemCount - this.__instances.length, 0), 
+        this.__chunkCount);
+      // Update the limit based on how many new items we're making, limited
+      // buy the total size of the list
+      this.__limit = Math.min(this.__limit + newCount, filteredItemCount);
     }
+    this.__itemsArrayChanged = false;
+    // Record some state about chunking for use in `__continueChunking`
+    this.__shouldMeasureChunk = newCount === this.__chunkCount;
+    this.__shouldContinueChunking = this.__limit < filteredItemCount;
+    this.__renderStartTime = performance.now();
+  }
+
+  __continueChunkingAfterRaf() {
+    requestAnimationFrame(() => this.__continueChunking());
+  }
+
+  __continueChunking() {
+    // Simple auto chunkSize throttling algorithm based on feedback loop:
+    // measure actual time between frames and scale chunk count by ratio of
+    // target/actual frame time.  Only modify chunk size if our measurement
+    // reflects the cost of a creating a full chunk's worth of instances; this
+    // avoids scaling up the chunk size if we e.g. quickly re-rendered instances
+    // in place
+    if (this.__shouldMeasureChunk) {
+      const renderTime = performance.now() - this.__renderStartTime;
+      const ratio = this._targetFrameTime / renderTime;
+      this.__chunkCount = Math.round(this.__chunkCount * ratio) || 1;
+    }
+    // Enqueue a new render if we haven't reached the full size of the list
+    if (this.__shouldContinueChunking) {
+      this.__debounceRender(this.__render);
+    }
+  }
+  
+  __updateInstances(items, isntIdxToItemsIdx) {
     // items->inst map kept for item path forwarding
     const itemsIdxToInstIdx = this.__itemsIdxToInstIdx = {};
     let instIdx = 0;
@@ -671,10 +674,7 @@ export class DomRepeat extends domRepeatBase {
   }
 
   __detachAndRemoveInstance(idx) {
-    let inst = this.__detachInstance(idx);
-    if (inst) {
-      this.__pool.push(inst);
-    }
+    this.__detachInstance(idx);
     this.__instances.splice(idx, 1);
   }
 
@@ -687,17 +687,7 @@ export class DomRepeat extends domRepeatBase {
   }
 
   __insertInstance(item, instIdx, itemIdx) {
-    let inst = this.__pool.pop();
-    if (inst) {
-      // TODO(kschaaf): If the pool is shared across turns, hostProps
-      // need to be re-set to reused instances in addition to item
-      inst._setPendingProperty(this.as, item);
-      inst._setPendingProperty(this.indexAs, instIdx);
-      inst._setPendingProperty(this.itemsIndexAs, itemIdx);
-      inst._flushProperties();
-    } else {
-      inst = this.__stampInstance(item, instIdx, itemIdx);
-    }
+    const inst = this.__stampInstance(item, instIdx, itemIdx);
     let beforeRow = this.__instances[instIdx + 1];
     let beforeNode = beforeRow ? beforeRow.children[0] : this;
     wrap(wrap(this).parentNode).insertBefore(inst.root, beforeNode);

--- a/test/unit/dom-repeat-elements.js
+++ b/test/unit/dom-repeat-elements.js
@@ -434,7 +434,7 @@ Polymer({
 });
 Polymer({
   _template: html`
-    <template id="repeater" is="dom-repeat" items="{{items}}" initial-count="10">
+    <template id="repeater" is="dom-repeat" items="{{items}}" initial-count="10" target-framerate="25">
       <x-wait>{{item.prop}}</x-wait>
     </template>
 `,

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -121,9 +121,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <h4>x-repeat-limit</h4>
   <x-repeat-limit id="limited"></x-repeat-limit>
 
-  <h4>x-repeat-chunked</h4>
-  <x-repeat-chunked id="chunked"></x-repeat-chunked>
-
   <div id="inDocumentContainer">
   </div>
 
@@ -141,7 +138,7 @@ import './dom-repeat-elements.js';
 import './dom-repeat-elements.js';
 import { flush } from '../../lib/utils/flush.js';
 import { calculateSplices } from '../../lib/utils/array-splice.js';
-/* global limited inDocumentRepeater inDocumentContainer inDocumentContainerOrig chunked nonUpgrade*/
+/* global limited inDocumentRepeater inDocumentContainer inDocumentContainerOrig nonUpgrade*/
 
 /*
   Expected:
@@ -3948,206 +3945,241 @@ suite('limit with sort & filter', function() {
 
 });
 
-// TODO(kschaaf): This test suite has proven to be flaky only on IE, only
-// on CI (Sauce) presumably because of rAF handling in the CI environment
-// disabling for IE for now to avoid Polymer tests being flaky
-if (!/Trident/.test(navigator.userAgent)) {
+suite('chunked rendering', function() {
 
-  // TODO(kschaaf): We're experiencing more flakiness on Safari on CI,
-  // for now, skip these tests and revisit
-  suite.skip('chunked rendering', function() {
+  let chunked;
+  let verifyAfterChange;
+  const verify = () => verifyAfterChange && verifyAfterChange();
+  setup(() => {
+    chunked = document.createElement('x-repeat-chunked');
+    chunked.addEventListener('dom-change', verify);
+    document.body.appendChild(chunked);
+  });
+  teardown(() => {
+    chunked.removeEventListener('dom-change', verify);
+    document.body.removeChild(chunked);
+    chunked = null;
+    verifyAfterChange = null;
+  });
 
-    test('basic chunked rendering', function(done) {
+  // Framerate=25, element cost = 4ms: should never make more than
+  // (1000/25) / 4 = 10 elements per frame
+  const MAX_PER_FRAME = (1000 / 25) / 4;
 
-      var checkItemOrder = function(stamped) {
-        for (var i=0; i<stamped.length; i++) {
-          assert.equal(stamped[i].textContent, i);
+  test('basic chunked rendering', function(done) {
+
+    var checkItemOrder = function(stamped) {
+      for (var i=0; i<stamped.length; i++) {
+        assert.equal(stamped[i].textContent, i);
+      }
+    };
+
+    let lastStamped;
+    let frameCount = 0;
+    verifyAfterChange = function() {
+      var stamped = Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)'));
+      checkItemOrder(stamped);
+      if (!lastStamped) {
+        // Initial rendering of initial count
+        assert.equal(stamped.length, 10);
+      } else {
+        // Remaining rendering increments
+        assert.isTrue(stamped.length > lastStamped.length,
+          'list instance count should increase each frame');
+        assert.deepEqual(lastStamped, stamped.slice(0, lastStamped.length),
+          'list should not re-render instances during mutation');
+        assert.isAtMost((stamped.length - lastStamped.length), MAX_PER_FRAME,
+          `list should not render more than ${MAX_PER_FRAME} per frame`);
+      }
+      if (stamped.length < chunked.items.length) {
+        frameCount++;
+        lastStamped = stamped;
+      } else {
+        // Final rendering at exact item count
+        assert.equal(stamped.length, 100, 'final count wrong');
+        assert.isAtLeast(frameCount, 10, 'should have taken at least 10 frames to render');
+        done();
+      }
+    };
+    chunked.items = chunked.preppedItems.slice();
+
+  });
+
+  test('mutations during chunked rendering', function(done) {
+
+    var checkItemOrder = function(stamped) {
+      var last = -1;
+      for (var i=0; i<stamped.length; i++) {
+        var curr = parseFloat(stamped[i].textContent);
+        assert.isTrue(curr > last);
+        last = curr;
+      }
+    };
+
+    var mutateArray = function(repeater, renderedCount) {
+      // The goal here is to remove & add some, and do it over
+      // the threshold of where we have currently rendered items, and
+      // ensure that the prop values of the newly inserted items are in
+      // ascending order so we can do a simple check in checkItemOrder
+      var overlap = 2;
+      var remove = 4;
+      var add = 6;
+      var start = renderedCount.length - overlap;
+      if (start + add < repeater.items.length) {
+        var end = start + remove;
+        var args = ['items', start, remove];
+        var startVal = repeater.items[start].prop;
+        var endVal = repeater.items[end].prop;
+        var delta = (endVal - startVal) / add;
+        for (var i=0; i<add; i++) {
+          args.push({prop: startVal + i*delta});
         }
-      };
+        repeater.splice.apply(repeater, args);
+      }
+    };
 
-      var lastLength = 0;
-      var checkCount = function() {
-        var stamped = chunked.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        checkItemOrder(stamped);
-        if (stamped.length && lastLength === 0) {
-          // Initial rendering of initial count
-          assert.equal(stamped.length, 10);
-        } else {
-          // Remaining rendering increments
-          assert.isTrue(stamped.length > lastLength);
+    let lastStamped;
+    var frameCount = 0;
+    verifyAfterChange = function() {
+      var stamped = Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)'));
+      checkItemOrder(stamped);
+      if (!lastStamped) {
+        // Initial rendering of initial count
+        assert.equal(stamped.length, 10);
+      } else {
+        // Remaining rendering increments
+        assert.isTrue(stamped.length > lastStamped.length,
+          'list instance count should increase each frame');
+        assert.deepEqual(lastStamped, stamped.slice(0, lastStamped.length),
+          'list should not re-render instances during mutation');
+        assert.isAtMost((stamped.length - lastStamped.length), MAX_PER_FRAME,
+          `list should not render more than ${MAX_PER_FRAME} per frame`);
+      }
+      if (stamped.length < chunked.items.length) {
+        if (frameCount++ < 5) {
+          mutateArray(chunked, stamped);
         }
-        if (stamped.length < 100) {
-          lastLength = stamped.length;
-          checkUntilComplete();
-        } else {
-          // Final rendering at exact item count
-          assert.equal(stamped.length, 100);
-          done();
+        lastStamped = stamped;
+      } else {
+        // Final rendering at exact item count
+        assert.equal(stamped.length, chunked.items.length, 'final count wrong');
+        assert.isAtLeast(frameCount, 10, 'should have taken at least 10 frames to render');
+        done();
+      }
+    };
+    chunked.items = chunked.preppedItems.slice();
+
+  });
+
+
+  test('mutations during chunked rendering, sort & filtered', function(done) {
+
+    var checkItemOrder = function(stamped) {
+      var last = Infinity;
+      for (var i=0; i<stamped.length; i++) {
+        var curr = parseFloat(stamped[i].textContent);
+        assert.isTrue(curr <= last);
+        assert.strictEqual(curr % 2, 0);
+        last = curr;
+      }
+    };
+
+    var mutateArray = function(repeater, stamped) {
+      var start = parseInt(stamped[0].textContent);
+      var end = parseInt(stamped[stamped.length-1].textContent);
+      var mid = (end-start)/2;
+      for (var i=0; i<5; i++) {
+        chunked.push('items', {prop: mid + 1});
+      }
+      chunked.splice('items', Math.round(stamped.length/2), 3);
+    };
+
+    var lastStamped;
+    var frameCount = 0;
+    verifyAfterChange = function() {
+      var stamped = Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)'));
+      checkItemOrder(stamped);
+      var filteredLength = chunked.items.filter(chunked.$.repeater.filter).length;
+      if (!lastStamped) {
+        // Initial rendering of initial count
+        assert.equal(stamped.length, 10);
+      } else {
+        // Remaining rendering increments
+        assert.isTrue(stamped.length > lastStamped.length,
+          'list instance count should increase each frame');
+        assert.deepEqual(lastStamped, stamped.slice(0, lastStamped.length),
+          'list should not re-render instances during mutation');
+        assert.isAtMost((stamped.length - lastStamped.length), MAX_PER_FRAME,
+          `list should not render more than ${MAX_PER_FRAME} per frame`);
+      }
+      if (stamped.length < filteredLength) {
+        if (frameCount++ < 4) {
+          mutateArray(chunked, stamped);
         }
-      };
-      var checkUntilComplete = function() {
-        // On polyfilled MO, need to wait one setTimeout before rAF
-        if (MutationObserver._isPolyfilled) {
-          setTimeout(function() {
-            requestAnimationFrame(checkCount);
-          });
-        } else {
-          requestAnimationFrame(checkCount);
-        }
-      };
+        lastStamped = stamped;
+      } else {
+        assert.equal(stamped.length, filteredLength, 'final count wrong');
+        assert.isAtLeast(frameCount, 5, 'should have taken at least 5 frames to render');
+        done();
+      }
+    };
+    chunked.$.repeater.sort = function(a, b) {
+      return b.prop - a.prop;
+    };
+    chunked.$.repeater.filter = function(a) {
+      return (a.prop % 2) === 0;
+    };
+    chunked.items = chunked.preppedItems.slice();
 
-      chunked.items = chunked.preppedItems.slice();
-      checkUntilComplete();
+  });
 
-    });
+  suite('resetting items array', () => {
 
-    test('mutations during chunked rendering', function(done) {
+    [false, true].forEach(reuse => {
 
-      var checkItemOrder = function(stamped) {
-        var last = -1;
-        for (var i=0; i<stamped.length; i++) {
-          var curr = parseFloat(stamped[i].textContent);
-          assert.isTrue(curr > last);
-          last = curr;
-        }
-      };
+      test(`reuseChunkedInstances=${reuse}`, (done) => {
 
-      var mutateArray = function(repeater, renderedCount) {
-        // The goal here is to remove & add some, and do it over
-        // the threshold of where we have currently rendered items, and
-        // ensure that the prop values of the newly inserted items are in
-        // ascending order so we can do a simple check in checkItemOrder
-        var overlap = 2;
-        var remove = 4;
-        var add = 6;
-        var start = renderedCount.length - overlap;
-        if (start + add < repeater.items.length) {
-          var end = start + remove;
-          var args = ['items', start, remove];
-          var startVal = repeater.items[start].prop;
-          var endVal = repeater.items[end].prop;
-          var delta = (endVal - startVal) / add;
-          for (var i=0; i<add; i++) {
-            args.push({prop: startVal + i*delta});
+        let i = 3;
+        let lastStamped;
+        verifyAfterChange = function() {
+          var stamped = Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)'));
+          if (!lastStamped) {
+            // Initial rendering of initial count
+            assert.equal(stamped.length, 10);
+          } else {
+            // Remaining rendering increments
+            assert.isTrue(stamped.length > lastStamped.length,
+              'list instance count should increase each frame');
+            assert.deepEqual(lastStamped, stamped.slice(0, lastStamped.length),
+              'list should not re-render instances during mutation');
+            assert.isAtMost((stamped.length - lastStamped.length), MAX_PER_FRAME,
+              `list should not render more than ${MAX_PER_FRAME} per frame`);
           }
-          repeater.splice.apply(repeater, args);
-        }
-      };
-
-      var lastLength = 0;
-      var mutateCount = 5;
-      var checkCount = function() {
-        var stamped = chunked.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        checkItemOrder(stamped);
-        if (stamped.length && lastLength === 0) {
-          // Initial rendering of initial count
-          assert.equal(stamped.length, 10);
-        } else {
-          // Remaining rendering increments
-          assert.isTrue(stamped.length > lastLength);
-        }
-        if (stamped.length < chunked.items.length) {
-          if (mutateCount-- > 0) {
-            mutateArray(chunked, stamped);
+          if (stamped.length < chunked.items.length) {
+            lastStamped = stamped;
+          } else {
+            assert.equal(stamped.length, chunked.items.length, 'final count wrong');
+            if (--i > 0) {
+              if (!reuse) {
+                lastStamped = null;
+              }
+              chunked.items = chunked.preppedItems.slice();
+            } else {
+              done();
+            }
           }
-          lastLength = stamped.length;
-          checkUntilComplete();
-        } else {
-          // Final rendering at exact item count
-          assert.equal(stamped.length, chunked.items.length);
-          done();
-        }
-      };
-      var checkUntilComplete = function() {
-        // On polyfilled MO, need to wait one setTimeout before rAF
-        if (MutationObserver._isPolyfilled) {
-          setTimeout(function() {
-            requestAnimationFrame(checkCount);
-          });
-        } else {
-          requestAnimationFrame(checkCount);
-        }
-      };
+        };
 
-      chunked.items = chunked.preppedItems.slice();
-      checkUntilComplete();
+        chunked.$.repeater.reuseChunkedInstances = reuse;
+        chunked.items = chunked.preppedItems.slice();
 
-    });
-
-
-    test('mutations during chunked rendering, sort & filtered', function(done) {
-
-      var checkItemOrder = function(stamped) {
-        var last = Infinity;
-        for (var i=0; i<stamped.length; i++) {
-          var curr = parseFloat(stamped[i].textContent);
-          assert.isTrue(curr <= last);
-          assert.strictEqual(curr % 2, 0);
-          last = curr;
-        }
-      };
-
-      var mutateArray = function(repeater, stamped) {
-        var start = parseInt(stamped[0].textContent);
-        var end = parseInt(stamped[stamped.length-1].textContent);
-        var mid = (end-start)/2;
-        for (var i=0; i<5; i++) {
-          chunked.push('items', {prop: mid + 1});
-        }
-        chunked.splice('items', Math.round(stamped.length/2), 3);
-      };
-
-      var lastLength = 0;
-      var mutateCount = 5;
-      var checkCount = function() {
-        var stamped = chunked.root.querySelectorAll('*:not(template):not(dom-repeat)');
-        checkItemOrder(stamped);
-        var filteredLength = chunked.items.filter(chunked.$.repeater.filter).length;
-        if (stamped.length && lastLength === 0) {
-          // Initial rendering of initial count
-          assert.equal(stamped.length, 10);
-        } else {
-          // Remaining rendering increments
-          if (stamped.length < filteredLength) {
-            assert.isTrue(stamped.length > lastLength);
-          }
-        }
-        if (stamped.length < filteredLength) {
-          if (mutateCount-- > 0) {
-            mutateArray(chunked, stamped);
-          }
-          lastLength = stamped.length;
-          checkUntilComplete();
-        } else {
-          assert.equal(stamped.length, filteredLength);
-          done();
-        }
-      };
-      var checkUntilComplete = function() {
-        // On polyfilled MO, need to wait one setTimeout before rAF
-        if (MutationObserver._isPolyfilled) {
-          setTimeout(function() {
-            requestAnimationFrame(checkCount);
-          });
-        } else {
-          requestAnimationFrame(checkCount);
-        }
-      };
-
-      chunked.$.repeater.sort = function(a, b) {
-        return b.prop - a.prop;
-      };
-      chunked.$.repeater.filter = function(a) {
-        return (a.prop % 2) === 0;
-      };
-      chunked.items = chunked.preppedItems.slice();
-      checkUntilComplete();
+      });
 
     });
 
   });
 
-}
+});
 
 suite('misc', function() {
 


### PR DESCRIPTION
* Only restart chunking (resetting the list to the initialCount) if the `items` array itself changed (and not splices to the array), to match Polymer 1 behavior.
* Add `reuseChunkedInstances` option to allow reusing instances even when `items` changes; this is likely the more common optimal case when using immutable data, but making it optional for backward compatibility.
* Only measure render time and throttle the chunk size if we rendered a full chunk of new items. Ensures that fast re-renders of existing items don't cause the chunk size to scale up dramatically, subsequently causing too many new items to be created in one chunk.
* Increase the limit by the chunk size as part of any render if there are new items to render, rather than only as a result of rendering.
* Continue chunking by comparing the filtered item count to the limit (not the unfiltered item count).

### Reference Issue
Fixes #5631
