### PR TITLE
Adds Trusted Types support for reflected boolean properties.

### DIFF
--- a/lib/mixins/properties-changed.js
+++ b/lib/mixins/properties-changed.js
@@ -531,7 +531,13 @@ export const PropertiesChanged = dedupingMixin(
       if (str === undefined) {
         node.removeAttribute(attribute);
       } else {
-        node.setAttribute(attribute, str);
+        node.setAttribute(
+            attribute,
+            // Closure's type for `setAttribute`'s second parameter incorrectly
+            // excludes `TrustedScript`.
+            (str === '' && window.trustedTypes) ?
+                /** @type {?} */ (window.trustedTypes.emptyScript) :
+                str);
       }
     }
 
@@ -550,9 +556,7 @@ export const PropertiesChanged = dedupingMixin(
     _serializeValue(value) {
       switch (typeof value) {
         case 'boolean':
-          return value ?
-              (window.trustedTypes ? window.trustedTypes.emptyScript : '') :
-              undefined;
+          return value ? '' : undefined;
         default:
           return value != null ? value.toString() : undefined;
       }

--- a/lib/mixins/properties-changed.js
+++ b/lib/mixins/properties-changed.js
@@ -550,7 +550,9 @@ export const PropertiesChanged = dedupingMixin(
     _serializeValue(value) {
       switch (typeof value) {
         case 'boolean':
-          return value ? '' : undefined;
+          return value ?
+              (window.trustedTypes ? window.trustedTypes.emptyScript : '') :
+              undefined;
         default:
           return value != null ? value.toString() : undefined;
       }


### PR DESCRIPTION
Like <https://github.com/Polymer/polymer/commit/8582dd6449822e003313dee3e6792aa0a8f98989>, this is also to work around <https://crbug.com/993268>. Given that [this bug should be fixed now](https://bugs.chromium.org/p/chromium/issues/detail?id=993268#c19), I'm not sure if we want to upstream this (since we're already including a workaround for it elsewhere) or leave it as an internal only patch.