### PR TITLE
fixed-readme-wrong-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Web Components are now implemented natively on Safari and Chrome (~70% of instal
   1. Then implement a `template` getter that returns an `HTMLTemplateElement` describing the element's rendering, including encapsulated styling and any property bindings.
 
 ```html
-  <script src="node_modules/@webcomponents/webcomponents-loader.js"></script>
+  <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script type="module">
     import {PolymerElement, html} from '@polymer/polymer';
 


### PR DESCRIPTION
fixed #5703
### Reference Issue
readme: wrong path to webcomponents-loader.js 

[polymer/README.md](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/README.md?plain=1#L69)

Line 69 in [1e8b246](https://github.com/Polymer/polymer/commit/1e8b246d01ea99adba305ea04c45d26da31f68f1)

 <script src="node_modules/@webcomponents/webcomponents-loader.js"></script> 
should be

node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js
