### PR TITLE
Add stricter types to mixinBehaviors

### DIFF
--- a/lib/legacy/class.d.ts
+++ b/lib/legacy/class.d.ts
@@ -14,11 +14,6 @@ import {DirMixinConstructor} from '../mixins/dir-mixin.js';
 export {mixinBehaviors};
 
 /**
- * Helper type to get the intersection of all types in a tuple.
- */
-type Intersection<T extends any[]> = T extends [infer U, ...infer V] ? U & Intersection<V> : unknown;
-
-/**
  * Mixins applied by LegacyElementMixin.
  */
 type LegacyElementMixins = LegacyElementMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor & GestureEventListenersConstructor & DirMixinConstructor;
@@ -36,8 +31,10 @@ type LegacyElementMixins = LegacyElementMixinConstructor & ElementMixinConstruct
 declare function mixinBehaviors<T, U>(behaviors: [U], klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
 declare function mixinBehaviors<T, U, V>(behaviors: [U, V], klass: {new(): T}): {new(): T & U & V} & LegacyElementMixins;
 declare function mixinBehaviors<T, U, V, W>(behaviors: [U, V, W], klass: {new(): T}): {new(): T & U & V & W} & LegacyElementMixins;
-declare function mixinBehaviors<T, U extends any[]>(behaviors: U, klass: {new(): T}): {new(): T & Intersection<U>} & LegacyElementMixins;
-declare function mixinBehaviors<T, U>(behavior: U, klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
+declare function mixinBehaviors<T, U, V, W, X>(behaviors: [U, V, W, X], klass: {new(): T}): {new(): T & U & V & W & X} & LegacyElementMixins;
+declare function mixinBehaviors<T, U, V, W, X, Y>(behaviors: [U, V, W, X, Y], klass: {new(): T}): {new(): T & U & V & W & X & Y} & LegacyElementMixins;
+declare function mixinBehaviors<T>(behaviors: object[], klass: {new(): T}): {new(): T} & LegacyElementMixins;
+declare function mixinBehaviors<T, U>(behaviors: U, klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
 
 export {Class};
 

--- a/lib/legacy/class.d.ts
+++ b/lib/legacy/class.d.ts
@@ -1,22 +1,10 @@
 // tslint:disable:variable-name Describing an API that's defined elsewhere.
 // tslint:disable:no-any describes the API as best we are able today
 
-import {LegacyElementMixinConstructor} from './legacy-element-mixin.js';
-import {ElementMixinConstructor} from '../mixins/element-mixin.js';
-import {PropertyEffectsConstructor} from '../mixins/property-effects.js';
-import {TemplateStampConstructor} from '../mixins/template-stamp.js';
-import {PropertyAccessorsConstructor} from '../mixins/property-accessors.js';
-import {PropertiesChangedConstructor} from '../mixins/properties-changed.js';
-import {PropertiesMixinConstructor} from '../mixins/properties-mixin.js';
-import {GestureEventListenersConstructor} from '../mixins/gesture-event-listeners.js';
-import {DirMixinConstructor} from '../mixins/dir-mixin.js';
+import {LegacyElementMixin} from './legacy-element-mixin.js';
 
 export {mixinBehaviors};
 
-/**
- * Mixins applied by LegacyElementMixin.
- */
-type LegacyElementMixins = LegacyElementMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor & GestureEventListenersConstructor & DirMixinConstructor;
 
 /**
  * Applies a "legacy" behavior or array of behaviors to the provided class.
@@ -28,13 +16,19 @@ type LegacyElementMixins = LegacyElementMixinConstructor & ElementMixinConstruct
  * @returns Returns a new Element class extended by the
  * passed in `behaviors` and also by `LegacyElementMixin`.
  */
-declare function mixinBehaviors<T, U>(behaviors: [U], klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
-declare function mixinBehaviors<T, U, V>(behaviors: [U, V], klass: {new(): T}): {new(): T & U & V} & LegacyElementMixins;
-declare function mixinBehaviors<T, U, V, W>(behaviors: [U, V, W], klass: {new(): T}): {new(): T & U & V & W} & LegacyElementMixins;
-declare function mixinBehaviors<T, U, V, W, X>(behaviors: [U, V, W, X], klass: {new(): T}): {new(): T & U & V & W & X} & LegacyElementMixins;
-declare function mixinBehaviors<T, U, V, W, X, Y>(behaviors: [U, V, W, X, Y], klass: {new(): T}): {new(): T & U & V & W & X & Y} & LegacyElementMixins;
-declare function mixinBehaviors<T>(behaviors: object[], klass: {new(): T}): {new(): T} & LegacyElementMixins;
-declare function mixinBehaviors<T, U>(behaviors: U, klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
+// These overloads are to prevent nested arrays of behaviors from being inferred
+// as behavior objects.
+declare function mixinBehaviors<T>(behaviors: [any[], ...any[]], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T>(behaviors: [any, any[], ...any[]], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T>(behaviors: [any, any, any[], ...any[]], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T>(behaviors: [any, any, any, any[], ...any[]], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T>(behaviors: [any, any, any, any, any[], ...any[]], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T, U>(behaviors: [U], klass: {new(): T}): {new(): T & U};
+declare function mixinBehaviors<T, U, V>(behaviors: [U, V], klass: {new(): T}): {new(): T & U & V};
+declare function mixinBehaviors<T, U, V, W>(behaviors: [U, V, W], klass: {new(): T}): {new(): T & U & V & W};
+declare function mixinBehaviors<T, U, V, W, X>(behaviors: [U, V, W, X], klass: {new(): T}): {new(): T & U & V & W & X};
+declare function mixinBehaviors<T, U, V, W, X, Y>(behaviors: [U, V, W, X, Y], klass: {new(): T}): {new(): T & U & V & W & X & Y};
+declare function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): {new(): T};
 
 export {Class};
 

--- a/lib/legacy/class.d.ts
+++ b/lib/legacy/class.d.ts
@@ -1,10 +1,27 @@
 // tslint:disable:variable-name Describing an API that's defined elsewhere.
 // tslint:disable:no-any describes the API as best we are able today
 
-import {LegacyElementMixin} from './legacy-element-mixin.js';
+import {LegacyElementMixinConstructor} from './legacy-element-mixin.js';
+import {ElementMixinConstructor} from '../mixins/element-mixin.js';
+import {PropertyEffectsConstructor} from '../mixins/property-effects.js';
+import {TemplateStampConstructor} from '../mixins/template-stamp.js';
+import {PropertyAccessorsConstructor} from '../mixins/property-accessors.js';
+import {PropertiesChangedConstructor} from '../mixins/properties-changed.js';
+import {PropertiesMixinConstructor} from '../mixins/properties-mixin.js';
+import {GestureEventListenersConstructor} from '../mixins/gesture-event-listeners.js';
+import {DirMixinConstructor} from '../mixins/dir-mixin.js';
 
 export {mixinBehaviors};
 
+/**
+ * Helper type to get the intersection of all types in a tuple.
+ */
+type Intersection<T extends any[]> = T extends [infer U, ...infer V] ? U & Intersection<V> : unknown;
+
+/**
+ * Mixins applied by LegacyElementMixin.
+ */
+type LegacyElementMixins = LegacyElementMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor & GestureEventListenersConstructor & DirMixinConstructor;
 
 /**
  * Applies a "legacy" behavior or array of behaviors to the provided class.
@@ -16,7 +33,11 @@ export {mixinBehaviors};
  * @returns Returns a new Element class extended by the
  * passed in `behaviors` and also by `LegacyElementMixin`.
  */
-declare function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T, U>(behaviors: [U], klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
+declare function mixinBehaviors<T, U, V>(behaviors: [U, V], klass: {new(): T}): {new(): T & U & V} & LegacyElementMixins;
+declare function mixinBehaviors<T, U, V, W>(behaviors: [U, V, W], klass: {new(): T}): {new(): T & U & V & W} & LegacyElementMixins;
+declare function mixinBehaviors<T, U extends any[]>(behaviors: U, klass: {new(): T}): {new(): T & Intersection<U>} & LegacyElementMixins;
+declare function mixinBehaviors<T, U>(behavior: U, klass: {new(): T}): {new(): T & U} & LegacyElementMixins;
 
 export {Class};
 


### PR DESCRIPTION
Context: Chromium is adding TypeScript support for their Polymer code. As there are still some legacy behaviors that need to be used until they can be ported to a mixin, `mixinBehaviors` needs to be used in the meantime - but due to the incomplete types of the function, [all calls of `mixinBehaviors` need to be manually typed](https://crrev.com/c/2877465).

This PR fixes this problem by providing a much stricter type than the current one, merging the behaviors specified in the arguments as well as applying the same mixins that `LegacyElementMixin` does. This requires each behavior passed to be typed correctly, and (unfortunately) exposes these properties to the class:

- Polymer-related properties like 'properties', 'observers' 'listeners'. Using `Omit<T>` to try to get around this results in type errors as `Omit<T>` rewrites the whole object type, resulting in TypeScript converting all instance member functions in the type to instance member properties, causing TS2425 when trying to override/implement a behavior function in a class.  
- "Private" properties which shouldn't be used by consumers of the behavior. This is a limitation of TypeScript as there is no notion of a "private property" on an object.

Both of these can be worked around by manually specifying a public interface for the behavior instead.

Note that the helper type used in one of the overloads requires [the use of TypeScript 4.1](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#recursive-conditional-types), released on November 2020. The overload is only necessary if more than 3 types are used, and can be removed if necessary (but IMO most people should be using TypeScript 4.1 by now).