### PR TITLE
Remove types from LegacyElementMixin's overridden setAttribute and removeAttribute.

### DIFF
--- a/lib/legacy/legacy-element-mixin.js
+++ b/lib/legacy/legacy-element-mixin.js
@@ -146,8 +146,6 @@ export const LegacyElementMixin = dedupingMixin((base) => {
     /**
      * Sets the value of an attribute.
      * @override
-     * @param {string} name The name of the attribute to change.
-     * @param {string|number|boolean|!TrustedHTML|!TrustedScriptURL|!TrustedURL} value The new attribute value.
      */
     setAttribute(name, value) {
       if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {
@@ -163,7 +161,6 @@ export const LegacyElementMixin = dedupingMixin((base) => {
     /**
      * Removes an attribute.
      * @override
-     * @param {string} name The name of the attribute to remove.
      */
     removeAttribute(name) {
       if (legacyNoObservedAttributes && !this._legacyForceObservedAttributes) {


### PR DESCRIPTION
Upstreaming http://cl/310649178. Apparently we don't need to specify the types at all if we're overriding and not widening them.