### PR TITLE
Accept function in legacy _template field for template parsing

### DIFF
--- a/lib/mixins/element-mixin.js
+++ b/lib/mixins/element-mixin.js
@@ -488,9 +488,14 @@ export const ElementMixin = dedupingMixin(base => {
       //     or set in registered(); once the static getter runs, a clone of it
       //     will overwrite it on the prototype as the working template.
       if (!this.hasOwnProperty(JSCompiler_renameProperty('_template', this))) {
-        const protoTemplate = this.prototype.hasOwnProperty(
+        let protoTemplate = this.prototype.hasOwnProperty(
           JSCompiler_renameProperty('_template', this.prototype)) ?
           this.prototype._template : undefined;
+        // Accept a function for the legacy Polymer({_template:...}) field for
+        // lazy parsing
+        if (typeof protoTemplate === 'function') {
+          protoTemplate = protoTemplate();
+        }
         this._template =
           // If user has put template on prototype (e.g. in legacy via registered
           // callback or info object), prefer that first. Note that `null` is

--- a/test/unit/behaviors.html
+++ b/test/unit/behaviors.html
@@ -347,6 +347,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ]
     });
 
+    const getTemplateFromFunction = () => html`<div id="from-function">[[prop]]</div>`;
+    Polymer({
+      is: 'template-from-function',
+      properties: { prop: {value: 'from-function'} },
+      _template: getTemplateFromFunction
+    });
+
+    const getTemplateFromBehaviorFunction = () => html`<div id="from-behavior-function">[[prop]]</div>`;
+    const functionTemplateBehavior = {
+      _template: getTemplateFromBehaviorFunction
+    };
+    Polymer({
+      is: 'template-from-behavior-function',
+      properties: { prop: {value: 'from-behavior-function'} },
+      behaviors: [functionTemplateBehavior]
+    });
+
     window.ModifyObserversBehavior = {
 
       __barChangedCalled: 0,
@@ -494,6 +511,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template-from-behavior-registered></template-from-behavior-registered>
     </template>
   </test-fixture>
+
+  <test-fixture id="from-function">
+    <template>
+      <template-from-function></template-from-function>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="from-behavior-function">
+    <template>
+      <template-from-behavior-function></template-from-behavior-function>
+    </template>
+  </test-fixture>
+
 
   <test-fixture id="modify-observers-via-behavior">
     <template>
@@ -649,7 +679,6 @@ suite('behavior.beforeRegister', function() {
 
 });
 
-
 suite('multi-behaviors element', function() {
   var el;
 
@@ -790,6 +819,24 @@ suite('templates from behaviors', function() {
     assert.ok(el.shadowRoot.querySelector('#behavior-from-registered'));
   });
 
+});
+
+suite('template from function', function() {
+  
+  test('template function assigned to _template', () => {
+    var el = fixture('from-function');
+    const div = el.shadowRoot.querySelector('#from-function');
+    assert.ok(div);
+    assert.equal(div.textContent, 'from-function');
+  });
+
+  test('template function assigned to _template in behavior', () => {
+    var el = fixture('from-behavior-function');
+    const div = el.shadowRoot.querySelector('#from-behavior-function');
+    assert.ok(div);
+    assert.equal(div.textContent, 'from-behavior-function');
+  });
+  
 });
 
 </script>


### PR DESCRIPTION
`Polymer`'s `_template` field will now accept a template-returning function in addition to a concrete `HTMLTemplateElement`, to allow for lazy template parsing.

Example:
```js
Polymer({
  is: 'lazy-template',
  _template: () => html`<div>lazy template</div>`;
});
```
In addition to the previously supported way:
```js
Polymer({
  is: 'eager-template',
  _template: html`<div>eager template</div>`;
});
```
### Reference Issue
Fixes #5660