### PR TITLE
Make sure that throwing an exception in an observer does not leave the PropertiesChanged mixin in an invalid state

### DIFF
--- a/lib/mixins/properties-changed.js
+++ b/lib/mixins/properties-changed.js
@@ -374,16 +374,19 @@ export const PropertiesChanged = dedupingMixin(
      * @override
      */
     _flushProperties() {
-      this.__dataCounter++;
-      const props = this.__data;
-      const changedProps = this.__dataPending;
-      const old = this.__dataOld;
-      if (this._shouldPropertiesChange(props, changedProps, old)) {
-        this.__dataPending = null;
-        this.__dataOld = null;
-        this._propertiesChanged(props, changedProps, old);
+      try {
+        this.__dataCounter++;
+        const props = this.__data;
+        const changedProps = this.__dataPending;
+        const old = this.__dataOld;
+        if (this._shouldPropertiesChange(props, changedProps, old)) {
+          this.__dataPending = null;
+          this.__dataOld = null;
+          this._propertiesChanged(props, changedProps, old);
+        }
+      } finally {
+        this.__dataCounter--;
       }
-      this.__dataCounter--;
     }
 
     /**


### PR DESCRIPTION
…e PropertiesChanged mixin in an invalid state

<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
