### PR TITLE
Global setting to use click on tap handlers

### DIFF
--- a/lib/mixins/gesture-event-listeners.js
+++ b/lib/mixins/gesture-event-listeners.js
@@ -11,6 +11,7 @@ import '../utils/boot.js';
 
 import { dedupingMixin } from '../utils/mixin.js';
 import { addListener, removeListener } from '../utils/gestures.js';
+import { useClickOnTap } from '../utils/settings.js';
 
 /**
  * Element class mixin that provides API for adding Polymer's cross-platform
@@ -46,6 +47,10 @@ export const GestureEventListeners = dedupingMixin((superClass) => {
      * @override
      */
     _addEventListenerToNode(node, eventName, handler) {
+      if (useClickOnTap && eventName === 'tap') {
+        super._addEventListenerToNode(node, 'click', handler);
+        return;
+      }
       if (!addListener(node, eventName, handler)) {
         super._addEventListenerToNode(node, eventName, handler);
       }
@@ -61,6 +66,10 @@ export const GestureEventListeners = dedupingMixin((superClass) => {
      * @override
      */
     _removeEventListenerFromNode(node, eventName, handler) {
+      if (useClickOnTap && eventName === 'tap') {
+        super._removeEventListenerFromNode(node, 'click', handler);
+        return;
+      }
       if (!removeListener(node, eventName, handler)) {
         super._removeEventListenerFromNode(node, eventName, handler);
       }

--- a/lib/utils/settings.js
+++ b/lib/utils/settings.js
@@ -99,6 +99,14 @@ export let passiveTouchGestures =
   window.Polymer && window.Polymer.setPassiveTouchGestures || false;
 
 /**
+ * Globally settable property to make on-tap use on-click.
+ * Defaults to `false` for backwards compatibility.
+ */
+export const useClickOnTap =
+    window.Polymer && window.Polymer.useClickOnTap || false;
+
+
+/**
  * Sets `passiveTouchGestures` globally for all elements using Polymer Gestures.
  *
  * @param {boolean} usePassive enable or disable passive touch gestures globally


### PR DESCRIPTION
Tap used to be recommended handler. However this changed to click in recent years, and tap actually causes problems with touch/scrolling. Global setting to always just use click.
