### PR TITLE
Wrap nodes before calling {add,remove}EventListener.

### DIFF
--- a/lib/mixins/property-effects.js
+++ b/lib/mixins/property-effects.js
@@ -963,7 +963,7 @@ function setupCompoundStorage(node, binding) {
 function addNotifyListener(node, inst, binding) {
   if (binding.listenerEvent) {
     let part = binding.parts[0];
-    node.addEventListener(binding.listenerEvent, function(e) {
+    wrap(node).addEventListener(binding.listenerEvent, function(e) {
       handleNotification(e, inst, binding.target, part.source, part.negate);
     });
   }

--- a/lib/mixins/template-stamp.js
+++ b/lib/mixins/template-stamp.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import '../utils/boot.js';
 
 import { dedupingMixin } from '../utils/mixin.js';
+import { wrap } from '../utils/wrap.js';
 
 // 1.x backwards-compatible auto-wrapper for template type extensions
 // This is a clear layering violation and gives favored-nation status to
@@ -552,7 +553,7 @@ export const TemplateStamp = dedupingMixin(
      * @override
      */
     _addEventListenerToNode(node, eventName, handler) {
-      node.addEventListener(eventName, handler);
+      wrap(node).addEventListener(eventName, handler);
     }
 
     /**
@@ -565,7 +566,7 @@ export const TemplateStamp = dedupingMixin(
      * @override
      */
     _removeEventListenerFromNode(node, eventName, handler) {
-      node.removeEventListener(eventName, handler);
+      wrap(node).removeEventListener(eventName, handler);
     }
 
   }


### PR DESCRIPTION
This PR is to prepare for webcomponents/polyfills#332, which will manually dispatch all events with targets that are disconnected in the real tree, even if they are connected in the user-facing tree. Before this change, all events (except `focus` and `blur`) were dispatched natively, which meant that events dispatched to nodes that were disconnected in the real tree but connected in the user-facing tree would incorrectly propagate only through the disconnected piece of the tree containing the node. Dispatching these events manually in Shady DOM fixes this issue, but only if it's aware all of the listeners it needs to call, which requires wrapping with `ShadyDOM.wrapIfNeeded` before calling `addEventListener`/`removeEventListener`.

These particular changes were needed to fix some failures that showed up in internal testing of webcomponents/polyfills#332, but there are other places in Polymer that use `addEventListener`/`removeEventListener` without wrapping first. AFAIK, these weren't wrapped originally as a perf optimization and I think that some of them could stay that way if necessary, but I'm not sure about all of them. Particularly:

https://github.com/Polymer/polymer/blob/master/lib/utils/flattened-nodes-observer.js#L286-L312

This one seems relatively likely to need to be wrapped given that `slotchange` bubbles.

https://github.com/Polymer/polymer/blob/master/lib/utils/gestures.js

The `addEventListener` on `window` is only used for testing if `passive` is supported, so that doesn't need to be wrapped, but `addEventListener` is also called on `document` and other nodes in general to listen for mouse events. I don't think it's likely that these need to be wrapped because the user can't interact with disconnected nodes.