### PR TITLE
Fix `Polymer.dom(el).attachShadow/shadowRoot`

### DIFF
--- a/lib/legacy/polymer.dom.js
+++ b/lib/legacy/polymer.dom.js
@@ -441,7 +441,7 @@ if (window['ShadyDOM'] && window['ShadyDOM']['inUse'] && window['ShadyDOM']['noP
   forwardMethods(DomApiNative.prototype, [
     'cloneNode', 'appendChild', 'insertBefore', 'removeChild',
     'replaceChild', 'setAttribute', 'removeAttribute',
-    'querySelector', 'querySelectorAll'
+    'querySelector', 'querySelectorAll', 'attachShadow'
   ]);
 
   // Properties that should return the logical, not composed tree. Note, `classList`
@@ -451,7 +451,7 @@ if (window['ShadyDOM'] && window['ShadyDOM']['inUse'] && window['ShadyDOM']['noP
     'parentNode', 'firstChild', 'lastChild',
     'nextSibling', 'previousSibling', 'firstElementChild',
     'lastElementChild', 'nextElementSibling', 'previousElementSibling',
-    'childNodes', 'children', 'classList'
+    'childNodes', 'children', 'classList', 'shadowRoot'
   ]);
 
   forwardProperties(DomApiNative.prototype, [

--- a/test/unit/polymer-dom.html
+++ b/test/unit/polymer-dom.html
@@ -415,6 +415,7 @@ suite('forwarded native api', function() {
     assert.isDefined(d.classList);
     assert.isDefined(d.textContent);
     assert.isDefined(d.innerHTML);
+    assert.isDefined(d.shadowRoot);
   });
 
   test('cloneNode', function() {
@@ -482,6 +483,12 @@ suite('forwarded native api', function() {
     assert.equal(query[0], d1);
     assert.equal(query[1], d2);
     assert.equal(query.length, 2);
+  });
+
+  test('attachShadow', function() {
+    const el = document.createElement('div');
+    dom(el).attachShadow({mode: 'open'});
+    assert.isDefined(el.shadowRoot);
   });
 
   test('tree accessors', function() {


### PR DESCRIPTION
Polymer itself does not need this since it directly uses `ShadyDOM.wrap`, but since this is a foot gun omission, `attachShadow` and `shadowRoot` is added here to the DOM wrapper returned by Polymer.dom.
