### PR TITLE
Update Closure types for overridden setAttribute in LegacyElementMixin.

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -8,7 +8,8 @@
     "index.html"
   ],
   "excludeIdentifiers": [
-    "templatizedBase"
+    "templatizedBase",
+    "setAttribute"
   ],
   "removeReferences": [
     "../shadycss/apply-shim.d.ts",

--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -145,9 +145,15 @@ export const LegacyElementMixin = dedupingMixin((base) => {
 
     /**
      * Sets the value of an attribute.
+     *
+     * NOTE: This function is explicitly excluded when running
+     * gen-typescript-declarations because the function it overrides has
+     * different signatures in Closure and TypeScript's built-in types. This
+     * function's signature should match the signature from Closure:
+     * https://github.com/google/closure-compiler/blob/8972fd4e9b0689e7ebdeea53580521c819f6aecc/externs/browser/w3c_dom1.js#L686-L694
      * @override
      * @param {string} name The name of the attribute to change.
-     * @param {string} value The new attribute value.
+     * @param {string|number|boolean|!TrustedHTML|!TrustedScriptURL|!TrustedURL} value The new attribute value.
      */
     setAttribute(name, value) {
       if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {


### PR DESCRIPTION
Closure and TypeScript have conflicting types for `Element.prototype.setAttribute`. The Closure types need to match because they're read directly from source, so this PR does that and just prevents TS types from being generated for this function.

cc #5651