### PR TITLE
Fix SyntaxError in Polymer Gestures

### DIFF
--- a/lib/utils/gestures.js
+++ b/lib/utils/gestures.js
@@ -147,7 +147,7 @@ function matchingLabels(el) {
       let root = el.getRootNode();
       // if there is an id on `el`, check for all labels with a matching `for` attribute
       if (el.id) {
-        let matching = root.querySelectorAll(`label[for = ${el.id}]`);
+        let matching = root.querySelectorAll(`label[for = '${el.id}']`);
         for (let i = 0; i < matching.length; i++) {
           labels.push(/** @type {!HTMLLabelElement} */(matching[i]));
         }


### PR DESCRIPTION
Without the quotes in safari you get the following error: SyntaxError: The string did not match the expected pattern.
### Reference Issue
Fixes https://github.com/Polymer/polymer/issues/5677
