### PR TITLE
Create SECURITY.md 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released. 
+Therefore, we ask that you align with us before any public disclosure.
+
+Please report it at [security advisory](https://github.com/polymer/polymer/security/advisories/new).


### PR DESCRIPTION
### Reference Issue
Closes #5723 

### Description
I've created the SECURITY.md file considering the [report vulnerability through security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which is a new GitHub feature.

If you're interested in GitHub's feature, it must be [activated for the repository](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository):
1. Open the repo's settings
2. Click on [Code security & analysis](https://github.com/polymer/polymer/settings/security_analysis)
3. Click "Enable" for "Private vulnerability reporting (Beta)"

Let me know if you rather ask that vulnerabilities to be reported through https://g.co/vulnz or an email instead.

Besides that, feel free to edit or suggest any changes to this document. It is supposed to reflect how the team want to receive and handle these reports.

Thanks!
