### PR TITLE
legacy-undefined-noBatch: Put `adoptedStyleSheets` use behind a global setting

### DIFF
--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -11,7 +11,7 @@
  */
 import '../utils/boot.js';
 
-import { rootPath, strictTemplatePolicy, allowTemplateFromDomModule, legacyOptimizations, legacyWarnings, syncInitialRender, supportsAdoptingStyleSheets} from '../utils/settings.js';
+import { rootPath, strictTemplatePolicy, allowTemplateFromDomModule, legacyOptimizations, legacyWarnings, syncInitialRender, supportsAdoptingStyleSheets, shareBuiltCSSWithAdoptedStyleSheets } from '../utils/settings.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { stylesFromTemplate, stylesFromModuleImports } from '../utils/style-gather.js';
 import { pathFromUrl, resolveCss, resolveUrl } from '../utils/resolve-url.js';
@@ -304,7 +304,7 @@ export const ElementMixin = dedupingMixin(base => {
     // potentially not shareable and sharing the ones that could be shared
     // would require some coordination. To keep it simple, all the includes
     // and styles are collapsed into a single shareable stylesheet.
-    if (builtCSS && supportsAdoptingStyleSheets) {
+    if (shareBuiltCSSWithAdoptedStyleSheets && builtCSS && supportsAdoptingStyleSheets) {
       // Remove styles in template and make a shareable stylesheet
       const styles = template.content.querySelectorAll('style');
       if (styles) {

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -11,7 +11,7 @@
  */
 import '../utils/boot.js';
 
-import { rootPath, strictTemplatePolicy, allowTemplateFromDomModule, legacyOptimizations, legacyWarnings, syncInitialRender, supportsAdoptingStyleSheets, shareBuiltCSSWithAdoptedStyleSheets } from '../utils/settings.js';
+import { rootPath, strictTemplatePolicy, allowTemplateFromDomModule, legacyOptimizations, legacyWarnings, syncInitialRender, supportsAdoptingStyleSheets, useAdoptedStyleSheetsWithBuiltCSS } from '../utils/settings.js';
 import { dedupingMixin } from '../utils/mixin.js';
 import { stylesFromTemplate, stylesFromModuleImports } from '../utils/style-gather.js';
 import { pathFromUrl, resolveCss, resolveUrl } from '../utils/resolve-url.js';
@@ -304,7 +304,7 @@ export const ElementMixin = dedupingMixin(base => {
     // potentially not shareable and sharing the ones that could be shared
     // would require some coordination. To keep it simple, all the includes
     // and styles are collapsed into a single shareable stylesheet.
-    if (shareBuiltCSSWithAdoptedStyleSheets && builtCSS &&
+    if (useAdoptedStyleSheetsWithBuiltCSS && builtCSS &&
         supportsAdoptingStyleSheets) {
       // Remove styles in template and make a shareable stylesheet
       const styles = template.content.querySelectorAll('style');

--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -304,7 +304,8 @@ export const ElementMixin = dedupingMixin(base => {
     // potentially not shareable and sharing the ones that could be shared
     // would require some coordination. To keep it simple, all the includes
     // and styles are collapsed into a single shareable stylesheet.
-    if (shareBuiltCSSWithAdoptedStyleSheets && builtCSS && supportsAdoptingStyleSheets) {
+    if (shareBuiltCSSWithAdoptedStyleSheets && builtCSS &&
+        supportsAdoptingStyleSheets) {
       // Remove styles in template and make a shareable stylesheet
       const styles = template.content.querySelectorAll('style');
       if (styles) {

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -351,7 +351,7 @@ export let shareBuiltCSSWithAdoptedStyleSheets =
 /**
  * Sets `shareBuiltCSSWithAdoptedStyleSheets` globally.
  *
- * @param {boolean} newValue enable or disable `shareBuiltCSSWithAdoptedStyleSheets`
+ * @param {boolean} value enable or disable `shareBuiltCSSWithAdoptedStyleSheets`
  * @return {void}
  */
 export const setShareBuiltCSSWithAdoptedStyleSheets = function(value) {

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -345,15 +345,15 @@ export const setLegacyNoObservedAttributes = function(noObservedAttributes) {
  * between component instances' shadow roots, if the app uses built Shady CSS
  * styles.
  */
-export let shareBuiltCSSWithAdoptedStyleSheets =
-  window.Polymer && window.Polymer.shareBuiltCSSWithAdoptedStyleSheets || false;
+export let useAdoptedStyleSheetsWithBuiltCSS =
+  window.Polymer && window.Polymer.useAdoptedStyleSheetsWithBuiltCSS || false;
 
 /**
- * Sets `shareBuiltCSSWithAdoptedStyleSheets` globally.
+ * Sets `useAdoptedStyleSheetsWithBuiltCSS` globally.
  *
- * @param {boolean} value enable or disable `shareBuiltCSSWithAdoptedStyleSheets`
+ * @param {boolean} value enable or disable `useAdoptedStyleSheetsWithBuiltCSS`
  * @return {void}
  */
-export const setShareBuiltCSSWithAdoptedStyleSheets = function(value) {
-  shareBuiltCSSWithAdoptedStyleSheets = value;
+export const setUseAdoptedStyleSheetsWithBuiltCSS = function(value) {
+  useAdoptedStyleSheetsWithBuiltCSS = value;
 };

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -339,3 +339,21 @@ export let legacyNoObservedAttributes =
 export const setLegacyNoObservedAttributes = function(noObservedAttributes) {
   legacyNoObservedAttributes = noObservedAttributes;
 };
+
+/**
+ * Setting to enable use of `adoptedStyleSheets` for sharing style sheets
+ * between component instances' shadow roots, if the app uses built Shady CSS
+ * styles.
+ */
+export let shareBuiltCSSWithAdoptedStyleSheets =
+  window.Polymer && window.Polymer.shareBuiltCSSWithAdoptedStyleSheets || false;
+
+/**
+ * Sets `shareBuiltCSSWithAdoptedStyleSheets` globally.
+ *
+ * @param {boolean} newValue enable or disable `shareBuiltCSSWithAdoptedStyleSheets`
+ * @return {void}
+ */
+export const setShareBuiltCSSWithAdoptedStyleSheets = function(value) {
+  shareBuiltCSSWithAdoptedStyleSheets = value;
+};

--- a/test/unit/styling-build-adopted-stylesheets.html
+++ b/test/unit/styling-build-adopted-stylesheets.html
@@ -18,7 +18,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="wct-browser-config.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script type="module">
-    import { supportsAdoptingStyleSheets } from '../../lib/utils/settings.js';
+    import {
+      setShareBuiltCSSWithAdoptedStyleSheets,
+      supportsAdoptingStyleSheets,
+    } from '../../lib/utils/settings.js';
+    setShareBuiltCSSWithAdoptedStyleSheets(true);
     window.supportsAdoptingStyleSheets = supportsAdoptingStyleSheets;
     let define = window.customElements.define;
     let order = [];

--- a/test/unit/styling-build-adopted-stylesheets.html
+++ b/test/unit/styling-build-adopted-stylesheets.html
@@ -19,10 +19,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script type="module">
     import {
-      setShareBuiltCSSWithAdoptedStyleSheets,
+      setUseAdoptedStyleSheetsWithBuiltCSS,
       supportsAdoptingStyleSheets,
     } from '../../lib/utils/settings.js';
-    setShareBuiltCSSWithAdoptedStyleSheets(true);
+    setUseAdoptedStyleSheetsWithBuiltCSS(true);
     window.supportsAdoptingStyleSheets = supportsAdoptingStyleSheets;
     let define = window.customElements.define;
     let order = [];


### PR DESCRIPTION
Currently, the `legacy-undefined-noBatch` branch always uses `adoptedStyleSheets` to share styles between component instances if supported by the browser and provided with built CSS. This PR puts this feature behind a new global setting (`shareBuiltCSSWithAdoptedStyleSheets`).