### PR TITLE
Add support for TrustedTypes to html-tag.js

### DIFF
--- a/lib/utils/html-tag.js
+++ b/lib/utils/html-tag.js
@@ -10,12 +10,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import './boot.js';
 
 /**
+ * Our TrustedTypePolicy for HTML which is declared using the Polymer html
+ * template tag function.
+ *
+ * That HTML is a developer-authored constant, and is parsed with innerHTML
+ * before any untrusted expressions have been mixed in. Therefor it is
+ * considered safe by construction.
+ *
+ * @type {!TrustedTypePolicy|undefined}
+ */
+const policy = window.trustedTypes &&
+    trustedTypes.createPolicy('polymer-html-literal', {createHTML: (s) => s});
+
+/**
  * Class representing a static string value which can be used to filter
  * strings by asseting that they have been created via this class. The
  * `value` property returns the string passed to the constructor.
  */
 class LiteralString {
-  constructor(string) {
+  /**
+   * @param {!ITemplateArray} strings Constant parts of tagged template literal
+   * @param {!Array<*>} values Variable parts of tagged template literal
+   */
+  constructor(strings, values) {
+    assertValidTemplateStringParameters(strings, values);
+    const string = values.reduce(
+        (acc, v, idx) => acc + literalValue(v) + strings[idx + 1], strings[0]);
     /** @type {string} */
     this.value = string.toString();
   }
@@ -48,7 +68,13 @@ function literalValue(value) {
  */
 function htmlValue(value) {
   if (value instanceof HTMLTemplateElement) {
-    return /** @type {!HTMLTemplateElement } */(value).innerHTML;
+    // Use the XML serializer to avoid xMSS attacks from browsers' sometimes
+    // unexpected formatting / cleanup of innerHTML.
+    const serializedNewTree = new XMLSerializer().serializeToString(
+        /** @type {!HTMLTemplateElement } */ (value));
+    return serializedNewTree.slice(
+        serializedNewTree.indexOf('>') + 1,
+        serializedNewTree.lastIndexOf('</'));
   } else if (value instanceof LiteralString) {
     return literalValue(value);
   } else {
@@ -92,10 +118,33 @@ function htmlValue(value) {
  * @return {!HTMLTemplateElement} Constructed HTMLTemplateElement
  */
 export const html = function html(strings, ...values) {
-  const template = /** @type {!HTMLTemplateElement} */(document.createElement('template'));
-  template.innerHTML = values.reduce((acc, v, idx) =>
-      acc + htmlValue(v) + strings[idx + 1], strings[0]);
+  assertValidTemplateStringParameters(strings, values);
+  const template =
+      /** @type {!HTMLTemplateElement} */ (document.createElement('template'));
+  let value = values.reduce(
+      (acc, v, idx) => acc + htmlValue(v) + strings[idx + 1], strings[0]);
+  if (policy) {
+    value = policy.createHTML(value);
+  }
+  template.innerHTML = value;
   return template;
+};
+
+/**
+ * @param {!ITemplateArray} strings Constant parts of tagged template literal
+ * @param {!Array<*>} values Array of values from quasis
+ */
+const assertValidTemplateStringParameters = (strings, values) => {
+  // Note: if/when https://github.com/tc39/proposal-array-is-template-object
+  // is standardized, use that instead when available, as it can perform an
+  // unforgable check (though of course, the function itself can be forged).
+  if (!Array.isArray(strings) || !Array.isArray(strings.raw) ||
+      (values.length !== strings.length - 1)) {
+    // This is either caused by a browser bug, a compiler bug, or someone
+    // calling the html template tag function as a regular function.
+    //
+    throw new TypeError('Invalid call to the html template tag');
+  }
 };
 
 /**
@@ -123,6 +172,5 @@ export const html = function html(strings, ...values) {
  * @return {!LiteralString} Constructed literal string
  */
 export const htmlLiteral = function(strings, ...values) {
-  return new LiteralString(values.reduce((acc, v, idx) =>
-      acc + literalValue(v) + strings[idx + 1], strings[0]));
+  return new LiteralString(strings, values);
 };


### PR DESCRIPTION
This avoids setting innerHTML to a string.

Internal version with security review at cl/387245589