### PR TITLE
Cancel chunking when disconnected. Fixes #5667

### DIFF
--- a/lib/elements/dom-repeat.js
+++ b/lib/elements/dom-repeat.js
@@ -346,6 +346,10 @@ export class DomRepeat extends domRepeatBase {
     for (let i=0; i<this.__instances.length; i++) {
       this.__detachInstance(i);
     }
+    // Stop chunking if one was in progress
+    if (this.__chunkingId) {
+      cancelAnimationFrame(this.__chunkingId);
+    }
   }
 
   /**
@@ -363,6 +367,10 @@ export class DomRepeat extends domRepeatBase {
       let wrappedParent = wrap(wrap(this).parentNode);
       for (let i=0; i<this.__instances.length; i++) {
         this.__attachInstance(i, wrappedParent);
+      }
+      // Restart chunking if one was in progress when disconnected
+      if (this.__chunkingId) {
+        this.__render();
       }
     }
   }
@@ -552,7 +560,10 @@ export class DomRepeat extends domRepeatBase {
     if (this.initialCount &&
        (this.__shouldMeasureChunk || this.__shouldContinueChunking)) {
       cancelAnimationFrame(this.__chunkingId);
-      this.__chunkingId = requestAnimationFrame(() => this.__continueChunking());
+      this.__chunkingId = requestAnimationFrame(() => {
+        this.__chunkingId = null;
+        this.__continueChunking();
+      });
     }
     // Set rendered item count
     this._setRenderedItemCount(this.__instances.length);

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3935,7 +3935,7 @@ suite('chunked rendering', function() {
   let chunked;
   let notifyChange;
   let targetCount;
-  let handleChange = () => {
+  const handleChange = () => {
     if (!targetCount || chunked.$.repeater.renderedItemCount >= targetCount) {
       notifyChange(Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)')));
     }

--- a/test/unit/dom-repeat.html
+++ b/test/unit/dom-repeat.html
@@ -3933,16 +3933,24 @@ suite('limit', function() {
 suite('chunked rendering', function() {
 
   let chunked;
-  let resolve;
+  let notifyChange;
   let targetCount;
-  const handleChange = () => {
+  let handleChange = () => {
     if (!targetCount || chunked.$.repeater.renderedItemCount >= targetCount) {
-      resolve(Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)')));
+      notifyChange(Array.from(chunked.root.querySelectorAll('*:not(template):not(dom-repeat)')));
     }
   };
   const waitUntilRendered = async (count) => {
     targetCount = count;
-    return await new Promise(r => resolve = r);
+    return await new Promise(r => notifyChange = r);
+  };
+  const expectNoChanges = async () => {
+    targetCount = null;
+    notifyChange = () => {
+      assert.fail('no changes were expected');
+    };
+    // Ensure no changes happen in the next rAF+sT
+    await new Promise(r => requestAnimationFrame(() => setTimeout(() => r())));
   };
   setup(() => {
     chunked = document.createElement('x-repeat-chunked');
@@ -4257,6 +4265,19 @@ suite('chunked rendering', function() {
     }
     assert.equal(stamped.length, chunked.items.length);
     assert.isAtLeast(frameCount, 2);
+  });
+
+  test('chunking stops after detaching, restarts after attaching', async () => {
+    chunked.items = chunked.preppedItems.slice();
+    const initialLength = (await waitUntilRendered()).length;
+    assert.isAbove(initialLength, 0);
+    assert.isBelow(initialLength, chunked.preppedItems.length);
+    document.body.removeChild(chunked);
+    await expectNoChanges();
+    const done = waitUntilRendered(chunked.preppedItems.length);
+    document.body.appendChild(chunked);
+    const endLength = (await done).length;
+    assert.equal(endLength, chunked.items.length);
   });
 
 });


### PR DESCRIPTION
If there was a pending `requestAnimationFrame` for chunking when the `dom-repeat` was disconnected, cancel the rAF so that we're not spending extra cycles creating DOM that no one will see, especially when tearing down/discarding views.  `__chunkingId` retains its handle upon disconnection as a signal that a render is required to kick chunking back off if the `dom-repeat` is subsequently re-connected.

Note that this still isn't a guarantee that rendering/chunking can't restart while the `dom-repeat` is disconnected (e.g. if any render-causing properties change while disconnected, such as `items`), since we don't gate all of `dom-repeat`'s work on actually being connected; that would be a larger change with the potential to break users relying on the current ability to render while disconnected.

### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #5667